### PR TITLE
Use `.json` suffix for "bin" file

### DIFF
--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -9,7 +9,7 @@ from tkinter import filedialog, messagebox, simpledialog
 from guiguts.mainwindow import maintext, sound_bell
 
 PAGEMARK_PREFIX = "Pg"
-BINFILE_SUFFIX = ".bin"
+BINFILE_SUFFIX = ".json"
 BINFILE_KEY_PAGEMARKS = "pagemarks"
 BINFILE_KEY_INSERTPOS = "insertpos"
 BINFILE_KEY_IMAGEDIR = "imagedir"


### PR DESCRIPTION
The `bin" file will contain project specific settings, such as page break locations, current editing location in file, image directory, etc.

It already used JSON, but previously retained the `.bin` suffix from GG1. This causes confusion, so better to give it a `.json` suffix.

Still referring to it as the "bin" file in comments, etc.