### PR TITLE
Facilitate use of external editor

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -304,6 +304,9 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         self.menu_file.add_button(
             "~Close", self.close_file, "Cmd+W" if is_mac() else ""
         )
+        page_menu = Menu(self.menu_file, "~Page Markers")
+        page_menu.add_button("~Add Page Marker Flags", self.file.add_page_flags)
+        page_menu.add_button("~Remove Page Marker Flags", self.file.remove_page_flags)
         if not is_mac():
             self.menu_file.add_separator()
             self.menu_file.add_button("E~xit", self.quit_program, "")

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -593,7 +593,7 @@ class File:
 
     def remove_page_flags(self) -> None:
         """Remove [PgNNN] flags."""
-        search_regex = r"\[" + PAGEMARK_PREFIX + r"\d+\]"
+        search_regex = r"\[" + PAGEMARK_PREFIX + r".+?\]"
         search_range = IndexRange(maintext().start(), maintext().end())
         while match := maintext().find_match(
             search_regex,

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -27,6 +27,7 @@ STATUSBAR_ROW = 2
 STATUSBAR_COL = 0
 MIN_PANE_WIDTH = 20
 TK_ANCHOR_MARK = "tk::anchor1"
+PAGE_FLAG_TAG = "PageFlag"
 
 
 class FindMatch:
@@ -161,6 +162,9 @@ class MainText(tk.Text):
             self.bind_event("<Command-Down>", lambda e: self.move_to_end())
             self.bind_event("<Command-Shift-Up>", lambda e: self.select_to_start())
             self.bind_event("<Command-Shift-Down>", lambda e: self.select_to_end())
+
+        # Configure tags
+        self.tag_configure(PAGE_FLAG_TAG, background="yellow")
 
         # Ensure text still shows selected when focus is in another dialog
         if "inactiveselect" not in kwargs.keys():


### PR DESCRIPTION
Allow user to add "Page Marker Flags" (e.g. `[Pg001]`) before they save a file and edit it in a different editor. When file is loaded back into GG2, location of Page Marker Flags is used to update the page break locations that were loaded from the bin (.json) file.
Since the bin file and main text file will not match, soften the consequent error message to a warning if the above situation is detected.
The "modified" flag on the file is set if any page boundary locations are updated, because although the text file is not modified, it needs resaving to save the updated bin file.