### PR TITLE
Add checksum to bin file to trap mismatches

### DIFF
--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -220,10 +220,10 @@ class File:
         md5checksum = bin_dict.get(BINFILE_KEY_MD5CHECKSUM)
         if md5checksum and md5checksum != self.get_md5_checksum():
             logger.error(
-                """Main file and bin (.json) file do not match.
-    File may have been edited in a different editor.
-    You may continue, but page boundary positions
-    may not be accurate."""
+                "Main file and bin (.json) file do not match.\n"
+                "  File may have been edited in a different editor.\n"
+                "  You may continue, but page boundary positions\n"
+                "  may not be accurate."
             )
         self.set_initial_position(bin_dict.get(BINFILE_KEY_INSERTPOS))
         # Since object loaded from bin file is a dictionary of dictionaries,
@@ -258,7 +258,7 @@ class File:
         Returns:
             MD5 checksum
         """
-        return hashlib.md5(maintext().get(1.0, tk.END).encode()).hexdigest()
+        return hashlib.md5(maintext().get_text().encode()).hexdigest()
 
     def store_recent_file(self, filename: str) -> None:
         """Store given filename in list of recent files.

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -363,9 +363,7 @@ class MainText(tk.Text):
             fname: Name of file to save text to.
         """
         with open(fname, "w", encoding="utf-8") as fh:
-            fh.write(
-                self.get(1.0, f"{tk.END}-1c")
-            )  # "-1c" because Tk has an extra newline at tk.END
+            fh.write(self.get_text())
             self.set_modified(False)
 
     def do_open(self, fname: str) -> None:
@@ -398,6 +396,16 @@ class MainText(tk.Text):
         if see:
             self.see(tk.INSERT)
             self.focus_set()
+
+    def get_text(self) -> str:
+        """Return all the text from the text widget.
+
+        Strips final additional newline that widget adds at tk.END.
+
+        Returns:
+            String containing text widget contents.
+        """
+        return self.get(1.0, f"{tk.END}-1c")
 
     # def mark_next(self, index: tk._tkinter.Tcl_Obj) -> str :
     # pos = super().mark_next(index)

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -363,7 +363,9 @@ class MainText(tk.Text):
             fname: Name of file to save text to.
         """
         with open(fname, "w", encoding="utf-8") as fh:
-            fh.write(self.get(1.0, tk.END))
+            fh.write(
+                self.get(1.0, f"{tk.END}-1c")
+            )  # "-1c" because Tk has an extra newline at tk.END
             self.set_modified(False)
 
     def do_open(self, fname: str) -> None:


### PR DESCRIPTION
User might have edited main file in an editor other than GG. This might mean page boundary positions stored in the bin file no longer match the positions in the text file. By storing an MD5 checksum in the bin file, check that the bin file and text file match, and warn if not.