### PR TITLE
Reset undo stack when file is loaded or closed

### DIFF
--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -490,11 +490,13 @@ class MainText(tk.Text):
             self.delete("1.0", tk.END)
             self.insert(tk.END, fh.read())
             self.set_modified(False)
+        self.edit_reset()
 
     def do_close(self) -> None:
         """Close current file and clear widget."""
         self.delete("1.0", tk.END)
         self.set_modified(False)
+        self.edit_reset()
 
     def get_index(self, pos: str) -> IndexRowCol:
         """Return index of given position as IndexRowCol object.


### PR DESCRIPTION
To stop user undoing past the range of the current file. Could previously "undo" load file and return to the contents of the previous file, but still with the name of the new file.