### PR TITLE
Handle attempts to undo/redo when stack is empty

### DIFF
--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -248,7 +248,14 @@ class MainText(tk.Text):
 
         # let the actual widget perform the requested action
         cmd = (self._orig,) + args
-        result = self.tk.call(cmd)
+        try:
+            result = self.tk.call(cmd)
+        except tk.TclError:
+            if args[0:2] == ("edit", "undo") or args[0:2] == ("edit", "redo"):
+                sound_bell()
+            else:
+                raise
+            result = None
 
         # generate an event if something was added or deleted,
         # or the cursor position changed


### PR DESCRIPTION
If there's nothing to undo/redo, then attempting to undo/redo raises a Tk exception. Trap that case and sound bell instead.