### PR TITLE
Fix bugs in prefs/recent files

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -93,17 +93,17 @@ class Guiguts:
             self.file.load_file(self.args.filename)
         elif self.args.recent:
             index = self.args.recent - 1
-            self.file.load_file(preferences["RecentFiles"][index])
+            self.file.load_file(preferences.get("RecentFiles")[index])
 
     @property
     def auto_image(self) -> bool:
         """Auto image flag: setting causes side effects in UI
         & starts repeating check."""
-        return preferences["AutoImage"]
+        return preferences.get("AutoImage")
 
     @auto_image.setter
     def auto_image(self, value: bool) -> None:
-        preferences["AutoImage"] = value
+        preferences.set("AutoImage", value)
         statusbar().set("see img", "Auto Img" if value else "See Img")
         if value:
             self.image_dir_check()
@@ -291,7 +291,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
     def init_file_recent_menu(self, parent: Menu) -> None:
         """Create the Recent Documents menu."""
         recent_menu = Menu(parent, "Recent Doc~uments")
-        for count, file in enumerate(preferences["RecentFiles"], start=1):
+        for count, file in enumerate(preferences.get("RecentFiles"), start=1):
             recent_menu.add_button(
                 f"~{count}: {file}", lambda fn=file: self.open_file(fn)
             )

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -236,8 +236,10 @@ class File:
             filename: Name of new file to add to list.
         """
         self.remove_recent_file(filename)
-        preferences["RecentFiles"].insert(0, filename)
-        del preferences["RecentFiles"][NUM_RECENT_FILES:]
+        recents = preferences.get("RecentFiles")
+        recents.insert(0, filename)
+        del recents[NUM_RECENT_FILES:]
+        preferences.set("RecentFiles", recents)
 
     def remove_recent_file(self, filename: str) -> None:
         """Remove given filename from list of recent files.
@@ -245,8 +247,10 @@ class File:
         Args:
             filename: Name of new file to add to list.
         """
-        if filename in preferences["RecentFiles"]:
-            preferences["RecentFiles"].remove(filename)
+        recents = preferences.get("RecentFiles")
+        if filename in recents:
+            recents.remove(filename)
+            preferences.set("RecentFiles", recents)
 
     def dict_to_page_marks(self, page_marks_dict: Any) -> None:
         """Set page marks from keys/values in dictionary.

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -654,7 +654,7 @@ class MainWindow:
             tk.Wm.protocol(mainimage(), "WM_DELETE_WINDOW", self.dock_image)  # type: ignore[call-overload]
         else:
             root().wm_forget(mainimage())  # type: ignore[arg-type]
-        preferences["ImageWindow"] = "Floated"
+        preferences.set("ImageWindow", "Floated")
 
     def dock_image(self, *args: Any) -> None:
         """Dock the image back into the main window"""
@@ -666,7 +666,7 @@ class MainWindow:
                 self.paned_window.forget(mainimage())
             except tk.TclError:
                 pass  # OK - image wasn't being managed by paned_window
-        preferences["ImageWindow"] = "Docked"
+        preferences.set("ImageWindow", "Docked")
 
     def load_image(self, filename: str) -> None:
         """Load the image for the given page.
@@ -675,7 +675,7 @@ class MainWindow:
             filename: Path to image file.
         """
         mainimage().load_image(filename)
-        if preferences["ImageWindow"] == "Docked":
+        if preferences.get("ImageWindow") == "Docked":
             self.dock_image()
         else:
             self.float_image()
@@ -713,7 +713,7 @@ def sound_bell() -> None:
     Visible flashes the first statusbar button (must be ttk.Button)
     Preference "Bell" contains "Audible", "Visible", both or neither
     """
-    bell_pref = preferences["Bell"]
+    bell_pref = preferences.get("Bell")
     if "Audible" in bell_pref:
         root().bell()
     if "Visible" in bell_pref:

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -77,12 +77,8 @@ class Preferences:
             key: Name of preference.
             value: Value for preference.
         """
-        print(key, flush=True)
-        print(self.get(key), flush=True)
-        print(value, flush=True)
         if self.get(key) != value:
             self.dict[key] = value
-            print("save", flush=True)
             self.save()
 
     def __del__(self) -> None:

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -1,5 +1,6 @@
 """Handle preferences"""
 
+import copy
 import json
 import os
 from typing import Any, Callable
@@ -57,10 +58,8 @@ class Preferences:
         self._remove_test_prefs_file()
         self.load()
 
-    def __getitem__(self, key: str) -> Any:
+    def get(self, key: str) -> Any:
         """Get preference value using key.
-
-        Provides `value = preferences[key]`
 
         Args:
             key: Name of preference.
@@ -69,19 +68,22 @@ class Preferences:
             Preferences value; default for ``key`` if no preference set;
             ``None`` if no default for ``key``.
         """
-        return self.dict.get(key, self.defaults.get(key))
+        return copy.deepcopy(self.dict.get(key, self.defaults.get(key)))
 
-    def __setitem__(self, key: str, value: Any) -> None:
-        """Set preference value and save to file.
-
-        Provides `preferences[key] = value`
+    def set(self, key: str, value: Any) -> None:
+        """Set preference value and save to file if value has changed.
 
         Args:
             key: Name of preference.
             value: Value for preference.
         """
-        self.dict[key] = value
-        self.save()
+        print(key, flush=True)
+        print(self.get(key), flush=True)
+        print(value, flush=True)
+        if self.get(key) != value:
+            self.dict[key] = value
+            print("save", flush=True)
+            self.save()
 
     def __del__(self) -> None:
         """Remove any test prefs file when finished."""
@@ -145,7 +147,7 @@ class Preferences:
         for key in self.callbacks.keys():
             callback = self.callbacks[key]
             if callback is not None:
-                callback(self[key])
+                callback(self.get(key))
 
     def _remove_test_prefs_file(self) -> None:
         """Remove temporary JSON file used for prefs during testing."""

--- a/src/guiguts/preferences_dialog.py
+++ b/src/guiguts/preferences_dialog.py
@@ -35,7 +35,7 @@ class PreferencesDialog(simpledialog.Dialog):
             self.labels[key] = ttk.Label(frame, text=key)
             self.labels[key].grid(row=row, column=0)
             self.entries[key] = ttk.Entry(frame, width=20)
-            self.entries[key].insert(tk.END, str(preferences[key]))
+            self.entries[key].insert(tk.END, str(preferences.get(key)))
             self.entries[key].grid(row=row, column=1)
         return frame
 
@@ -61,7 +61,7 @@ class PreferencesDialog(simpledialog.Dialog):
         always returns a string.
         """
         for key in preferences.keys():
-            preferences[key] = self.entries[key].get()
+            preferences.set(key, self.entries[key].get())
         preferences.save()
         self.destroy()
 

--- a/tests/test_guiguts.py
+++ b/tests/test_guiguts.py
@@ -24,8 +24,8 @@ def test_preferences() -> None:
     assert preferences.get_default("pkey1") is None
     preferences.set_default("pkey1", "pdefault1")
     assert preferences.get_default("pkey1") == "pdefault1"
-    preferences["pkey1"] = "pvalue1"
-    assert preferences["pkey1"] == "pvalue1"
+    preferences.set("pkey1", "pvalue1")
+    assert preferences.get("pkey1") == "pvalue1"
     assert preferences.get_default("pkey1") == "pdefault1"
     keys = preferences.keys()
     assert len(keys) == 1


### PR DESCRIPTION
Preferences were being saved every time AutoImg was checking for whether to load an image, because the "docked/floated" flag was set.  Altered so that the prefs are only saved when the value is changed, not if it is set to the same value as it formerly was.

When getting a preference that was a list (like the list of recent files, the code was not doing a `copy` (due to my Python ignorance). This meant that when the new recent file was added, it was inserted directly into the prefs list rather than "setting" the list, hence saving wasn't being triggered. Fixed by using `deepcopy` - in fact, a shallow `copy` would be OK for the current settings stored in prefs, but hopefully a deep copy will avoid similar headaches in the future. Performance is not an issue for the relatively small number of prefs values.

Fixes #90 
Fixes #91 
