### PR TITLE
Trap JSON decode errors more cleanly

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -50,7 +50,7 @@ class Guiguts:
         self.logging_init()
         logger.info("Guiguts started")
 
-        self.set_preferences_defaults()
+        self.initialize_preferences()
 
         self.file = File(self.filename_changed)
 
@@ -254,10 +254,8 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         messagebox.showinfo(title="Spawn stdout", message=result.stdout)
         messagebox.showinfo(title="Spawn stderr", message=result.stderr)
 
-    def set_preferences_defaults(self) -> None:
-        """Set default preferences - will be overridden by any values set
-        in the Preferences file.
-        """
+    def initialize_preferences(self) -> None:
+        """Set default preferences and load settings from the GGPrefs file."""
 
         def set_auto_image(value: bool) -> None:
             self.auto_image = value
@@ -271,6 +269,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         preferences.set_callback(
             "LineNumbers", lambda show: maintext().show_line_numbers(show)
         )
+        preferences.load()
 
     # Lay out menus
     def init_menus(self) -> None:

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Final, TypedDict, Literal
 
 from guiguts.mainwindow import maintext, sound_bell
 from guiguts.preferences import preferences
-from guiguts.utilities import is_windows
+from guiguts.utilities import is_windows, load_dict_from_json
 
 logger = logging.getLogger(__package__)
 
@@ -188,12 +188,9 @@ class File:
         Args:
             basename - name of current text file - bin file has ".bin" appended.
         """
-        binfile_name = bin_name(basename)
-        if not os.path.isfile(binfile_name):
-            return
-        with open(binfile_name, "r") as fp:
-            bin_dict = json.load(fp)
-        self.interpret_bin(bin_dict)
+        bin_dict = load_dict_from_json(bin_name(basename))
+        if bin_dict is not None:
+            self.interpret_bin(bin_dict)  # type: ignore[arg-type]
 
     def save_bin(self, basename: str) -> None:
         """Save bin file associated with current file.

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -2,10 +2,14 @@
 
 import copy
 import json
+import logging
 import os
 from typing import Any, Callable
 
-from guiguts.utilities import is_x11, _called_from_test
+from guiguts.utilities import is_x11, _called_from_test, load_dict_from_json
+
+
+logger = logging.getLogger(__package__)
 
 
 class Preferences:
@@ -56,7 +60,6 @@ class Preferences:
         self.prefsfile = os.path.join(self.prefsdir, prefs_name)
 
         self._remove_test_prefs_file()
-        self.load()
 
     def get(self, key: str) -> Any:
         """Get preference value using key.
@@ -132,9 +135,9 @@ class Preferences:
 
     def load(self) -> None:
         """Load preferences dictionary from JSON file."""
-        if os.path.isfile(self.prefsfile):
-            with open(self.prefsfile, "r") as fp:
-                self.dict = json.load(fp)
+        prefs_dict = load_dict_from_json(self.prefsfile)
+        if prefs_dict is not None:
+            self.dict = prefs_dict
 
     def run_callbacks(self) -> None:
         """Run all defined callbacks, passing value as argument.

--- a/src/guiguts/utilities.py
+++ b/src/guiguts/utilities.py
@@ -1,6 +1,12 @@
 """Handy utility functions"""
 
+import json
 import platform
+import logging
+import os.path
+from typing import Any, Optional
+
+logger = logging.getLogger(__package__)
 
 # Flag so application code can detect if within a pytest run - only use if really needed
 # See: https://pytest.org/en/7.4.x/example/simple.html#detect-if-running-from-within-a-pytest-run
@@ -38,3 +44,21 @@ def _is_system(system: str) -> bool:
         if _is_system.system not in ["Darwin", "Linux", "Windows"]:
             raise Exception("Unknown windowing system")
         return _is_system.system == system
+
+
+def load_dict_from_json(filename: str) -> Optional[dict[str, Any]]:
+    """If file exists, attempt to load into dict.
+
+    Args:
+        filename: Name of JSON file to load.
+
+    Returns:
+        Dictionary if loaded successfully, or None.
+    """
+    if os.path.isfile(filename):
+        with open(filename, "r") as fp:
+            try:
+                return json.load(fp)
+            except json.decoder.JSONDecodeError as exc:
+                logger.error(f"Unable to load {filename}\n" + str(exc))
+    return None

--- a/src/guiguts/utilities.py
+++ b/src/guiguts/utilities.py
@@ -60,5 +60,7 @@ def load_dict_from_json(filename: str) -> Optional[dict[str, Any]]:
             try:
                 return json.load(fp)
             except json.decoder.JSONDecodeError as exc:
-                logger.error(f"Unable to load {filename}\n" + str(exc))
+                logger.error(
+                    f"Unable to load {filename} -- not valid JSON format\n" + str(exc)
+                )
     return None


### PR DESCRIPTION
Instead of an unhandled exception being reported, log an error if a JSON file cannot be decoded, e.g. if the user has edited it.

Code commonized and used in two places: loading `GGprefs.json` and loading the project json file (the file formerly known as "bin").

It also became apparent that `GGprefs.json` was being loaded too early (when the preferences module was imported into `application.py`, rather than being deliberately initialized at the correct time.)

Order is now: parse args, start logger, load prefs, initialize GUI. This means the logger is initialized correctly in debug mode (set via command line), and provides future opportunity for command line args to suppress loading prefs, which was useful for testing purposes in GG1.

Fixes #71 