### PR TITLE
Trap attempt to load beyond list of recent files

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -112,7 +112,10 @@ class Guiguts:
             self.file.load_file(self.args.filename)
         elif self.args.recent:
             index = self.args.recent - 1
-            self.file.load_file(preferences.get("RecentFiles")[index])
+            try:
+                self.file.load_file(preferences.get("RecentFiles")[index])
+            except IndexError:
+                pass  # Not enough recent files to load the requested one
 
     @property
     def auto_image(self) -> bool:


### PR DESCRIPTION
Trying to load the 3 most recent file when there are only 2 files in the list in the prefs file, or similar attempts caused traceback.

Fixes #127