### PR TITLE
Use `logging` module for messages

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -68,6 +68,7 @@ class Guiguts:
         root().update_idletasks()
 
         self.logging_add_gui(self.logger)
+        self.logger.info("GUI initialized")
 
         preferences.run_callbacks()
 

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -31,6 +31,7 @@ from guiguts.preferences import preferences
 from guiguts.preferences_dialog import PreferencesDialog
 from guiguts.utilities import is_mac
 
+logger = logging.getLogger(__package__)
 
 MESSAGE_FORMAT = "%(asctime)s: %(levelname)s - %(message)s"
 DEBUG_FORMAT = "%(asctime)s: %(levelname)s - %(filename)s:%(lineno)d - %(message)s"
@@ -46,8 +47,8 @@ class Guiguts:
 
         self.parse_args()
 
-        self.logger = self.logging_init()
-        self.logger.info("Guiguts started")
+        self.logging_init()
+        logger.info("Guiguts started")
 
         self.set_preferences_defaults()
 
@@ -67,8 +68,8 @@ class Guiguts:
         # or focus will not return to maintext on Windows
         root().update_idletasks()
 
-        self.logging_add_gui(self.logger)
-        self.logger.info("GUI initialized")
+        self.logging_add_gui()
+        logger.info("GUI initialized")
 
         preferences.run_callbacks()
 
@@ -391,7 +392,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         statusbar.add("next img", text=">", width=1)
         statusbar.add_binding("next img", "<ButtonRelease-1>", self.file.next_page)
 
-    def logging_init(self) -> logging.Logger:
+    def logging_init(self) -> None:
         """Set up basic logger until GUI is ready."""
         if self.args.debug:
             log_level = logging.DEBUG
@@ -401,22 +402,17 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             log_level = logging.INFO
             console_log_level = logging.WARNING
             formatter = logging.Formatter(MESSAGE_FORMAT, "%H:%M:%S")
-        logger = logging.getLogger(__package__)
         logger.setLevel(log_level)
         # Output to console
         console_handler = logging.StreamHandler()
         console_handler.setLevel(console_log_level)
         console_handler.setFormatter(formatter)
         logger.addHandler(console_handler)
-        return logger
 
-    def logging_add_gui(self, logger: logging.Logger) -> None:
+    def logging_add_gui(self) -> None:
         """Add handlers to display log messages via the GUI.
 
         Assumes mainwindow has created the message_log handler.
-
-        Args:
-            logger: Logger to be updated with GUI handlers.
         """
 
         # Message log is approximate GUI equivalent to console output

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -7,7 +7,7 @@ import tkinter as tk
 from tkinter import filedialog, messagebox, simpledialog
 from typing import Any, Callable, Final, TypedDict, Literal
 
-from guiguts.mainwindow import maintext, sound_bell
+from guiguts.mainwindow import maintext, sound_bell, logger
 from guiguts.preferences import preferences
 from guiguts.utilities import is_windows
 
@@ -112,9 +112,7 @@ class File:
         try:
             maintext().do_open(filename)
         except FileNotFoundError:
-            messagebox.showerror(
-                title="File Not Found", message=f"Unable to open {filename}"
-            )
+            logger.error(f"Unable to open {filename}")
             self.remove_recent_file(filename)
             self.filename = ""
             return

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -1,15 +1,18 @@
 """Handle file operations"""
 
 import json
+import logging
 import os.path
 import re
 import tkinter as tk
 from tkinter import filedialog, messagebox, simpledialog
 from typing import Any, Callable, Final, TypedDict, Literal
 
-from guiguts.mainwindow import maintext, sound_bell, logger
+from guiguts.mainwindow import maintext, sound_bell
 from guiguts.preferences import preferences
 from guiguts.utilities import is_windows
+
+logger = logging.getLogger(__package__)
 
 FOLDER_DIR = "folder" if is_windows() else "directory"
 NUM_RECENT_FILES = 9

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -17,6 +17,7 @@ from typing import Any, Callable, Optional
 from guiguts.preferences import preferences
 from guiguts.utilities import is_mac, is_x11
 
+logger = logging.getLogger(__package__)
 
 TEXTIMAGE_WINDOW_ROW = 0
 TEXTIMAGE_WINDOW_COL = 0
@@ -670,7 +671,7 @@ class MessageLog(logging.Handler):
         Args:
             record: Record containing message.
         """
-        message = self.format(record)
+        message = self.format(record) + "\n"
         self._messagelog += message
 
         # If dialog is visible, append error
@@ -885,6 +886,3 @@ def statusbar() -> StatusBar:
     """Return the single StatusBar widget"""
     assert MainWindow.statusbar is not None
     return MainWindow.statusbar
-
-
-logger = logging.getLogger(__package__)

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -1,16 +1,15 @@
 """Define key components of main window"""
 
 
-from datetime import datetime
 from idlelib.redirector import WidgetRedirector  # type: ignore[import-not-found]
+import logging
 import os.path
 from PIL import Image, ImageTk
 import re
-import sys
 import time
 import traceback
 import tkinter as tk
-from tkinter import ttk
+from tkinter import ttk, messagebox
 
 from types import TracebackType
 from typing import Any, Callable, Optional
@@ -55,7 +54,7 @@ class Root(tk.Tk):
         writing it to stderr.
         """
         err = "Tkinter Exception\n" + "".join(traceback.format_exception(exc, val, tb))
-        messagelog().error(err)
+        logger.error(err)
 
 
 class Menu(tk.Menu):
@@ -640,36 +639,48 @@ class MessageLogDialog(tk.Toplevel):
         self.messagelog.insert("end", message)
 
 
-class MessageLog:
-    """Handles the output of messages."""
+class ErrorHandler(logging.Handler):
+    """Handle GUI output of error messages."""
 
-    def __init__(self) -> None:
-        """Initialize message logging.
+    def __init__(self, *args: Any) -> None:
+        """Initialize error logging handler."""
+        super().__init__(*args)
 
-        Attributes:
-            _messagelog: List of messages that have been output.
-            dialog: The dialog to write the messages to
+    def emit(self, record: logging.LogRecord) -> None:
+        """Output error message to message box.
+
+        Args:
+            record: Record containing error message.
         """
+        messagebox.showerror(title=record.levelname, message=record.getMessage())
+
+
+class MessageLog(logging.Handler):
+    """Handle GUI output of all messages."""
+
+    def __init__(self, *args: Any) -> None:
+        """Initialize the message log handler."""
+        super().__init__(*args)
         self._messagelog: str = ""
         self.dialog: MessageLogDialog
 
-    def error(self, error: str) -> None:
-        """Output an error message to the message log dialog
-
-        If the dialog does not exist, create it.
+    def emit(self, record: logging.LogRecord) -> None:
+        """Log message in message log.
 
         Args:
-            error: Message to be output.
+            record: Record containing message.
         """
-        date_time = datetime.now().strftime("%H:%M:%S:")
-        error = f"{date_time} {error}\n"
-        sys.stderr.write(error)
-        self._messagelog += error
+        message = self.format(record)
+        self._messagelog += message
 
-        # If dialog exists, append error, otherwise create dialog & write whole log
+        # If dialog is visible, append error
         if hasattr(self, "dialog") and self.dialog.winfo_exists():
-            self.dialog.append(error)
-        else:
+            self.dialog.append(message)
+            self.dialog.lift()
+
+    def show(self) -> None:
+        """Show the message log dialog."""
+        if not (hasattr(self, "dialog") and self.dialog.winfo_exists()):
             self.dialog = MessageLogDialog(root())
             self.dialog.append(self._messagelog)
         self.dialog.lift()
@@ -876,7 +887,4 @@ def statusbar() -> StatusBar:
     return MainWindow.statusbar
 
 
-def messagelog() -> MessageLog:
-    """Return the single MessageLog object"""
-    assert MainWindow.messagelog is not None
-    return MainWindow.messagelog
+logger = logging.getLogger(__package__)


### PR DESCRIPTION
1. Add `-d` or `--debug` command line option which starts GG in debug mode: messages will contain `filename:linenum`. Also, debug messages will be displayed (see below).
2. Add basic message handler when program starts that just outputs to stderr.
3. Once GUI is initialized, add two more handlers: one to show error messages in a popup messagebox dialog; the other to log all messages in the message log window, which can be viewed at any time via the `View` menu.
4. In debug mode, all messages are written to stderr and the message log. In non-debug mode, debug messages are not displayed at all, and info messages are only written to the message log, not to stderr.
5. Messages show timestamp, severity of message, and the message. Also filename:linenum when in debug mode.

Fixes #94