### PR TITLE
Remember & offer `Recent Documents` in File menu

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -37,12 +37,12 @@ class Guiguts:
 
         self.set_preferences_defaults()
 
-        self.file = File(self.update_title)
+        self.file = File(self.filename_changed)
 
         self.mainwindow = MainWindow()
         self.update_title()
 
-        self.init_menus(menubar())
+        self.init_menus()
 
         self.init_statusbar(statusbar())
 
@@ -73,6 +73,10 @@ class Guiguts:
     def run(self):
         """Run the app."""
         root().mainloop()
+
+    def filename_changed(self):
+        self.init_file_menu()  # Recreate file menu to reflect recent files
+        self.update_title()
 
     def update_title(self):
         """Update the window title to reflect current status."""
@@ -161,23 +165,24 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         """Set default preferences - will be overridden by any values set
         in the Preferences file.
         """
-        preferences.set_default("ImageWindow", "Docked")
-        preferences.set_default("Bell", "VisibleAudible")
 
         def set_auto_image(value):
             self.auto_image = value
 
         preferences.set_default("AutoImage", False)
         preferences.set_callback("AutoImage", set_auto_image)
+        preferences.set_default("Bell", "VisibleAudible")
+        preferences.set_default("ImageWindow", "Docked")
+        preferences.set_default("RecentFiles", [])
 
     # Lay out menus
-    def init_menus(self, menubar):
+    def init_menus(self):
         """Create all the menus."""
-        self.init_file_menu(menubar)
-        self.init_edit_menu(menubar)
-        self.init_view_menu(menubar)
-        self.init_help_menu(menubar)
-        self.init_os_menu(menubar)
+        self.init_file_menu()
+        self.init_edit_menu()
+        self.init_view_menu()
+        self.init_help_menu()
+        self.init_os_menu()
 
         if is_mac():
             root().createcommand(
@@ -186,20 +191,36 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             root().createcommand("tk::mac::OpenDocument", self.open_document)
             root().createcommand("tk::mac::Quit", self.quit_program)
 
-    def init_file_menu(self, parent):
-        """Create the File menu."""
-        menu_file = Menu(parent, "~File")
-        menu_file.add_button("~Open...", self.file.open_file, "Cmd/Ctrl+O")
-        menu_file.add_button("~Save", self.file.save_file, "Cmd/Ctrl+S")
-        menu_file.add_button("Save ~As...", self.file.save_as_file, "Cmd/Ctrl+Shift+S")
-        menu_file.add_separator()
-        menu_file.add_button("Spawn ~Process", self.spawn_process)
-        menu_file.add_separator()
-        menu_file.add_button("~Quit", self.quit_program, "Cmd+Q" if is_mac() else "")
+    def init_file_menu(self):
+        """(Re-)create the File menu."""
+        try:
+            self.menu_file.delete(0, "end")
+        except AttributeError:
+            self.menu_file = Menu(menubar(), "~File")
+        self.menu_file.add_button("~Open...", self.file.open_file, "Cmd/Ctrl+O")
+        self.init_file_recent_menu(self.menu_file)
+        self.menu_file.add_button("~Save", self.file.save_file, "Cmd/Ctrl+S")
+        self.menu_file.add_button(
+            "Save ~As...", self.file.save_as_file, "Cmd/Ctrl+Shift+S"
+        )
+        self.menu_file.add_separator()
+        self.menu_file.add_button("Spawn ~Process", self.spawn_process)
+        self.menu_file.add_separator()
+        self.menu_file.add_button(
+            "~Quit", self.quit_program, "Cmd+Q" if is_mac() else ""
+        )
 
-    def init_edit_menu(self, parent):
+    def init_file_recent_menu(self, parent):
+        """Create the Recent Documents menu."""
+        recent_menu = Menu(parent, "Recent Doc~uments")
+        for count, file in enumerate(reversed(preferences["RecentFiles"]), start=1):
+            recent_menu.add_button(
+                f"~{count}: {file}", lambda fn=file: self.file.load_file(fn)
+            )
+
+    def init_edit_menu(self):
         """Create the Edit menu."""
-        menu_edit = Menu(parent, "~Edit")
+        menu_edit = Menu(menubar(), "~Edit")
         menu_edit.add_button("~Undo", "<<Undo>>", "Cmd/Ctrl+Z")
         menu_edit.add_button(
             "~Redo", "<<Redo>>", "Cmd+Shift+Z" if is_mac() else "Ctrl+Y"
@@ -211,31 +232,31 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_edit.add_separator()
         menu_edit.add_button("Pre~ferences...", lambda: PreferencesDialog(root()))
 
-    def init_view_menu(self, parent):
+    def init_view_menu(self):
         """Create the View menu."""
-        menu_view = Menu(parent, "~View")
+        menu_view = Menu(menubar(), "~View")
         menu_view.add_button("~Dock", self.mainwindow.dock_image, "Cmd/Ctrl+D")
         menu_view.add_button("~Float", self.mainwindow.float_image, "Cmd/Ctrl+F")
         menu_view.add_button("~Load Image", self.load_image)
 
-    def init_help_menu(self, parent):
+    def init_help_menu(self):
         """Create the Help menu."""
-        menu_help = Menu(parent, "~Help")
+        menu_help = Menu(menubar(), "~Help")
         menu_help.add_button("Guiguts ~Manual", self.show_help_manual)
         menu_help.add_button("About ~Guiguts", self.help_about)
 
-    def init_os_menu(self, parent):
+    def init_os_menu(self):
         """Create the OS-specific menu.
 
         Currently only does anything on Macs
         """
         if is_mac():
             # Apple menu
-            menu_app = Menu(parent, "", name="apple")
+            menu_app = Menu(menubar(), "", name="apple")
             menu_app.add_button("About ~Guiguts", self.help_about)
             menu_app.add_separator()
             # Window menu
-            Menu(parent, "Window", name="window")
+            Menu(menubar(), "Window", name="window")
         else:
             menu_app = None
 

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -7,7 +7,9 @@ import tkinter as tk
 from tkinter import filedialog, messagebox, simpledialog
 
 from guiguts.mainwindow import maintext, sound_bell
+from guiguts.preferences import preferences
 
+NUM_RECENT_FILES = 9
 PAGEMARK_PREFIX = "Pg"
 BINFILE_SUFFIX = ".bin"
 BINFILE_KEY_PAGEMARKS = "pagemarks"
@@ -79,12 +81,14 @@ class File:
             filename: Name of file to be loaded. Bin filename has ".bin" appended.
         """
         self.reset()
-        self.filename = filename
         maintext().do_open(filename)
         maintext().set_insert_index(1.0, see=True)
         self.load_bin(filename)
         if not self.contains_page_marks():
             self.mark_page_boundaries()
+        self.store_recent_files(filename)
+        # Load complete, so set filename (including side effects)
+        self.filename = filename
 
     def save_file(self, *args):
         """Save the current file.
@@ -187,6 +191,19 @@ class File:
         bin_dict[BINFILE_KEY_PAGEMARKS] = self.dict_from_page_marks()
         bin_dict[BINFILE_KEY_IMAGEDIR] = self.image_dir
         return bin_dict
+
+    def store_recent_files(self, filename):
+        """Store given filename in list of recent files.
+
+        Args:
+            filename: Name of new file to add to list.
+        """
+        recent_files = preferences["RecentFiles"]
+        if filename in recent_files:
+            recent_files.remove(filename)
+        recent_files.append(filename)
+        del recent_files[0:-NUM_RECENT_FILES]
+        preferences["RecentFiles"] = recent_files
 
     def dict_to_page_marks(self, page_marks_dict):
         """Set page marks from keys/values in dictionary.

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -136,7 +136,7 @@ class Menu(tk.Menu):
         command_args = {"menu": self}
         if label:
             (label_tilde, label_txt) = _process_label(label)
-            command_args["label"] = (label_txt,)
+            command_args["label"] = label_txt
             if label_tilde >= 0:
                 command_args["underline"] = label_tilde
         # Only needs cascade if a child of menu/menubar, not if a context popup menu


### PR DESCRIPTION
This feature requires that the FIle menu can be recreated, whenever you change the "recent documents" list.

The reason for 9 recent documents is for the menu keyboard navigation (1 to 9) though we could make 0 do a tenth if anyone objects. Seems like 9 is enough though.