### PR TITLE
Remove Ctrl+D & Ctrl+F shortcuts

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -235,8 +235,8 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
     def init_view_menu(self):
         """Create the View menu."""
         menu_view = Menu(menubar(), "~View")
-        menu_view.add_button("~Dock", self.mainwindow.dock_image, "Cmd/Ctrl+D")
-        menu_view.add_button("~Float", self.mainwindow.float_image, "Cmd/Ctrl+F")
+        menu_view.add_button("~Dock", self.mainwindow.dock_image)
+        menu_view.add_button("~Float", self.mainwindow.float_image)
         menu_view.add_button("~Load Image", self.load_image)
 
     def init_help_menu(self):


### PR DESCRIPTION
The `Ctrl+D` and `Ctrl+F` shortcuts were just a temporary experiment, and clash with other desirable shortcuts.