### PR TITLE
Add line numbers to main text window

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,7 @@
 [flake8]
 
-# Recommended settings to avoid line-length conflicts with black
+# Recommended settings to avoid line-length and
+# "line break before binary operator" conflicts with black
 max-line-length = 80
 select = C,E,F,W,B,B950
-extend-ignore = E203, E501, E704
+extend-ignore = E203, E501, E704, W503

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -248,6 +248,10 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         preferences.set_default("Bell", "VisibleAudible")
         preferences.set_default("ImageWindow", "Docked")
         preferences.set_default("RecentFiles", [])
+        preferences.set_default("LineNumbers", True)
+        preferences.set_callback(
+            "LineNumbers", lambda show: maintext().show_line_numbers(show)
+        )
 
     # Lay out menus
     def init_menus(self) -> None:
@@ -350,6 +354,9 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             ),
         )
         statusbar.add_binding("rowcol", "<ButtonRelease-1>", self.file.goto_line)
+        statusbar.add_binding(
+            "rowcol", "<ButtonRelease-3>", maintext().toggle_line_numbers
+        )
 
         statusbar.add(
             "img",

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -156,12 +156,39 @@ def _process_accel(accel: str) -> tuple[str, str]:
     return (accel, f"<{keyevent}>")
 
 
+# TextLineNumbers widget adapted from answer at
+# https://stackoverflow.com/questions/16369470/tkinter-adding-line-number-to-text-widget
+class TextLineNumbers(tk.Canvas):
+    def __init__(
+        self, parent: tk.Widget, text_widget: tk.Text, *args: Any, **kwargs: Any
+    ) -> None:
+        tk.Canvas.__init__(self, parent, *args, **kwargs)
+        self.textwidget = text_widget
+
+    def redraw(self, *args: Any) -> None:
+        """redraw line numbers"""
+        self.delete("all")
+
+        text_pos = self.winfo_width() - 2
+        index = self.textwidget.index("@0,0")
+        while True:
+            dline = self.textwidget.dlineinfo(index)
+            if dline is None:
+                break
+            linenum = str(index).split(".")[0]
+            self.create_text(text_pos, dline[1], anchor="ne", text=linenum)
+            index = self.textwidget.index("%s+1line" % index)
+
+
 class MainText(tk.Text):
     """MainText is the main text window, and inherits from ``tk.Text``."""
 
     def __init__(self, parent: tk.Widget, **kwargs: Any) -> None:
-        """Create a Frame, and put a Text and two Scrollbars in the Frame.
-        Layout and linking of the Scrollbars to the Text widget is done here.
+        """Create a Frame, and put a TextLineNumbers widget, a Text and two
+        Scrollbars in the Frame.
+
+        Layout and linking of the TextLineNumbers widget and Scrollbars to
+        the Text widget are done here.
 
         Args:
             parent: Parent widget to contain MainText.
@@ -170,28 +197,103 @@ class MainText(tk.Text):
 
         # Create surrounding Frame
         self.frame = ttk.Frame(parent)
-        self.frame.columnconfigure(0, weight=1)
+        self.frame.columnconfigure(1, weight=1)
         self.frame.rowconfigure(0, weight=1)
 
         # Create Text itself & place in Frame
         super().__init__(self.frame, **kwargs)
-        tk.Text.grid(self, column=0, row=0, sticky="NSEW")
+        tk.Text.grid(self, column=1, row=0, sticky="NSEW")
+
+        # Create a proxy for the underlying widget
+        self._w: str  # Let mypy know about _w
+        self._orig = self._w + "_orig"
+        self.tk.call("rename", self._w, self._orig)
+        self.tk.createcommand(self._w, self._proxy)
+
+        # Create Line Numbers widget
+        self.linenumbers = TextLineNumbers(self.frame, self, width=35)
+        self.linenumbers.grid(column=0, row=0, sticky="NSEW")
+
+        self.bind("<<Change>>", self._on_change)
+        self.bind("<Configure>", self._on_change)
 
         # Create scrollbars, place in Frame, and link to Text
         hscroll = ttk.Scrollbar(self.frame, orient=tk.HORIZONTAL, command=self.xview)
-        hscroll.grid(column=0, row=1, sticky="EW")
+        hscroll.grid(column=1, row=1, sticky="EW")
         self["xscrollcommand"] = hscroll.set
         vscroll = ttk.Scrollbar(self.frame, orient=tk.VERTICAL, command=self.yview)
-        vscroll.grid(column=1, row=0, sticky="NS")
+        vscroll.grid(column=2, row=0, sticky="NS")
         self["yscrollcommand"] = vscroll.set
 
         # Set up response to text being modified
         self.modifiedCallbacks: list[Callable[[], None]] = []
         self.bind("<<Modified>>", self.modify_flag_changed_callback)
 
+    def _proxy(self, *args: Any) -> Any:
+        """Proxy to intercept commands sent to widget and generate a
+        <<Changed>> event if line numbers need updating."""
+
+        # Avoid error when copying or deleting
+        if (
+            (args[0] == "get" or args[0] == "delete")
+            and args[1] == "sel.first"
+            and args[2] == "sel.last"
+            and not self.tag_ranges("sel")
+        ):
+            return
+
+        # let the actual widget perform the requested action
+        cmd = (self._orig,) + args
+        result = self.tk.call(cmd)
+
+        # generate an event if something was added or deleted,
+        # or the cursor position changed
+        if (
+            args[0] in ("insert", "replace", "delete")
+            or args[0:3] == ("mark", "set", "insert")
+            or args[0:2] == ("xview", "moveto")
+            or args[0:2] == ("xview", "scroll")
+            or args[0:2] == ("yview", "moveto")
+            or args[0:2] == ("yview", "scroll")
+        ):
+            self.event_generate("<<Change>>", when="tail")
+
+        # return what the actual widget returned
+        return result
+
+    def _on_change(self, event: tk.Event) -> None:
+        """Callback when visible region of file may have changed"""
+        self.linenumbers.redraw()
+
     def grid(self, *args: Any, **kwargs: Any) -> None:
         """Override ``grid``, so placing MainText widget actually places surrounding Frame"""
         return self.frame.grid(*args, **kwargs)
+
+    def toggle_line_numbers(self) -> None:
+        """Toggle whether line numbers are shown."""
+        self.show_line_numbers(not self.line_numbers_shown())
+
+    def show_line_numbers(self, show: bool) -> None:
+        """Show or hide line numbers.
+
+        Args:
+            show: True to show, False to hide.
+        """
+        if self.line_numbers_shown() == show:
+            return
+        if show:
+            self.linenumbers.grid()
+        else:
+            self.linenumbers.grid_remove()
+        preferences["LineNumbers"] = show
+
+    def line_numbers_shown(self) -> bool:
+        """Check if line numbers are shown.
+
+        Returns:
+            True if shown, False if not.
+        """
+        return self.linenumbers.winfo_viewable()
 
     def key_bind(self, keyevent: str, handler: Callable[[Any], None]) -> None:
         """Bind lower & uppercase versions of ``keyevent`` to ``handler``


### PR DESCRIPTION
Line numbers are shown by default. Can be toggled by right-clicking the first (Line:Col) status bar button (as in GG1). Setting is stored in Prefs, so will be remembered next time program is run.

Merging note: Setting a preference has different syntax after #93 is merged