### PR TITLE
Mypy

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -39,6 +39,10 @@ jobs:
     - name: Report undocumented code with sphinx
       run: |
         poetry run python -m sphinx -M coverage docs docs/build -W
+    - name: Static type check with mypy
+      run: |
+        poetry run mypy -p guiguts
+        poetry run mypy tests
     - name: Test with pytest
       run: |
         poetry run pytest

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ you can start a virtual environment shell with `poetry shell`, then run
 GG2 with `guiguts`.
 
 ## Code style
+
 Guiguts 2 uses [flake8](https://pypi.org/project/flake8) for static code analysis
 and [black](https://pypi.org/project/black) for consistent styling. Both use
 default settings, with the exception of maximum line length checking which is
@@ -101,6 +102,7 @@ with black.
 Both tools will be installed via `poetry` as described above.
 
 `poetry run flake8 .` will check all `src` & `tests` python files.
+
 `poetry run black .` will reformat all `src` & `tests` python files where necessary.
 
 This project uses Github Actions to ensure neither of the above tools reports any
@@ -111,21 +113,49 @@ are used. To summarize, class names use CapWords; constants are ALL_UPPERCASE;
 most other variables, functions and methods are all_lowercase.
 
 ## Documentation
+
 [Google-style docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
 are used to document modules, classes, functions, etc.
 
 [Sphinx](https://www.sphinx-doc.org/en/master/index.html) will be installed by
 poetry (above) and can be used to create HTML documentation by running the following command:
-`poetry run python -m sphinx -b html docs docs/build`
+```bash
+poetry run python -m sphinx -b html docs docs/build`
+```
 
 HTML docs will appear in the `docs/build` directory.
 
 Sphinx can also be used to check coverage, i.e. that docstrings have been used everywhere
 appropriate:
-`poetry run python -m sphinx -M coverage docs docs/build`
+```bash
+poetry run python -m sphinx -M coverage docs docs/build`
+```
 
 This project uses Github Actions to ensure running sphinx does not report an error, and
 that the coverage check does not report any undocumented items.
+
+## Type checking
+
+[Mypy](https://mypy.readthedocs.io/en/stable/index.html) will be installed by
+poetry (above) and is used for static type checking. Where developers have added 
+[type hints](https://peps.python.org/pep-0484/), mypy will issue warnings when those
+types are used incorrectly.
+
+It is not intended that every variable should have its type annotated, but developers
+are encouraged to add type hints to function definitions, e.g.
+```python
+def myfunc(num: int) -> str:
+    ...
+```
+Note that functions without type annotation will not be type checked. The
+[type hints cheat sheet](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html)
+has a summary of how to use type annotations for various common situations.
+
+To type check the Guiguts package and the test routines:
+```bash
+poetry run mypy -p guiguts
+poetry run mypy tests
+```
 
 ## Testing
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -384,6 +384,52 @@ files = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.8.0"
+description = "Optional static typing for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mypy-1.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:485a8942f671120f76afffff70f259e1cd0f0cfe08f81c05d8816d958d4577d3"},
+    {file = "mypy-1.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:df9824ac11deaf007443e7ed2a4a26bebff98d2bc43c6da21b2b64185da011c4"},
+    {file = "mypy-1.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2afecd6354bbfb6e0160f4e4ad9ba6e4e003b767dd80d85516e71f2e955ab50d"},
+    {file = "mypy-1.8.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8963b83d53ee733a6e4196954502b33567ad07dfd74851f32be18eb932fb1cb9"},
+    {file = "mypy-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:e46f44b54ebddbeedbd3d5b289a893219065ef805d95094d16a0af6630f5d410"},
+    {file = "mypy-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:855fe27b80375e5c5878492f0729540db47b186509c98dae341254c8f45f42ae"},
+    {file = "mypy-1.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4c886c6cce2d070bd7df4ec4a05a13ee20c0aa60cb587e8d1265b6c03cf91da3"},
+    {file = "mypy-1.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d19c413b3c07cbecf1f991e2221746b0d2a9410b59cb3f4fb9557f0365a1a817"},
+    {file = "mypy-1.8.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9261ed810972061388918c83c3f5cd46079d875026ba97380f3e3978a72f503d"},
+    {file = "mypy-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:51720c776d148bad2372ca21ca29256ed483aa9a4cdefefcef49006dff2a6835"},
+    {file = "mypy-1.8.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:52825b01f5c4c1c4eb0db253ec09c7aa17e1a7304d247c48b6f3599ef40db8bd"},
+    {file = "mypy-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f5ac9a4eeb1ec0f1ccdc6f326bcdb464de5f80eb07fb38b5ddd7b0de6bc61e55"},
+    {file = "mypy-1.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afe3fe972c645b4632c563d3f3eff1cdca2fa058f730df2b93a35e3b0c538218"},
+    {file = "mypy-1.8.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:42c6680d256ab35637ef88891c6bd02514ccb7e1122133ac96055ff458f93fc3"},
+    {file = "mypy-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:720a5ca70e136b675af3af63db533c1c8c9181314d207568bbe79051f122669e"},
+    {file = "mypy-1.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:028cf9f2cae89e202d7b6593cd98db6759379f17a319b5faf4f9978d7084cdc6"},
+    {file = "mypy-1.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4e6d97288757e1ddba10dd9549ac27982e3e74a49d8d0179fc14d4365c7add66"},
+    {file = "mypy-1.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f1478736fcebb90f97e40aff11a5f253af890c845ee0c850fe80aa060a267c6"},
+    {file = "mypy-1.8.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:42419861b43e6962a649068a61f4a4839205a3ef525b858377a960b9e2de6e0d"},
+    {file = "mypy-1.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:2b5b6c721bd4aabaadead3a5e6fa85c11c6c795e0c81a7215776ef8afc66de02"},
+    {file = "mypy-1.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5c1538c38584029352878a0466f03a8ee7547d7bd9f641f57a0f3017a7c905b8"},
+    {file = "mypy-1.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4ef4be7baf08a203170f29e89d79064463b7fc7a0908b9d0d5114e8009c3a259"},
+    {file = "mypy-1.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7178def594014aa6c35a8ff411cf37d682f428b3b5617ca79029d8ae72f5402b"},
+    {file = "mypy-1.8.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ab3c84fa13c04aeeeabb2a7f67a25ef5d77ac9d6486ff33ded762ef353aa5592"},
+    {file = "mypy-1.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:99b00bc72855812a60d253420d8a2eae839b0afa4938f09f4d2aa9bb4654263a"},
+    {file = "mypy-1.8.0-py3-none-any.whl", hash = "sha256:538fd81bb5e430cc1381a443971c0475582ff9f434c16cd46d2c66763ce85d9d"},
+    {file = "mypy-1.8.0.tar.gz", hash = "sha256:6ff8b244d7085a0b425b56d327b480c3b29cafbd2eff27316a004f9a7391ae07"},
+]
+
+[package.dependencies]
+mypy-extensions = ">=1.0.0"
+typing-extensions = ">=4.1.0"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+install-types = ["pip"]
+mypyc = ["setuptools (>=50)"]
+reports = ["lxml"]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
@@ -752,6 +798,28 @@ lint = ["docutils-stubs", "flake8", "mypy"]
 test = ["pytest"]
 
 [[package]]
+name = "types-pillow"
+version = "10.1.0.2"
+description = "Typing stubs for Pillow"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "types-Pillow-10.1.0.2.tar.gz", hash = "sha256:525c1c5ee67b0ac1721c40d2bc618226ef2123c347e527e14e05b920721a13b9"},
+    {file = "types_Pillow-10.1.0.2-py3-none-any.whl", hash = "sha256:131078ffa547bf9a201d39ffcdc65633e108148085f4f1b07d4647fcfec6e923"},
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.9.0"
+description = "Backported and Experimental Type Hints for Python 3.8+"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "typing_extensions-4.9.0-py3-none-any.whl", hash = "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"},
+    {file = "typing_extensions-4.9.0.tar.gz", hash = "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.1.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -770,4 +838,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "fef3e4107ef800c258dbe2e05e9129c2de18ba9bcdfce9a20efd644843a7778e"
+content-hash = "12cf49078ddb525561ee123bbac72638370d9910ab8b2d1e27072a25484c094c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ black = "^23.12"
 flake8 = "^6.1"
 Sphinx = "^7.2"
 pytest = "^7.4"
+mypy = "^1.8"
+types-Pillow = "^10.1"
 build = "^1.0.3"
 
 [tool.poetry.scripts]

--- a/src/guiguts/preferences_dialog.py
+++ b/src/guiguts/preferences_dialog.py
@@ -14,13 +14,13 @@ class PreferencesDialog(simpledialog.Dialog):
         entries: Dictionary of ``Entry`` widgets showing preference values.
     """
 
-    def __init__(self, parent):
+    def __init__(self, parent: tk.Tk) -> None:
         """Initialize ``labels`` and ``entries`` to empty dictionaries."""
-        self.labels = {}
-        self.entries = {}
+        self.labels: dict[str, ttk.Label] = {}
+        self.entries: dict[str, ttk.Entry] = {}
         super().__init__(parent, "Set Preferences")
 
-    def body(self, frame):
+    def body(self, frame: tk.Frame) -> tk.Frame:
         """Override default to construct widgets needed to show all
         preferences keys/values.
 
@@ -39,7 +39,7 @@ class PreferencesDialog(simpledialog.Dialog):
             self.entries[key].grid(row=row, column=1)
         return frame
 
-    def buttonbox(self):
+    def buttonbox(self) -> None:
         """Override default to set up OK and Cancel buttons."""
         frame = ttk.Frame(self, padding=5)
         frame.pack()
@@ -54,7 +54,7 @@ class PreferencesDialog(simpledialog.Dialog):
         self.bind("<Return>", lambda event: self.ok_pressed())
         self.bind("<Escape>", lambda event: self.cancel_pressed())
 
-    def ok_pressed(self):
+    def ok_pressed(self) -> None:
         """Update all preferences from the corresponding ``Entry``` widget.
 
         Does not cope with non-string values at the moment, since get()
@@ -65,6 +65,6 @@ class PreferencesDialog(simpledialog.Dialog):
         preferences.save()
         self.destroy()
 
-    def cancel_pressed(self):
+    def cancel_pressed(self) -> None:
         """Destroy dialog."""
         self.destroy()

--- a/src/guiguts/utilities.py
+++ b/src/guiguts/utilities.py
@@ -9,23 +9,28 @@ _called_from_test = False
 
 #
 # Functions to check which OS is being used
-def is_mac():
+def is_mac() -> bool:
     """Return true if running on Mac"""
     return _is_system("Darwin")
 
 
-def is_windows():
+def is_windows() -> bool:
     """Return true if running on Windows"""
     return _is_system("Windows")
 
 
-def is_x11():
+def is_x11() -> bool:
     """Return true if running on Linux"""
     return _is_system("Linux")
 
 
-def _is_system(system):
-    """Return true if running on given system"""
+# mypy: disable-error-code="attr-defined"
+def _is_system(system: str) -> bool:
+    """Return true if running on given system
+
+    Args:
+        system: Name of system to check against
+    """
     try:
         return _is_system.system == system
     except AttributeError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
 """Configure pytest"""
 
+import pytest
+
 import guiguts.utilities
 
 
-def pytest_configure(config):
+def pytest_configure(config: pytest.Config) -> None:
     """Set flag so application code can detect if within a pytest run
 
     See: https://pytest.org/en/7.4.x/example/simple.html#detect-if-running-from-within-a-pytest-run

--- a/tests/test_guiguts.py
+++ b/tests/test_guiguts.py
@@ -6,20 +6,20 @@ from guiguts.preferences import preferences
 from guiguts.utilities import is_mac, is_windows, is_x11, _is_system
 
 
-def test_which_os():
+def test_which_os() -> None:
     """Test the OS checking functions"""
     assert is_mac() or is_windows() or is_x11()
     assert not _is_system("Android")
 
 
-def test_file():
+def test_file() -> None:
     """Test the File class"""
     ff = File(lambda: None)
     ff.filename = "dummy.txt"
     assert ff.filename == "dummy.txt"
 
 
-def test_preferences():
+def test_preferences() -> None:
     """Test the Preferences class"""
     assert preferences.get_default("pkey1") is None
     preferences.set_default("pkey1", "pdefault1")
@@ -37,7 +37,7 @@ def test_preferences():
     assert "pkey2" in keys
 
 
-def test_mainwindow():
+def test_mainwindow() -> None:
     """Test mainwindow functions"""
     (tilde, text) = _process_label("~Save...")
     assert tilde == 0


### PR DESCRIPTION
Use mypy for static type checking.

Mypy set up to install via poetry and to run as Github Action.

Source code changes: 

Primarily function definitions now have type annotations, plus
a few other places that mypy needed them.

There is no output from a default run of mypy now.

In addition, when mypy is run with `--disallow-untyped-defs`
there is also no output, meaning all function defs have type
hints so all code is being type checked.

A couple of small type errors/dangers were highlighted by the
process and have been fixed.

There are 7 instances of `# type: ignore[...]` directives, generally
to do with either incompatibility between Tkinter and its stubs
file, or just too complicated to sort out to satisfy mypy at the
moment.