### PR TITLE
(Mac) Remove redundant "Quit" item from File menu

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -213,10 +213,9 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         )
         self.menu_file.add_separator()
         self.menu_file.add_button("Spawn ~Process", self.spawn_process)
-        self.menu_file.add_separator()
-        self.menu_file.add_button(
-            "~Quit", self.quit_program, "Cmd+Q" if is_mac() else ""
-        )
+        if not is_mac():
+            self.menu_file.add_separator()
+            self.menu_file.add_button("E~xit", self.quit_program, "")
 
     def init_file_recent_menu(self, parent):
         """Create the Recent Documents menu."""


### PR DESCRIPTION
In Mac applications, the standard location for the "Quit" menu item is under the so-called "Application" menu. Tkinter automatically supplies this by default. The second Quit item in the file menu is redundant.

The default Quit menu item binds Cmd-Q, so the menu item removed by this commit was not actually able to bind Cmd-Q, though it clearly attempted to do so.

I tested both of the Quit menu items. Both behaved in the same way, asking if the user wished to save their changes before exit (if the file state was dirty). As far as I can tell, this removal doesn't create any behavioral change.

<img width="273" alt="Screenshot 2023-12-22 at 11 26 54 PM" src="https://github.com/DistributedProofreaders/guiguts-py/assets/294481/ec1347e6-7fcc-4ef3-8816-c6cdbd7162ae">

<img width="362" alt="Screenshot 2023-12-22 at 11 27 08 PM" src="https://github.com/DistributedProofreaders/guiguts-py/assets/294481/b1b0ee40-c4a8-4820-931a-3bed093e7c8e">
