### PR TITLE
Store geometry of root and toplevel dialogs

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -260,6 +260,9 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             "LineNumbers", lambda show: maintext().show_line_numbers(show)
         )
         preferences.set_default("SearchHistory", [])
+        preferences.set_default("DialogGeometry", {})
+        preferences.set_default("RootGeometry", "800x400")
+
         preferences.load()
 
     # Lay out menus

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -79,7 +79,7 @@ class Root(tk.Tk):
 
         By setting flag now, and queuing calls to _save_config,
         we ensure the flag will be true for the first call to
-        _save_config when pricess becomes idle."""
+        _save_config when process becomes idle."""
         self.save_config = True
         self.after_idle(self._save_config)
 

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -120,12 +120,12 @@ class ToplevelDialog(tk.Toplevel):
         config_dict = preferences.get("DialogGeometry")
         try:
             geometry = config_dict[self.__class__.__name__]
-            x_resize, y_resize = self.resizable()
-            if not (x_resize or y_resize):
-                geometry = re.sub(r"^\d+x\d+", "", geometry)
-            self.geometry(geometry)
         except KeyError:
-            pass  # OK if no stored geometry for this dialog
+            return  # Do nothing if no stored geometry for this dialog
+        x_resize, y_resize = self.resizable()
+        if not (x_resize or y_resize):
+            geometry = re.sub(r"^\d+x\d+", "", geometry)
+        self.geometry(geometry)
 
     def _handle_config(self, event: tk.Event) -> None:
         """Callback from dialog <Configure> event.

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -132,7 +132,7 @@ class ToplevelDialog(tk.Toplevel):
 
         By setting flag now, and queuing calls to _save_config,
         we ensure the flag will be true for the first call to
-        _save_config when pricess becomes idle."""
+        _save_config when process becomes idle."""
         self.save_config = True
         self.after_idle(self._save_config)
 

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -72,11 +72,14 @@ class ToplevelDialog(tk.Toplevel):
     # Used to ensure only one instance of any dialog is created.
     _toplevel_dialogs: dict[str, "ToplevelDialog"] = {}
 
-    def __init__(self, title: str, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self, title: str, resizable: bool = True, *args: Any, **kwargs: Any
+    ) -> None:
         """Initialize the dialog."""
         super().__init__(*args, **kwargs)
         self.bind("<Escape>", lambda event: self.destroy())
         self.title(title)
+        self.resizable(resizable, resizable)
 
         self.columnconfigure(0, weight=1)
         self.rowconfigure(0, weight=1)


### PR DESCRIPTION
Currently implemented for the main (root) window and for dialogs inheriting from ToplevelDialog.

Width & Height and position on screen are stored in the GGprefs file. If a dialog is set not to be resizable, then the width and height are ignored when loaded from the GGprefs file, and the dialog is created at its default size. Currently there are no non-resizable Toplevel dialogs.