### PR TITLE
Omit Edit->Preferences menu item on Mac platform

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -341,8 +341,9 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_edit.add_button(
             "Colu~mn Paste", maintext().columnize_paste, "Cmd/Ctrl+Shift+V"
         )
-        menu_edit.add_separator()
-        menu_edit.add_button("Pre~ferences...", lambda: PreferencesDialog(root()))
+        if not is_mac():
+            menu_edit.add_separator()
+            menu_edit.add_button("Pre~ferences...", lambda: PreferencesDialog(root()))
 
     def init_view_menu(self) -> None:
         """Create the View menu."""


### PR DESCRIPTION
On the Mac platform, tkinter is automatically adding a Settings menu under the {application_name} menu, making the "Preferences..." item under the Edit menu redundant.

The customary and "correct" place for the Settings menu item on Mac is the one which is provided by the framework as a default. This PR omits the second menu item on the Mac platform only.

Fixes #115