### PR TITLE
Add ability to set language(s) for a book

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -343,14 +343,14 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             "",
         )
         menu_edit.add_button(
-            "~Title Case Selection",
+            "T~itle Case Selection",
             lambda *args: maintext().transform_selection(
                 maintext().title_case_transformer
             ),
             "",
         )
         menu_edit.add_button(
-            "U~PPERCASE SELECTION",
+            "UPP~ERCASE SELECTION",
             lambda *args: maintext().transform_selection(str.upper),
             "",
         )

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -174,7 +174,7 @@ class Guiguts:
 
     def languages_changed(self) -> None:
         """Handle side effects needed when languages change."""
-        statusbar().set("languages label", "Lang: " + self.file.languages)
+        statusbar().set("languages label", "Lang: " + (self.file.languages or ""))
 
     def update_title(self) -> None:
         """Update the window title to reflect current status."""

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -52,7 +52,7 @@ class Guiguts:
 
         self.initialize_preferences()
 
-        self.file = File(self.filename_changed)
+        self.file = File(self.filename_changed, self.languages_changed)
 
         self.mainwindow = MainWindow()
         self.update_title()
@@ -60,6 +60,8 @@ class Guiguts:
         self.init_menus()
 
         self.init_statusbar(statusbar())
+
+        self.file.languages = preferences.get("DefaultLanguages")
 
         maintext().focus_set()
         maintext().add_modified_callback(self.update_title)
@@ -170,6 +172,10 @@ class Guiguts:
             self.image_dir_check()
         maintext().after_idle(maintext().focus_set)
 
+    def languages_changed(self) -> None:
+        """Handle side effects needed when languages change."""
+        statusbar().set("languages label", "Lang: " + self.file.languages)
+
     def update_title(self) -> None:
         """Update the window title to reflect current status."""
         modtitle = " - edited" if maintext().is_modified() else ""
@@ -257,6 +263,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         preferences.set_default("SearchHistory", [])
         preferences.set_default("DialogGeometry", {})
         preferences.set_default("RootGeometry", "800x400")
+        preferences.set_default("DefaultLanguages", "en")
 
         preferences.load()
 
@@ -441,6 +448,11 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         statusbar.add_binding("page label", "<ButtonRelease-1>", self.file.goto_page)
         statusbar.add_binding(
             "page label", "<ButtonRelease-3>", self.show_page_details_dialog
+        )
+
+        statusbar.add("languages label", text="Lang: ")
+        statusbar.add_binding(
+            "languages label", "<ButtonRelease-1>", self.file.set_languages
         )
 
     def logging_init(self) -> None:

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -94,6 +94,7 @@ class File:
     def languages(self) -> Any:
         """Languages of currently loaded file.
 
+        Multiple languages are separated by "+"
         When assigned to, executes callback function to update interface"""
         return self._languages
 
@@ -102,6 +103,8 @@ class File:
         self._languages = value
         self._languages_callback()
         preferences.set("DefaultLanguages", value)
+        # Inform maintext, so text manipulation algorithms there can check languages
+        maintext().set_languages(value)
 
     def reset(self) -> None:
         """Reset file internals to defaults, e.g. filename, page markers, etc"""
@@ -264,8 +267,6 @@ class File:
         self.set_page_marks(self.page_details)
         self.image_dir = bin_dict.get(BINFILE_KEY_IMAGEDIR)
         self.languages = bin_dict.get(BINFILE_KEY_LANGUAGES)
-        # if languages := bin_dict.get(BINFILE_KEY_LANGUAGES):
-        # self.languages = languages
 
     def create_bin(self) -> BinDict:
         """From relevant variables, etc., create dictionary suitable for saving

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -28,6 +28,7 @@ BINFILE_KEY_MD5CHECKSUM: Final = "md5checksum"
 BINFILE_KEY_PAGEDETAILS: Final = "pagedetails"
 BINFILE_KEY_INSERTPOS: Final = "insertpos"
 BINFILE_KEY_IMAGEDIR: Final = "imagedir"
+BINFILE_KEY_LANGUAGES: Final = "languages"
 
 
 class BinDict(TypedDict):
@@ -35,6 +36,7 @@ class BinDict(TypedDict):
     pagedetails: PageDetails
     insertpos: str
     imagedir: str
+    languages: str
 
 
 class File:
@@ -43,10 +45,16 @@ class File:
     Attributes:
         _filename: Current filename.
         _filename_callback: Function to be called whenever filename is set.
+        _languages: Languages used in file.
+        _languages_callback: Function to be called whenever languages are set.
         _image_dir: Directory containing scan images.
     """
 
-    def __init__(self, filename_callback: Callable[[], None]):
+    def __init__(
+        self,
+        filename_callback: Callable[[], None],
+        languages_callback: Callable[[], None],
+    ):
         """
         Args:
             filename_callback: Function to be called whenever filename is set.
@@ -54,6 +62,7 @@ class File:
         self._filename = ""
         self._filename_callback = filename_callback
         self._image_dir = ""
+        self._languages_callback = languages_callback
         self.page_details = PageDetails()
 
     @property
@@ -80,6 +89,19 @@ class File:
     @image_dir.setter
     def image_dir(self, value: str) -> None:
         self._image_dir = value
+
+    @property
+    def languages(self) -> Any:
+        """Languages of currently loaded file.
+
+        When assigned to, executes callback function to update interface"""
+        return self._languages
+
+    @languages.setter
+    def languages(self, value: str) -> None:
+        self._languages = value
+        self._languages_callback()
+        preferences.set("DefaultLanguages", value)
 
     def reset(self) -> None:
         """Reset file internals to defaults, e.g. filename, page markers, etc"""
@@ -130,6 +152,7 @@ class File:
             self.filename = ""
             return
         maintext().set_insert_index(IndexRowCol(1, 0))
+        self.languages = preferences.get("DefaultLanguages")
         self.load_bin(filename)
         if not self.contains_page_marks():
             self.mark_page_boundaries()
@@ -240,6 +263,9 @@ class File:
                 )
         self.set_page_marks(self.page_details)
         self.image_dir = bin_dict.get(BINFILE_KEY_IMAGEDIR)
+        self.languages = bin_dict.get(BINFILE_KEY_LANGUAGES)
+        # if languages := bin_dict.get(BINFILE_KEY_LANGUAGES):
+        # self.languages = languages
 
     def create_bin(self) -> BinDict:
         """From relevant variables, etc., create dictionary suitable for saving
@@ -254,6 +280,7 @@ class File:
             BINFILE_KEY_INSERTPOS: maintext().get_insert_index().index(),
             BINFILE_KEY_PAGEDETAILS: self.page_details,
             BINFILE_KEY_IMAGEDIR: self.image_dir,
+            BINFILE_KEY_LANGUAGES: self.languages,
         }
         return bin_dict
 
@@ -446,6 +473,21 @@ class File:
             return ""
         else:
             return self.page_details[img]["label"]
+
+    def set_languages(self) -> None:
+        """Allow the user to set languages.
+
+        Multiple languages may be separated by any non-word character
+        which will be converted to "+"
+        """
+        languages = simpledialog.askstring(
+            "Set Language(s)", "Language(s)", parent=maintext()
+        )
+        if languages:
+            lang_list = re.split(r"\W", languages)
+            lang_list2 = [lang for lang in lang_list if lang]
+            self.languages = "+".join(lang_list2)
+            maintext().set_modified(True)  # Because bin file needs saving
 
     def goto_line(self) -> None:
         """Go to the line number the user enters"""

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -844,8 +844,9 @@ class MainText(tk.Text):
 
         Multiple languages are separated by "+"
         """
-        assert re.match(r"[a-z]+(\+[a-z]+)*", languages)
-        self.languages = languages
+        if languages:
+            assert re.match(r"[a-z_]+(\+[a-z_]+)*", languages)
+            self.languages = languages
 
     def get_language_list(self) -> list[str]:
         """Get list of languages used in text.

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -801,21 +801,23 @@ class MainText(tk.Text):
         Returns:
             A transformed string
         """
-        # A list of words to *not* capitalize. This list should only be used
-        # for English text.
-        exception_words = (
-            "a",
-            "an",
-            "and",
-            "at",
-            "by",
-            "from",
-            "in",
-            "of",
-            "on",
-            "the",
-            "to",
-        )
+        # A list of words to *not* capitalize.
+        exception_words: tuple[str, ...] = ()
+        if "en" in self.get_language_list():
+            # This list should only be used for English text.
+            exception_words = (
+                "a",
+                "an",
+                "and",
+                "at",
+                "by",
+                "from",
+                "in",
+                "of",
+                "on",
+                "the",
+                "to",
+            )
 
         def capitalize_first_letter(match):
             word = match.group()
@@ -836,6 +838,22 @@ class MainText(tk.Text):
         # Edge case: if the string started with a word found in exception_words, it
         # will have been lowercased erroneously.
         return s2[0].upper() + s2[1:]
+
+    def set_languages(self, languages: str) -> None:
+        """Set languages used in text.
+
+        Multiple languages are separated by "+"
+        """
+        assert re.match(r"[a-z]+(\+[a-z]+)*", languages)
+        self.languages = languages
+
+    def get_language_list(self) -> list[str]:
+        """Get list of languages used in text.
+
+        Returns:
+            List of language strings.
+        """
+        return self.languages.split("+")
 
 
 # For convenient access, store the single MainText instance here,

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -803,7 +803,7 @@ class MainText(tk.Text):
         """
         # A list of words to *not* capitalize.
         exception_words: tuple[str, ...] = ()
-        if "en" in self.get_language_list():
+        if any(lang.startswith("en") for lang in self.get_language_list()):
             # This list should only be used for English text.
             exception_words = (
                 "a",

--- a/tests/test_guiguts.py
+++ b/tests/test_guiguts.py
@@ -14,7 +14,7 @@ def test_which_os() -> None:
 
 def test_file() -> None:
     """Test the File class"""
-    ff = File(lambda: None)
+    ff = File(lambda: None, lambda: None)
     ff.filename = "dummy.txt"
     assert ff.filename == "dummy.txt"
 


### PR DESCRIPTION
1. Lang button added to status bar
2. User can click button and enter one or more languages,
e.g. "en" or "en+la" or "fr,de" or "en es cz"
3. Languages are stored in the projects bin file.
4. If a file doesn't have a bin file (and when GG first starts) the
language defaults to the most recently used language, which
is stored in the Prefs file.

Also make Title Case Selection language-dependent:
List of exception words (such as "a" and "the") should only be
used in English texts.

Also resolved two duplicate keyboard navigation letters in the
Edit menu.