### PR TITLE
Check for save when app closed via WM

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -60,6 +60,10 @@ class Guiguts:
 
         self.load_file_if_given()
 
+        root().protocol(
+            "WM_DELETE_WINDOW", lambda: self.file.check_save() and root().destroy()
+        )
+
     def parse_args(self):
         """Parse command line args"""
         parser = argparse.ArgumentParser(


### PR DESCRIPTION
Closing the window via the Window Manager needs to check if the file should be saved first. 
User can respond: 
Yes - file is saved, or "save as"dialog appears if file hasn't been saved previously - cancelling this save returns to the app. 
No - app exits.
Cancel - returns to app.