### PR TITLE
Avoid Auto Img dir selection loop

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -2,6 +2,7 @@
 """Guiguts - an application to support creation of ebooks for PG"""
 
 
+import os.path
 import re
 import subprocess
 from tkinter import messagebox
@@ -59,6 +60,7 @@ class Guiguts:
         preferences["AutoImage"] = value
         statusbar().set("see img", "Auto Img" if value else "See Img")
         if value:
+            self.image_dir_check()
             self.auto_image_check()
 
     def auto_image_check(self):
@@ -69,6 +71,18 @@ class Guiguts:
     def toggle_auto_image(self):
         self.auto_image = not self.auto_image
 
+    def see_image(self):
+        """Show the image corresponding to current location."""
+        self.image_dir_check()
+        self.mainwindow.load_image(self.file.get_current_image_path())
+
+    def image_dir_check(self):
+        """Check if image dir is set up correctly."""
+        if self.file.filename and not (
+            self.file.image_dir and os.path.exists(self.file.image_dir)
+        ):
+            self.file.choose_image_dir()
+
     def run(self):
         """Run the app."""
         root().mainloop()
@@ -76,6 +90,8 @@ class Guiguts:
     def filename_changed(self):
         self.init_file_menu()  # Recreate file menu to reflect recent files
         self.update_title()
+        if self.auto_image:
+            self.image_dir_check()
 
     def update_title(self):
         """Update the window title to reflect current status."""
@@ -127,12 +143,12 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
     def open_file(self):
         """Open new file, close old image if open."""
         if self.file.open_file():
-            self.mainwindow.load_image("")
+            self.mainwindow.clear_image()
 
     def close_file(self):
         """Close currently loaded file and associated image."""
         self.file.close_file()
-        self.mainwindow.load_image("")
+        self.mainwindow.clear_image()
 
     def show_help_manual(self, *args):
         """Display the manual."""
@@ -240,7 +256,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_view = Menu(menubar(), "~View")
         menu_view.add_button("~Dock", self.mainwindow.dock_image)
         menu_view.add_button("~Float", self.mainwindow.float_image)
-        menu_view.add_button("~Load Image", self.mainwindow.load_image)
+        menu_view.add_button("~See Image", self.see_image)
 
     def init_help_menu(self):
         """Create the Help menu."""
@@ -289,7 +305,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         statusbar.add_binding(
             "see img",
             "<ButtonRelease-1>",
-            lambda: self.mainwindow.load_image(self.file.get_current_image_path()),
+            self.see_image,
         )
         statusbar.add_binding(
             "see img", "<ButtonRelease-3>", self.file.choose_image_dir

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -8,7 +8,9 @@ from tkinter import filedialog, messagebox, simpledialog
 
 from guiguts.mainwindow import maintext, sound_bell
 from guiguts.preferences import preferences
+from guiguts.utilities import is_windows
 
+FOLDER_DIR = "folder" if is_windows() else "directory"
 NUM_RECENT_FILES = 9
 PAGEMARK_PREFIX = "Pg"
 BINFILE_SUFFIX = ".json"
@@ -346,20 +348,18 @@ class File:
             if unable to get image file name.
         """
         basename = self.get_current_image_name()
-        if basename:
+        if self.image_dir and basename:
             basename += ".png"
             path = os.path.join(self.image_dir, basename)
-            if not os.path.exists(path):
-                self.choose_image_dir()
-                path = os.path.join(self.image_dir, basename)
             if os.path.exists(path):
                 return path
         return ""
 
     def choose_image_dir(self):
         """Allow user to select directory containing png image files"""
-        self.image_dir = filedialog.askdirectory(mustexist=True)
-        return self.image_dir
+        self.image_dir = filedialog.askdirectory(
+            mustexist=True, title="Select " + FOLDER_DIR + " containing scans"
+        )
 
     def goto_line(self):
         """Go to the line number the user enters"""

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -130,6 +130,10 @@ class MainWindow:
         else:
             self.float_image()
 
+    def clear_image(self):
+        """Clear the image currently being shown."""
+        mainimage().load_image("")
+
 
 class Menu(tk.Menu):
     """Extend ``tk.Menu`` to make adding buttons with accelerators simpler."""


### PR DESCRIPTION
Previous test was wrong: instead of checking if the scan file exists, it makes sense to check if a scan dir has been chosen.

Now avoids loop, and doesn't turn off Auto Img just because you haven't set up the scan dir.

Fixes #70