### PR TITLE
Fix macOS shortcut key bindings

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -222,7 +222,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         if self.file.open_file(filename):
             self.mainwindow.clear_image()
 
-    def close_file(self) -> None:
+    def close_file(self, *args: Any) -> None:
         """Close currently loaded file and associated image."""
         self.file.close_file()
         self.mainwindow.clear_image()

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -13,7 +13,7 @@ from guiguts.mainwindow import maintext, sound_bell, IndexRowCol, root
 import guiguts.page_details as page_details
 from guiguts.page_details import PageDetail, PageDetails, PAGE_LABEL_PREFIX
 from guiguts.preferences import preferences
-from guiguts.utilities import is_windows, load_dict_from_json, is_mac
+from guiguts.utilities import is_windows, load_dict_from_json
 
 logger = logging.getLogger(__package__)
 
@@ -104,8 +104,7 @@ class File:
                 )
             if filename:
                 self.load_file(filename)
-            if is_mac():
-                root().grab_focus()
+            root().grab_focus()
         return filename
 
     def close_file(self) -> None:
@@ -165,8 +164,7 @@ class File:
             self.filename = fn
             maintext().do_save(fn)
             self.save_bin(fn)
-        if is_mac():
-            root().grab_focus()
+        root().grab_focus()
         return fn
 
     def check_save(self) -> bool:

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -9,11 +9,11 @@ import tkinter as tk
 from tkinter import filedialog, messagebox, simpledialog
 from typing import Any, Callable, Final, TypedDict, Literal, Optional
 
-from guiguts.mainwindow import maintext, sound_bell, IndexRowCol
+from guiguts.mainwindow import maintext, sound_bell, IndexRowCol, root
 import guiguts.page_details as page_details
 from guiguts.page_details import PageDetail, PageDetails, PAGE_LABEL_PREFIX
 from guiguts.preferences import preferences
-from guiguts.utilities import is_windows, load_dict_from_json
+from guiguts.utilities import is_windows, load_dict_from_json, is_mac
 
 logger = logging.getLogger(__package__)
 
@@ -104,6 +104,8 @@ class File:
                 )
             if filename:
                 self.load_file(filename)
+            if is_mac():
+                root().grab_focus()
         return filename
 
     def close_file(self) -> None:
@@ -163,6 +165,8 @@ class File:
             self.filename = fn
             maintext().do_save(fn)
             self.save_bin(fn)
+            if is_mac():
+                root().grab_focus()
         return fn
 
     def check_save(self) -> bool:

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -165,8 +165,8 @@ class File:
             self.filename = fn
             maintext().do_save(fn)
             self.save_bin(fn)
-            if is_mac():
-                root().grab_focus()
+        if is_mac():
+            root().grab_focus()
         return fn
 
     def check_save(self) -> bool:

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -38,16 +38,24 @@ class Root(tk.Tk):
         self.option_add("*tearOff", False)
         self.rowconfigure(0, weight=1)
         self.columnconfigure(0, weight=1)
-        self.after_idle(self.grab_focus)
+        self.after_idle(lambda: self.grab_focus(True))
 
-    def grab_focus(self) -> None:
+    def grab_focus(self, icon_deicon: bool = False) -> None:
         """Arcane calls to force window manager to put root window
         to the front and make it active. Then set focus to the text window.
+
+        Omitting any of these statements or re-ordering them will stop it
+        working on startup on Windows.
+
+        Args:
+            icon_deicon: If true, also iconify & deiconify window, which really
+                forces it to the front on Windows.
         """
         self.lift()
-        self.call("wm", "iconify", ".")
-        self.call("wm", "deiconify", ".")
-        maintext().focus_set()
+        if icon_deicon:
+            self.iconify()
+            self.deiconify()
+        maintext().focus_force()
 
     def report_callback_exception(
         self, exc: type[BaseException], val: BaseException, tb: TracebackType | None

--- a/tests/test_guiguts.py
+++ b/tests/test_guiguts.py
@@ -60,4 +60,4 @@ def test_mainwindow() -> None:
     assert event == "<Shift-Control-Z>"
     (accel, event) = _process_accel("Cmd+?")
     assert accel == "Cmd+?"
-    assert event == "<Meta-?>"
+    assert event == "<Command-?>"


### PR DESCRIPTION
Primary problem is to do with case on the Mac. Having `Ctrl+Shift+S` and `Ctrl+Shift+s` appeared to stop them from working, whereas that is useful on other platforms due to behavior when Caps Lock is on. More details in code comments.

Couple of minor fixes:

When called via shortcut, functions
get called with an event arg, but not when called via menu. Such functions therefore need optional arg.

Also, after `Cmd+o` and `Cmd+Shift+s` which pop file selection dialogs, on macOS focus was not returned to the main window, which can confuse users.

Fixes #64 