### PR TITLE
Enhance Checker Dialog

### DIFF
--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -324,23 +324,36 @@ class SearchDialog(ToplevelDialog):
 
         checker_dialog = CheckerDialog.show_dialog("Search Results")
         checker_dialog.reset()
+        # Construct opening line describing the search
+        desc_reg = "regex" if SearchDialog.regex.get() else "string"
+        prefix = f'Search for {desc_reg} "'
+        desc = f'{prefix}{search_string}"'
+        if SearchDialog.matchcase.get():
+            desc += ", matching case"
+        if SearchDialog.wholeword.get():
+            desc += ", whole words only"
+        if SearchDialog.selection.get():
+            desc += ", within selection"
+        checker_dialog.add_entry(desc, None, len(prefix), len(prefix + search_string))
+        checker_dialog.add_entry("")
+
         for match in matches:
             line = maintext().get(
                 f"{match.rowcol.index()} linestart", f"{match.rowcol.index()} lineend"
             )
-            line_prefix = f"{match.rowcol.row}.{match.rowcol.col}: "
-            result = line_prefix + line
             end_rowcol = IndexRowCol(
                 maintext().index(match.rowcol.index() + f"+{match.count}c")
             )
-            hilite_start = match.rowcol.col + len(line_prefix)
+            hilite_start = match.rowcol.col
             if end_rowcol.row > match.rowcol.row:
-                hilite_end = len(result)
+                hilite_end = len(line)
             else:
-                hilite_end = end_rowcol.col + len(line_prefix)
+                hilite_end = end_rowcol.col
             checker_dialog.add_entry(
-                IndexRange(match.rowcol, end_rowcol), result, hilite_start, hilite_end
+                line, IndexRange(match.rowcol, end_rowcol), hilite_start, hilite_end
             )
+        checker_dialog.add_entry("")
+        checker_dialog.add_entry("End of search results")
 
     def replace_clicked(
         self, opposite_dir: bool = False, search_again: bool = False

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -87,7 +87,7 @@ class SearchDialog(ToplevelDialog):
         search_button = ttk.Button(
             search_frame1,
             text="Search",
-            # default="active",
+            default="active",
             takefocus=False,
             command=self.search_clicked,
         )
@@ -322,7 +322,9 @@ class SearchDialog(ToplevelDialog):
             sound_bell()
             return
 
-        checker_dialog = CheckerDialog.show_dialog("Search Results")
+        checker_dialog = CheckerDialog.show_dialog(
+            "Search Results", self.findall_clicked
+        )
         checker_dialog.reset()
         # Construct opening line describing the search
         desc_reg = "regex" if SearchDialog.regex.get() else "string"

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -106,20 +106,24 @@ class ToplevelDialog(tk.Toplevel):
         grab_focus(self)
 
     @classmethod
-    def show_dialog(cls: type[TlDlg], title: Optional[str] = None) -> TlDlg:
+    def show_dialog(
+        cls: type[TlDlg], title: Optional[str] = None, *args: Any, **kwargs: Any
+    ) -> TlDlg:
         """Show the instance of this dialog class, or create it if it doesn't exist.
 
         Args:
             title: Dialog title.
+            args: Optional args to pass to dialog constructor.
+            kwargs: Optional kwargs to pass to dialog constructor.
         """
         dlg_name = cls.__name__
         if dlg := cls.get_dialog():
             dlg.deiconify()
         else:
             if title is not None:
-                ToplevelDialog._toplevel_dialogs[dlg_name] = cls(title)  # type: ignore[call-arg]
+                ToplevelDialog._toplevel_dialogs[dlg_name] = cls(title, *args, **kwargs)  # type: ignore[call-arg]
             else:
-                ToplevelDialog._toplevel_dialogs[dlg_name] = cls()  # type: ignore[call-arg]
+                ToplevelDialog._toplevel_dialogs[dlg_name] = cls(*args, **kwargs)  # type: ignore[call-arg]
         return ToplevelDialog._toplevel_dialogs[dlg_name]  # type: ignore[return-value]
 
     @classmethod


### PR DESCRIPTION
Improve `CheckerDialog.add_entry` method

1. Swap argument order and make the range indicating the area of interest in the main text an optional argument. This makes it possible to add general text to the dialog, e.g. header line.
2. If a range is given, automatically add the start of the range as a prefix to the line of text. Otherwise this code would probably be duplicated in every tool that wants to add lines to the dialog.
3. Stop using "reserved" word `range` as a variable name. 
5. Update Search dialog to use the new checker features, in particular a header and footer to the Search All results.

Add default header widgets to CheckerDialogs

1. Add label showing number of "errors"
2. Add "Re-run" button to re-run the same check
3. Use this for Search Dialog's Find All button.