### PR TITLE
Add column (block) Cut, Copy & Paste

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -5,7 +5,6 @@
 import argparse
 import logging
 import os.path
-import re
 import subprocess
 from tkinter import messagebox
 from typing import Any
@@ -333,6 +332,17 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_edit.add_separator()
         menu_edit.add_cut_copy_paste()
         menu_edit.add_separator()
+        menu_edit.add_button("Columni~ze Selection", maintext().columnize_selection)
+        menu_edit.add_button(
+            "Co~lumn Cut", maintext().columnize_cut, "Cmd/Ctrl+Shift+X"
+        )
+        menu_edit.add_button(
+            "C~olumn Copy", maintext().columnize_copy, "Cmd/Ctrl+Shift+C"
+        )
+        menu_edit.add_button(
+            "Colu~mn Paste", maintext().columnize_paste, "Cmd/Ctrl+Shift+V"
+        )
+        menu_edit.add_separator()
         menu_edit.add_button("Pre~ferences...", lambda: PreferencesDialog(root()))
 
     def init_view_menu(self) -> None:
@@ -368,13 +378,12 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
     def init_statusbar(self, statusbar: StatusBar) -> None:
         """Add labels to initialize the statusbar"""
 
-        index_pattern = re.compile(r"(\d+)\.(\d+)")
-        statusbar.add(
-            "rowcol",
-            update=lambda: index_pattern.sub(
-                r"L:\1 C:\2", maintext().get_insert_index()
-            ),
-        )
+        def rowcol_str() -> str:
+            """Format current insert index for statusbar."""
+            row, col = maintext().get_insert_index().rowcol()
+            return f"L:{row} C:{col}"
+
+        statusbar.add("rowcol", update=rowcol_str)
         statusbar.add_binding("rowcol", "<ButtonRelease-1>", self.file.goto_line)
         statusbar.add_binding(
             "rowcol", "<ButtonRelease-3>", maintext().toggle_line_numbers

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -332,7 +332,6 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_edit.add_separator()
         menu_edit.add_cut_copy_paste()
         menu_edit.add_separator()
-        menu_edit.add_button("Columni~ze Selection", maintext().columnize_selection)
         menu_edit.add_button(
             "Co~lumn Cut", maintext().columnize_cut, "Cmd/Ctrl+Shift+X"
         )

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -9,7 +9,7 @@ import tkinter as tk
 from tkinter import filedialog, messagebox, simpledialog
 from typing import Any, Callable, Final, TypedDict, Literal, Optional
 
-from guiguts.mainwindow import maintext, sound_bell
+from guiguts.mainwindow import maintext, sound_bell, IndexRowCol
 import guiguts.page_details as page_details
 from guiguts.page_details import PageDetail, PageDetails, PAGE_LABEL_PREFIX
 from guiguts.preferences import preferences
@@ -126,7 +126,7 @@ class File:
             self.remove_recent_file(filename)
             self.filename = ""
             return
-        maintext().set_insert_index("1.0", see=True)
+        maintext().set_insert_index(IndexRowCol(1, 0), see=True)
         self.load_bin(filename)
         if not self.contains_page_marks():
             self.mark_page_boundaries()
@@ -247,7 +247,7 @@ class File:
         self.update_page_marks(self.page_details)
         bin_dict: BinDict = {
             BINFILE_KEY_MD5CHECKSUM: self.get_md5_checksum(),
-            BINFILE_KEY_INSERTPOS: maintext().get_insert_index(),
+            BINFILE_KEY_INSERTPOS: maintext().get_insert_index().index(),
             BINFILE_KEY_PAGEDETAILS: self.page_details,
             BINFILE_KEY_IMAGEDIR: self.image_dir,
         }
@@ -305,7 +305,7 @@ class File:
         """
         if not index:
             index = "1.0"
-        maintext().set_insert_index(index, see=True)
+        maintext().set_insert_index(IndexRowCol(index), see=True)
 
     def update_page_marks(self, page_details: PageDetails) -> None:
         """Update page mark locations in page details structure.
@@ -380,7 +380,7 @@ class File:
         Returns:
             Name of preceding mark. Empty string if none found.
         """
-        insert = maintext().get_insert_index()
+        insert = maintext().get_insert_index().index()
         mark = insert
         good_mark = ""
         # First check for page marks at the current cursor position & return last one
@@ -449,7 +449,7 @@ class File:
             "Go To Line", "Line number", parent=maintext()
         )
         if line_num is not None:
-            maintext().set_insert_index(f"{line_num}.0", see=True)
+            maintext().set_insert_index(IndexRowCol(line_num, 0), see=True)
 
     def goto_image(self) -> None:
         """Go to the image the user enters"""
@@ -466,7 +466,7 @@ class File:
         """
         if image_num is not None:
             try:
-                index = maintext().index(page_mark_from_img(image_num))
+                index = maintext().get_index(page_mark_from_img(image_num))
             except tk._tkinter.TclError:  # type: ignore[attr-defined]
                 # Bad image number
                 return
@@ -499,12 +499,12 @@ class File:
         Args:
             direction: +1 to go to next page; -1 for previous page
         """
-        insert = maintext().get_insert_index()
+        insert = maintext().get_insert_index().index()
         cur_page = self.get_current_image_name()
         mark = page_mark_from_img(cur_page) if cur_page else insert
         while mark := page_mark_next_previous(mark, direction):
             if maintext().compare(mark, "!=", insert):
-                maintext().set_insert_index(mark, see=True)
+                maintext().set_insert_index(maintext().get_index(mark), see=True)
                 return
         sound_bell()
 

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -160,6 +160,71 @@ def _process_accel(accel: str) -> tuple[str, str]:
     return (accel, f"<{keyevent}>")
 
 
+class IndexRowCol:
+    """Class to store/manipulate Tk Text indexes.
+
+    Attributes:
+        row: Row or line number.
+        col: Column number.
+    """
+
+    row: int
+    col: int
+
+    def __init__(self, index_or_row: str | int, col: Optional[int] = None) -> None:
+        """Construct index either from string or two ints.
+
+        Args:
+            index_or_row: String index, or int row
+            col: Optional column - needed if index_or_row is an int
+        """
+        if isinstance(index_or_row, str):
+            assert col is None
+            rr, cc = index_or_row.split(".", 1)
+            self.row = int(rr)
+            self.col = int(cc)
+        else:
+            assert isinstance(index_or_row, int) and isinstance(col, int)
+            self.row = index_or_row
+            self.col = col
+
+    def index(self) -> str:
+        """Return string index from object's row/col attributes."""
+        return f"{self.row}.{self.col}"
+
+    def rowcol(self) -> tuple[int, int]:
+        """Return row, col tuple."""
+        return self.row, self.col
+
+
+class IndexRange:
+    """Class to store/manipulate a Text range defined by two indexes.
+
+    Attributes:
+        start: Start index.
+        end: End index.
+    """
+
+    def __init__(self, start: str | IndexRowCol, end: str | IndexRowCol) -> None:
+        """Initialize IndexRange with two strings or IndexRowCol objects.
+
+
+        Args:
+            start: Index of start of range - either string or IndexRowCol
+            end: Index of end of range - either string or IndexRowCol
+        """
+        if isinstance(start, str):
+            self.start = IndexRowCol(start)
+        else:
+            assert isinstance(start, IndexRowCol)
+            self.start = start
+        if isinstance(end, str):
+            self.end = IndexRowCol(end)
+        else:
+            assert isinstance(start, IndexRowCol)
+            self.end = end
+
+
 # TextLineNumbers widget adapted from answer at
 # https://stackoverflow.com/questions/16369470/tkinter-adding-line-number-to-text-widget
 class TextLineNumbers(tk.Canvas):
@@ -179,7 +244,7 @@ class TextLineNumbers(tk.Canvas):
             dline = self.textwidget.dlineinfo(index)
             if dline is None:
                 break
-            linenum = str(index).split(".")[0]
+            linenum = IndexRowCol(index).row
             self.create_text(text_pos, dline[1], anchor="ne", text=linenum)
             index = self.textwidget.index("%s+1line" % index)
 
@@ -232,6 +297,18 @@ class MainText(tk.Text):
         # Set up response to text being modified
         self.modifiedCallbacks: list[Callable[[], None]] = []
         self.bind("<<Modified>>", self.modify_flag_changed_callback)
+
+        self.bind("<<Cut>>", self.smart_cut)
+        self.bind("<<Copy>>", self.smart_copy)
+        self.bind("<<Paste>>", self.smart_paste)
+
+        # Column selection
+        self.column_selecting = False
+        self.bind("<Shift-ButtonPress-1>", self.column_select_click)
+        self.bind("<Shift-B1-Motion>", self.column_select_motion)
+        self.bind("<Shift-ButtonRelease-1>", self.column_select_release)
+        self.bind("<KeyRelease-Shift_L>", self.column_select_stop)
+        self.bind("<KeyRelease-Shift_R>", self.column_select_stop)
 
     def _proxy(self, *args: Any) -> Any:
         """Proxy to intercept commands sent to widget and generate a
@@ -382,17 +459,34 @@ class MainText(tk.Text):
         self.delete("1.0", tk.END)
         self.set_modified(False)
 
-    def get_insert_index(self) -> str:
-        """Return index of the insert cursor."""
-        return self.index(tk.INSERT)
+    def get_index(self, pos: str) -> IndexRowCol:
+        """Return index of given position as IndexRowCol object.
 
-    def set_insert_index(self, index: str, see: bool = False) -> None:
+        Wrapper for `Tk::Text.index()`
+
+        Args:
+            pos: Index to position in file.
+
+        Returns:
+            IndexRowCol containing position in file.
+        """
+        return IndexRowCol(self.index(pos))
+
+    def get_insert_index(self) -> IndexRowCol:
+        """Return index of the insert cursor as IndexRowCol object.
+
+        Returns:
+            IndexRowCol containing position of the insert cursor.
+        """
+        return self.get_index(tk.INSERT)
+
+    def set_insert_index(self, insert_pos: IndexRowCol, see: bool = False) -> None:
         """Set the position of the insert cursor.
 
         Args:
-            index: String containing index/mark to position cursor.
+            rowcol: Location to position insert cursor.
         """
-        self.mark_set(tk.INSERT, index)
+        self.mark_set(tk.INSERT, insert_pos.index())
         if see:
             self.see(tk.INSERT)
             self.focus_set()
@@ -407,13 +501,221 @@ class MainText(tk.Text):
         """
         return self.get(1.0, f"{tk.END}-1c")
 
-    # def mark_next(self, index: tk._tkinter.Tcl_Obj) -> str :
-    # pos = super().mark_next(index)
-    # return pos if pos else ""
+    def columnize_copy(self, *args: Any) -> None:
+        """Columnize the current selection and copy it."""
+        self.columnize_selection()
+        self.column_copy_cut()
 
-    # def mark_previous(self, index: tk._tkinter.Tcl_Obj) -> str :
-    # pos = super().mark_previous(index)
-    # return pos if pos else ""
+    def columnize_cut(self, *args: Any) -> None:
+        """Columnize the current selection and copy it."""
+        self.columnize_selection()
+        self.column_copy_cut(cut=True)
+
+    def columnize_paste(self, *args: Any) -> None:
+        """Columnize the current selection, if any, and paste the clipboard contents."""
+        self.columnize_selection()
+        self.column_paste()
+
+    def columnize_selection(self) -> None:
+        """Adjust current selection to column mode,
+        spanning a block defined by the two given corners."""
+        if not (ranges := self.selected_ranges()):
+            return
+        self.do_column_select(IndexRange(ranges[0].start, ranges[-1].end))
+
+    def do_column_select(self, col_range: IndexRange) -> None:
+        """Use multiple selection ranges to select a block
+        defined by the start & end of the given range.
+
+        Args:
+            IndexRange containing corners of block to be selected."""
+        self.tag_remove("sel", "1.0", tk.END)
+        min_row = min(col_range.start.row, col_range.end.row)
+        max_row = max(col_range.start.row, col_range.end.row)
+        min_col = min(col_range.start.col, col_range.end.col)
+        max_col = max(col_range.start.col, col_range.end.col)
+        for line in range(min_row, max_row + 1):
+            self.tag_add(
+                "sel",
+                IndexRowCol(line, min_col).index(),
+                IndexRowCol(line, max_col).index(),
+            )
+
+    def selected_ranges(self) -> list[IndexRange]:
+        """Get the ranges of text marked with the `sel` tag.
+
+        Returns:
+            List of IndexRange objects indicating the selected range(s)
+        """
+        ranges = self.tag_ranges("sel")
+        assert len(ranges) % 2 == 0
+        sel_ranges = []
+        for idx in range(0, len(ranges), 2):
+            sel_ranges.append(IndexRange(str(ranges[idx]), str(ranges[idx + 1])))
+        return sel_ranges
+
+    def column_copy_cut(self, cut: bool = False) -> None:
+        """Copy or cut the selected text to the clipboard.
+
+        A newline character is inserted between each line.
+
+        Args:
+            cut: True if cut is required, defaults to False (copy)
+        """
+        if not (ranges := self.selected_ranges()):
+            return
+        self.clipboard_clear()
+        for range in ranges:
+            start = range.start.index()
+            end = range.end.index()
+            string = self.get(start, end)
+            if cut:
+                self.delete(start, end)
+            self.clipboard_append(string + "\n")
+
+    def column_paste(self) -> None:
+        """Paste the clipboard text column-wise, overwriting any selected text.
+
+        If more lines in clipboard than selected ranges, remaining lines will be
+        inserted in the same column in lines below. If more selected ranges than
+        clipboard lines, clipboard will be repeated until all selected ranges are
+        replaced.
+        """
+        # Trap empty clipboard or no STRING representation
+        try:
+            clipboard = self.clipboard_get()
+        except tk.TclError:
+            return
+        cliplines = clipboard.splitlines()
+        if not cliplines:
+            return
+        num_cliplines = len(cliplines)
+
+        # If nothing selected, set up an empty selection range at the current insert position
+        sel_ranges = self.selected_ranges()
+        ranges = []
+        if sel_ranges:
+            start_rowcol = sel_ranges[0].start
+            end_rowcol = sel_ranges[-1].end
+            for row in range(start_rowcol.row, end_rowcol.row + 1):
+                rbeg = IndexRowCol(row, start_rowcol.col)
+                rend = IndexRowCol(row, end_rowcol.col)
+                ranges.append(IndexRange(rbeg, rend))
+        else:
+            insert_index = self.get_insert_index()
+            ranges.append(IndexRange(insert_index, insert_index))
+        num_ranges = len(ranges)
+
+        # Add any necessary newlines if near end of file
+        min_row = ranges[0].start.row
+        max_row = min_row + max(num_cliplines, num_ranges)
+        end_index = self.get_index(IndexRowCol(max_row, 0).index())
+        if max_row > end_index.row:
+            self.insert(
+                end_index.index() + " lineend", "\n" * (max_row - end_index.row)
+            )
+
+        for line in range(max(num_cliplines, num_ranges)):
+            # Add any necessary spaces if line being pasted into is too short
+            start_rowcol = IndexRowCol(ranges[0].start.row + line, ranges[0].start.col)
+            end_rowcol = IndexRowCol(ranges[0].start.row + line, ranges[-1].end.col)
+            end_index = self.get_index(end_rowcol.index())
+            nspaces = start_rowcol.col - end_index.col
+            if nspaces > 0:
+                self.insert(end_index.index(), " " * nspaces)
+
+            clipline = cliplines[line % num_cliplines]
+            if line < num_ranges:
+                self.replace(start_rowcol.index(), end_rowcol.index(), clipline)
+            else:
+                self.insert(start_rowcol.index(), clipline)
+        rowcol = self.get_index(f"{start_rowcol.index()} + {len(clipline)}c")
+        self.set_insert_index(rowcol, True)
+
+    def smart_copy(self, *args: Any) -> str:
+        """Do column copy if multiple ranges selected, else default copy."""
+        if len(self.selected_ranges()) == 1:
+            return ""  # Permit default behavior to happen
+        self.column_copy_cut()
+        return "break"  # Skip default behavior
+
+    def smart_cut(self, *args: Any) -> str:
+        """Do column cut if multiple ranges selected, else default cut."""
+        if len(self.selected_ranges()) == 1:
+            return ""  # Permit default behavior to happen
+        self.column_copy_cut(cut=True)
+        return "break"  # Skip default behavior
+
+    def smart_paste(self, *args: Any) -> str:
+        """Do column paste if multiple ranges selected, else default paste."""
+        if len(self.selected_ranges()) == 1:
+            return ""  # Permit default behavior to happen
+        self.column_paste()
+        return "break"  # Skip default behavior
+
+    def column_select_click(self, event: tk.Event) -> str:
+        """Callback when column selection is started via mouse click.
+
+        Args
+            event: Event containing mouse coordinates.
+
+        Returns:
+            "break" to stop default binding.
+        """
+        self.column_select_start = self.get_index(f"@{event.x},{event.y}")
+        self.tag_add("sel", self.column_select_start.index())
+        self.column_selecting = True
+        return "break"
+
+    def column_select_motion(self, event: tk.Event) -> str:
+        """Callback when column selection continues via mouse motion.
+
+        Args:
+            event: Event containing mouse coordinates.
+
+        Returns:
+            "break" to stop default binding or "" to allow it.
+        """
+        # Attempt to start up column selection if arriving here without a previous click
+        # to start, e.g. user presses modifier key after beginning mouse-drag selection.
+        cur_index = self.get_index(f"@{event.x},{event.y}")
+        if not self.column_selecting:
+            ranges = self.selected_ranges()
+            if not ranges:  # Fallback to using insert cursor position
+                insert_rowcol = self.get_insert_index()
+                ranges = [IndexRange(insert_rowcol, insert_rowcol)]
+            if self.compare(cur_index.index(), ">", ranges[0].start.index()):
+                self.column_select_start = ranges[0].start
+            else:
+                self.column_select_start = ranges[-1].end
+            self.column_selecting = True
+
+        self.do_column_select(IndexRange(self.column_select_start, cur_index))
+        return "break"
+
+    def column_select_release(self, event: tk.Event) -> str:
+        """Callback when column selection is stopped via mouse button release.
+
+        Args:
+            event: Event containing mouse coordinates.
+
+        Returns:
+            "break" to stop default binding or "" to allow it.
+        """
+        break_str = self.column_select_motion(event)
+        self.column_select_stop(event)
+        return break_str
+
+    def column_select_stop(self, event: tk.Event) -> None:
+        """Stop column selection. Called when modifier key is released.
+
+        Args:
+            event: Event containing mouse coordinates.
+
+        Returns:
+            "break" to stop default binding or "" to allow it.
+        """
+        self.column_selecting = False
 
 
 class MainImage(tk.Frame):


### PR DESCRIPTION
1. Add classes to handle Tk Text indexes. GG1 has many occurrences of combining a row/column to get a string Tk Text index, or split an index into the row & column. To reduce this, store in a class which can be constructed with either form, and from which either form can be extracted. Also add a class to handle a single range of such indexes, i.e. a start and end.
2. Add Columnize Selection, which takes the current selection and replaces it with multiple selections in order to form a block from the top-left to the bottom-right of the current selection. This feature may not be required in practice, but is required internally to do Column Cut/Copy/Paste, so I plan to leave it in the menu for now.
3. Make Shift+Mouse-click & drag do column selection. Press Shift, then mouse-click, then drag. Should also generally work to click & drag to start normal select, then press Shift and continue dragging to switch to column select - but not vice versa, i.e. starting column selecting then releasing Shift to do normal select is not supported.
4. Add Column Copy (shortcut Shift+Ctrl+C/Shift+Cmd+C) which either copies a column selection, or columnizes a normal selection and then copies it. If there is a column selection, then normal Copy (Ctrl/Cmd+C) actually does a Column Copy. Format in clipboard is multiple lines delimited by newline characters.
5. Add Column Cut (shortcut Shift+Ctrl+X/Shift+Cmd+X) similar to Column Copy but cuts instead of copying. Normal Cut does Column Cut if there is a column selection.
6. Add Column Paste (shortcut Shift+Ctrl+V/Shift+Cmd+V) which pastes a previously copied/cut column selection. If there is no selected text in the main window the block will be inserted at the insert cursor position. If there is selected text, then selected lines will be replaced with pasted lines. If the clipboard text has fewer lines than the selected text, the clipboard is repeated to fill the space of the selected text. If the clipboard text has more lines than the selected text, then after all the selected text lines have been replaced, the remainder of the clipboard text is pasted in the lines below. Additional lines and/or spaces are added if necessary to make the column paste work as a block if near the end of a file or pasting over variable length lines. Normal Paste does Column Paste if there is already a column selection in the text.