### PR TITLE
Add pylint to Github Actions pipeline

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -30,6 +30,10 @@ jobs:
     - name: Lint with flake8
       run: |
         poetry run flake8 ./src
+    - name: Lint with pylint
+      run: |
+        poetry run pylint --recursive y .
+      continue-on-error: true
     - name: Check format with black
       run: |
         poetry run black --check --verbose ./src

--- a/README.md
+++ b/README.md
@@ -129,20 +129,29 @@ poetry env use $(brew --prefix)/bin/python3.11
 
 ## Code style
 
-Guiguts 2 uses [flake8](https://pypi.org/project/flake8) for static code analysis
-and [black](https://pypi.org/project/black) for consistent styling. Both use
-default settings, with the exception of maximum line length checking which is
-adjusted in the recommended manner using the `.flake8` file to avoid conflicts
-with black.
+Guiguts 2 uses [flake8](https://pypi.org/project/flake8) and
+[pylint](https://www.pylint.org) for static code analysis, and
+[black](https://pypi.org/project/black) for consistent styling.  All use default
+settings, with the exception of maximum line length checking which is adjusted
+in the recommended manner (using the `.flake8` file and the `tool.pylint`
+section of `pyproject.toml`) to avoid conflicts with black.
 
-Both tools will be installed via `poetry` as described above.
+All of the above tools will be installed via `poetry` as described above.
 
 `poetry run flake8 .` will check all `src` & `tests` python files.
 
+`poetry run pylint --recursive y .` will check all `src` & `tests` python files.
+
 `poetry run black .` will reformat all `src` & `tests` python files where necessary.
 
-This project uses Github Actions to ensure neither of the above tools reports any
+This project uses Github Actions to ensure neither flake8 nor black report any
 error.
+
+> **NOTE:** At this time, `pylint` is running in GitHub Actions in an advisory
+mode only.  That means that any warning or error reported by `pylint` will not
+cause the Action to fail. Over time, as we make changes in Guiguts and/or the
+`pylint` configuration, the aim is to clear all of `pylint`'s warnings. At that
+point perhaps it can run in an enforcement mode.
 
 Naming conventions from [PEP8](https://pep8.org/#prescriptive-naming-conventions)
 are used. To summarize, class names use CapWords; constants are ALL_UPPERCASE;

--- a/poetry.lock
+++ b/poetry.lock
@@ -12,6 +12,17 @@ files = [
 ]
 
 [[package]]
+name = "astroid"
+version = "3.0.3"
+description = "An abstract syntax tree for Python with inference support."
+optional = false
+python-versions = ">=3.8.0"
+files = [
+    {file = "astroid-3.0.3-py3-none-any.whl", hash = "sha256:92fcf218b89f449cdf9f7b39a269f8d5d617b27be68434912e11e79203963a17"},
+    {file = "astroid-3.0.3.tar.gz", hash = "sha256:4148645659b08b70d72460ed1921158027a9e53ae8b7234149b1400eddacbb93"},
+]
+
+[[package]]
 name = "babel"
 version = "2.14.0"
 description = "Internationalization utilities"
@@ -227,6 +238,21 @@ files = [
 ]
 
 [[package]]
+name = "dill"
+version = "0.3.8"
+description = "serialize all of Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "dill-0.3.8-py3-none-any.whl", hash = "sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7"},
+    {file = "dill-0.3.8.tar.gz", hash = "sha256:3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca"},
+]
+
+[package.extras]
+graph = ["objgraph (>=1.7.2)"]
+profile = ["gprof2dot (>=2022.7.29)"]
+
+[[package]]
 name = "docutils"
 version = "0.20.1"
 description = "Docutils -- Python Documentation Utilities"
@@ -285,6 +311,20 @@ files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
+
+[[package]]
+name = "isort"
+version = "5.13.2"
+description = "A Python utility / library to sort Python imports."
+optional = false
+python-versions = ">=3.8.0"
+files = [
+    {file = "isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"},
+    {file = "isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109"},
+]
+
+[package.extras]
+colors = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "jinja2"
@@ -615,6 +655,33 @@ plugins = ["importlib-metadata"]
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "pylint"
+version = "3.0.3"
+description = "python code static checker"
+optional = false
+python-versions = ">=3.8.0"
+files = [
+    {file = "pylint-3.0.3-py3-none-any.whl", hash = "sha256:7a1585285aefc5165db81083c3e06363a27448f6b467b3b0f30dbd0ac1f73810"},
+    {file = "pylint-3.0.3.tar.gz", hash = "sha256:58c2398b0301e049609a8429789ec6edf3aabe9b6c5fec916acd18639c16de8b"},
+]
+
+[package.dependencies]
+astroid = ">=3.0.1,<=3.1.0-dev0"
+colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
+dill = [
+    {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
+    {version = ">=0.3.6", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
+]
+isort = ">=4.2.5,<5.13.0 || >5.13.0,<6"
+mccabe = ">=0.6,<0.8"
+platformdirs = ">=2.2.0"
+tomlkit = ">=0.10.1"
+
+[package.extras]
+spelling = ["pyenchant (>=3.2,<4.0)"]
+testutils = ["gitpython (>3)"]
+
+[[package]]
 name = "pyproject-hooks"
 version = "1.0.0"
 description = "Wrappers to call pyproject.toml-based build backend hooks."
@@ -919,14 +986,25 @@ standalone = ["Sphinx (>=5)"]
 test = ["pytest"]
 
 [[package]]
+name = "tomlkit"
+version = "0.12.3"
+description = "Style preserving TOML library"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tomlkit-0.12.3-py3-none-any.whl", hash = "sha256:b0a645a9156dc7cb5d3a1f0d4bab66db287fcb8e0430bdd4664a095ea16414ba"},
+    {file = "tomlkit-0.12.3.tar.gz", hash = "sha256:75baf5012d06501f07bee5bf8e801b9f343e7aac5a92581f20f80ce632e6b5a4"},
+]
+
+[[package]]
 name = "types-pillow"
-version = "10.2.0.20240125"
+version = "10.2.0.20240213"
 description = "Typing stubs for Pillow"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "types-Pillow-10.2.0.20240125.tar.gz", hash = "sha256:c449b2c43b9fdbe0494a7b950e6b39a4e50516091213fec24ef3f33c1d017717"},
-    {file = "types_Pillow-10.2.0.20240125-py3-none-any.whl", hash = "sha256:322dbae32b4b7918da5e8a47c50ac0f24b0aa72a804a23857620f2722b03c858"},
+    {file = "types-Pillow-10.2.0.20240213.tar.gz", hash = "sha256:4800b61bf7eabdae2f1b17ade0d080709ed33e9f26a2e900e470e8b56ebe2387"},
+    {file = "types_Pillow-10.2.0.20240213-py3-none-any.whl", hash = "sha256:062c5a0f20301a30f2df4db583f15b3c2a1283a12518d1f9d81396154e12c1af"},
 ]
 
 [[package]]
@@ -971,4 +1049,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "8661c27344ef57fff70908e7eb8728c82343c37576e8aa6717af6461c656ccb9"
+content-hash = "98973542a29adb7b87d0957073d263eea606eea30863dfbc32e8d4b033def0b5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ flake8 = "^6.1"
 Sphinx = "^7.2"
 pytest = "^7.4"
 mypy = "^1.8"
+pylint = "^3.0.3"
 types-Pillow = "^10.1"
 types-regex = "^2023.12"
 build = "^1.0.3"
@@ -28,3 +29,21 @@ guiguts = "guiguts.application:main"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pylint."messages control"]
+confidence = ["HIGH", "CONTROL_FLOW", "INFERENCE", "INFERENCE_FAILURE", "UNDEFINED"]
+
+disable = [
+  "raw-checker-failed",
+  "bad-inline-option",
+  "locally-disabled",
+  "file-ignored",
+  "suppressed-message",
+  "useless-suppression",
+  "deprecated-pragma",
+  "use-symbolic-message-instead",
+  "line-too-long"
+]
+
+enable = ["c-extension-no-member"]
+


### PR DESCRIPTION
Because pylint is currently reporting a bunch of warnings, suggestions, etc, this is in advisory mode only. No matter what pylint finds, the Action will not fail due to pylint.

The way I envision this going is:
- pylint runs in the Action
- Any of us can review its output by looking in the Action tab on Github
- Some things we'll fix, some we'll tell pylint to ignore
- Eventually the output will be empty; then we can choose to remove `continue-on-error` from the Action

The new section in `pyproject.toml` is mostly defaults. The only non-default is that I added `line-too-long` to the `disable` list. Since we use Black for formatting, I don't see value in that one. There are probably other formatting-related warnings we can ignore.

**Suggestion:** Actions are currently running only on direct pushes to `master`, or on PRs targeting `master`. Personally I would run on every push, because I'd rather it run in my fork before I create a PR.

I would like to point out the changes in `poetry.lock`. I added pylint to the dependencies and then did what Poetry asked me to do, and it changed a bunch of unrelated dependency versions. I'm not sure if that's normal; I'm not that familiar with Poetry.

Fixes #138 