### PR TITLE
Fix to AutoImg key bug

### DIFF
--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -142,7 +142,7 @@ class Preferences:
         for key in self.callbacks.keys():
             callback = self.callbacks[key]
             if callback:
-                callback(self.dict[key])
+                callback(self[key])
 
     def _remove_test_prefs_file(self):
         """Remove temporary JSON file used for prefs during testing."""


### PR DESCRIPTION
Accessed dictionary directly instead of via `__getitem__` meaning it didn't fall back to the default if the user had not set the preference.