### PR TITLE
Reset page markers when loading file

### DIFF
--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -37,6 +37,11 @@ class File:
         self._filename = value
         self._filename_callback()
 
+    def reset(self):
+        """Reset file internals to defaults, e.g. filename, page markers, etc"""
+        self._filename = ""
+        self.remove_page_marks()
+
     def open_file(self, *args):
         """Open and load a text file."""
         if self.check_save():
@@ -51,6 +56,7 @@ class File:
         Args:
             filename: Name of file to be loaded. Bin filename has ".bin" appended.
         """
+        self.reset()
         self.filename = filename
         maintext().do_open(filename)
         maintext().set_insert_index(1.0, see=True)


### PR DESCRIPTION
Page markers from old file were left behind - if there were fewer pages in the new file, this caused the page forward/backward code and image viewer to fail.

Fixes #63