### PR TITLE
Add Project Dictionary support

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,3 +56,13 @@ Widgets
 =======
     
 .. automodule:: widgets
+ 
+Root
+====
+    
+.. automodule:: root
+ 
+Project Dict
+============
+    
+.. automodule:: project_dict

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -394,7 +394,9 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_edit = Menu(menubar(), "~Tools")
         menu_edit.add_button(
             "~Spelling Check",
-            lambda: spell_check(self.file.add_good_word_to_project_dictionary),
+            lambda: spell_check(
+                self.file.project_dict, self.file.add_good_word_to_project_dictionary
+            ),
         )
 
     def init_view_menu(self) -> None:

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -17,7 +17,6 @@ if __name__ == "__main__" and __package__ is None:
 from guiguts.file import File, NUM_RECENT_FILES
 from guiguts.maintext import maintext
 from guiguts.mainwindow import (
-    root,
     MainWindow,
     Menu,
     menubar,
@@ -25,9 +24,9 @@ from guiguts.mainwindow import (
     statusbar,
     ErrorHandler,
 )
-
 from guiguts.page_details import PageDetailsDialog
 from guiguts.preferences import preferences
+from guiguts.root import root
 from guiguts.search import show_search_dialog, find_next
 from guiguts.spell import spell_check
 from guiguts.utilities import is_mac
@@ -393,7 +392,10 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
     def init_tools_menu(self) -> None:
         """Create the Tools menu."""
         menu_edit = Menu(menubar(), "~Tools")
-        menu_edit.add_button("~Spelling Check", spell_check)
+        menu_edit.add_button(
+            "~Spelling Check",
+            lambda: spell_check(self.file.add_good_word_to_project_dictionary),
+        )
 
     def init_view_menu(self) -> None:
         """Create the View menu."""

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -306,9 +306,14 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         self.menu_file.add_button(
             "~Close", self.close_file, "Cmd+W" if is_mac() else ""
         )
-        page_menu = Menu(self.menu_file, "~Page Markers")
+        page_menu = Menu(self.menu_file, "Page ~Markers")
         page_menu.add_button("~Add Page Marker Flags", self.file.add_page_flags)
         page_menu.add_button("~Remove Page Marker Flags", self.file.remove_page_flags)
+        page_menu = Menu(self.menu_file, "~Project")
+        page_menu.add_button(
+            "~Add Good/Bad Words to Project Dictionary",
+            self.file.add_good_and_bad_words,
+        )
         if not is_mac():
             self.menu_file.add_separator()
             self.menu_file.add_button("E~xit", self.quit_program, "")

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -206,6 +206,15 @@ class CheckerDialog(ToplevelDialog):
             self.process_command(self.entries[entry_index])
         return "break"
 
+    def process_entry_current(self) -> None:
+        """Call the "process" callback function, if any, on the
+        currently selected entry, if any."""
+        if self.process_command:
+            tag_range = self.text.tag_nextrange(SELECT_TAG_NAME, "1.0")
+            if tag_range:
+                rowcol = IndexRowCol(tag_range[0])
+                self.process_command(self.entries[rowcol.row - 1])
+
     def process_remove_entry_by_click(self, event: tk.Event) -> str:
         """Select clicked line in dialog, and jump to the line in the
         main text widget that corresponds to it. Call the

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -10,6 +10,7 @@ from guiguts.utilities import IndexRowCol, IndexRange, is_mac
 from guiguts.widgets import ToplevelDialog
 
 MARK_PREFIX = "chk"
+MARK_REMOVED_ENTRY = "MarkRemovedEntry"
 HILITE_TAG_NAME = "chk_hilite"
 SELECT_TAG_NAME = "chk_select"
 
@@ -75,16 +76,48 @@ class CheckerDialog(ToplevelDialog):
         self.text.grid(column=0, row=1, sticky="NSEW")
 
         self.text.bind("<1>", self.select_entry_by_click)
+        # On Mac, equivalent of mouse button 3 is button 2 (2-button mice) or
+        # Control with button 1 (1 button mice), so 2 bindings per function
         if is_mac():
             self.text.bind("<2>", self.remove_entry_by_click)
             self.text.bind("<Control-1>", self.remove_entry_by_click)
+            self.text.bind(
+                "<Shift-2>",
+                lambda event: self.remove_entry_by_click(event, all_matching=True),
+            )
+            self.text.bind(
+                "<Shift-Control-1>",
+                lambda event: self.remove_entry_by_click(event, all_matching=True),
+            )
             self.text.bind("<Command-1>", self.process_entry_by_click)
             self.text.bind("<Command-2>", self.process_remove_entry_by_click)
             self.text.bind("<Command-Control-1>", self.process_remove_entry_by_click)
+            self.text.bind(
+                "<Shift-Command-2>",
+                lambda event: self.process_remove_entry_by_click(
+                    event, all_matching=True
+                ),
+            )
+            self.text.bind(
+                "<Shift-Command-Control-1>",
+                lambda event: self.process_remove_entry_by_click(
+                    event, all_matching=True
+                ),
+            )
         else:
             self.text.bind("<3>", self.remove_entry_by_click)
+            self.text.bind(
+                "<Shift-3>",
+                lambda event: self.remove_entry_by_click(event, all_matching=True),
+            )
             self.text.bind("<Control-1>", self.process_entry_by_click)
             self.text.bind("<Control-3>", self.process_remove_entry_by_click)
+            self.text.bind(
+                "<Shift-Control-3>",
+                lambda event: self.process_remove_entry_by_click(
+                    event, all_matching=True
+                ),
+            )
 
         self.process_command = process_command
         self.text.tag_configure(
@@ -149,26 +182,6 @@ class CheckerDialog(ToplevelDialog):
         word = "Entry" if self.count_linked_entries == 1 else "Entries"
         self.count_label["text"] = f"{self.count_linked_entries} {word}"
 
-    def remove_entry_by_click(self, event: tk.Event) -> str:
-        """Remove the entry that was clicked in the dialog.
-
-        Args:
-            event: Event object containing mouse click position.
-
-        Returns:
-            "break" to avoid calling other callbacks.
-        """
-        try:
-            entry_index = self.entry_index_from_click(event)
-        except IndexError:
-            return "break"
-        del self.entries[entry_index]
-        self.text.delete(f"{entry_index+1}.0", f"{entry_index+2}.0")
-        entry_index = min(entry_index, len(self.entries) - 1)
-        if len(self.entries) > 0:
-            self.select_entry(entry_index)
-        return "break"
-
     def select_entry_by_click(self, event: tk.Event) -> str:
         """Select clicked line in dialog, and jump to the line in the
         main text widget that corresponds to it.
@@ -202,26 +215,16 @@ class CheckerDialog(ToplevelDialog):
         except IndexError:
             return "break"
         self.select_entry(entry_index)
-        if self.process_command:
-            self.process_command(self.entries[entry_index])
+        self.process_entry_current()
         return "break"
 
-    def process_entry_current(self) -> None:
-        """Call the "process" callback function, if any, on the
-        currently selected entry, if any."""
-        if self.process_command:
-            tag_range = self.text.tag_nextrange(SELECT_TAG_NAME, "1.0")
-            if tag_range:
-                rowcol = IndexRowCol(tag_range[0])
-                self.process_command(self.entries[rowcol.row - 1])
-
-    def process_remove_entry_by_click(self, event: tk.Event) -> str:
-        """Select clicked line in dialog, and jump to the line in the
-        main text widget that corresponds to it. Call the
-        "process" callback function, if any, then remove the entry.
+    def remove_entry_by_click(self, event: tk.Event, all_matching: bool = False) -> str:
+        """Remove the entry that was clicked in the dialog.
 
         Args:
             event: Event object containing mouse click position.
+            all_matching: If True remove all other entries that have the same
+                message as the chosen entry (e.g. same spelling error)
 
         Returns:
             "break" to avoid calling other callbacks.
@@ -231,26 +234,32 @@ class CheckerDialog(ToplevelDialog):
         except IndexError:
             return "break"
         self.select_entry(entry_index)
-        if self.process_command:
-            self.process_command(self.entries[entry_index])
-        self.remove_entry_by_click(event)
+        self.remove_entry_current(all_matching)
         return "break"
 
-    def select_entry(self, entry_index: int) -> None:
-        """Select line in dialog corresponding to given entry index,
-        and jump to the line in the main text widget that corresponds to it.
+    def process_remove_entry_by_click(
+        self, event: tk.Event, all_matching: bool = False
+    ) -> str:
+        """Select clicked line in dialog, and jump to the line in the
+        main text widget that corresponds to it. Call the
+        "process" callback function, if any, then remove the entry.
 
         Args:
             event: Event object containing mouse click position.
+            all_matching: If True remove all other entries that have the same
+                message as the chosen entry (e.g. same spelling error)
+
+        Returns:
+            "break" to avoid calling other callbacks.
         """
-        self.highlight_entry(entry_index)
-        entry = self.entries[entry_index]
-        if entry.text_range is not None:
-            start = maintext().index(self._mark_from_rowcol(entry.text_range.start))
-            end = maintext().index(self._mark_from_rowcol(entry.text_range.end))
-            maintext().do_select(IndexRange(start, end))
-            maintext().set_insert_index(IndexRowCol(start), focus=False)
-        self.lift()
+        try:
+            entry_index = self.entry_index_from_click(event)
+        except IndexError:
+            return "break"
+        self.select_entry(entry_index)
+        self.process_entry_current()
+        self.remove_entry_current(all_matching)
+        return "break"
 
     def entry_index_from_click(self, event: tk.Event) -> int:
         """Get the index into the list of entries based on the mouse position
@@ -268,6 +277,79 @@ class CheckerDialog(ToplevelDialog):
         if entry_index < 0 or entry_index >= len(self.entries):
             raise IndexError
         return entry_index
+
+    def process_entry_current(self) -> None:
+        """Call the "process" callback function, if any, on the
+        currently selected entry, if any."""
+        if self.process_command:
+            entry_index = self.current_entry_index()
+            if entry_index is not None:
+                self.process_command(self.entries[entry_index])
+
+    def remove_entry_current(self, all_matching: bool = False) -> None:
+        """Remove the current entry, if any.
+
+        Args:
+            all_matching: If True remove all other entries that have the same
+                message as the chosen entry (e.g. same spelling error)
+        """
+        entry_index = self.current_entry_index()
+        if entry_index is not None:
+            # Mark before removing in case earlier entries get removed due to
+            # all_matching being True
+            self.text.mark_set(MARK_REMOVED_ENTRY, f"{entry_index+1}.0")
+            del_text = self.entries[entry_index].text
+            if all_matching:
+                # Work in reverse since deleting from list while iterating
+                for ii in range(len(self.entries) - 1, -1, -1):
+                    if self.entries[ii].text == del_text:
+                        del self.entries[ii]
+                        self.text.delete(f"{ii+1}.0", f"{ii+2}.0")
+            else:
+                del self.entries[entry_index]
+                self.text.delete(f"{entry_index+1}.0", f"{entry_index+2}.0")
+            # Select line after first deleted line
+            entry_rowcol = IndexRowCol(self.text.index(MARK_REMOVED_ENTRY))
+            entry_index = min(entry_rowcol.row - 1, len(self.entries) - 1)
+            if len(self.entries) > 0:
+                self.select_entry(entry_index)
+
+    def process_remove_entry_current(self, all_matching: bool = False) -> None:
+        """Call the "process" callback function, if any, for the current entry, if any,
+        then remove the entry.
+
+        Args:
+            all_matching: If True remove all other entries that have the same
+                message as the chosen entry (e.g. same spelling error)
+        """
+        self.process_entry_current()
+        self.remove_entry_current(all_matching)
+
+    def current_entry_index(self) -> Optional[int]:
+        """Get the index entry of the currently selected error message.
+
+        Returns:
+            Index into self.entries array, or None if no message selected.
+        """
+        if tag_range := self.text.tag_nextrange(SELECT_TAG_NAME, "1.0"):
+            return IndexRowCol(tag_range[0]).row - 1
+        return None
+
+    def select_entry(self, entry_index: int) -> None:
+        """Select line in dialog corresponding to given entry index,
+        and jump to the line in the main text widget that corresponds to it.
+
+        Args:
+            event: Event object containing mouse click position.
+        """
+        self.highlight_entry(entry_index)
+        entry = self.entries[entry_index]
+        if entry.text_range is not None:
+            start = maintext().index(self._mark_from_rowcol(entry.text_range.start))
+            end = maintext().index(self._mark_from_rowcol(entry.text_range.end))
+            maintext().do_select(IndexRange(start, end))
+            maintext().set_insert_index(IndexRowCol(start), focus=False)
+        self.lift()
 
     def highlight_entry(self, entry_index: int) -> None:
         """Highlight the line of text corresponding to the entry_index.

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -48,7 +48,6 @@ class CheckerDialog(ToplevelDialog):
         title: str,
         rerun_command: Callable[[], None],
         process_command: Optional[Callable[[CheckerEntry], None]] = None,
-        *args: Any,
         **kwargs: Any,
     ) -> None:
         """Initialize the dialog.
@@ -58,7 +57,7 @@ class CheckerDialog(ToplevelDialog):
             rerun_command: Function to call to re-run the check.
             process_command: Function to call to "process" the current error, e.g. swap he/be
         """
-        super().__init__(title, *args, **kwargs)
+        super().__init__(title, **kwargs)
         self.top_frame.rowconfigure(0, weight=0)
         self.header_frame = ttk.Frame(self.top_frame, padding=2)
         self.header_frame.grid(column=0, row=0, sticky="NSEW")

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -4,7 +4,6 @@ import hashlib
 import json
 import logging
 import os.path
-from pathlib import Path
 import regex as re
 import tkinter as tk
 from tkinter import filedialog, messagebox, simpledialog
@@ -14,6 +13,7 @@ from guiguts.maintext import maintext, PAGE_FLAG_TAG
 import guiguts.page_details as page_details
 from guiguts.page_details import PageDetail, PageDetails, PAGE_LABEL_PREFIX
 from guiguts.preferences import preferences
+from guiguts.project_dict import ProjectDict, GOOD_WORDS_FILENAME, BAD_WORDS_FILENAME
 from guiguts.root import root
 from guiguts.spell import spell_check_clear_dictionary
 from guiguts.utilities import (
@@ -22,7 +22,6 @@ from guiguts.utilities import (
     IndexRowCol,
     IndexRange,
     sound_bell,
-    load_wordfile_into_dict,
 )
 from guiguts.widgets import grab_focus
 
@@ -39,11 +38,6 @@ BINFILE_KEY_INSERTPOS: Final = "insertpos"
 BINFILE_KEY_IMAGEDIR: Final = "imagedir"
 BINFILE_KEY_LANGUAGES: Final = "languages"
 
-GOOD_WORDS_KEY = "good words"
-BAD_WORDS_KEY = "bad words"
-GOOD_WORDS_FILENAME = "good_words.txt"
-BAD_WORDS_FILENAME = "bad_words.txt"
-
 PAGE_FLAGS_NONE = 0
 PAGE_FLAGS_SOME = 1
 PAGE_FLAGS_ALL = 2
@@ -55,104 +49,6 @@ class BinDict(TypedDict):
     insertpos: str
     imagedir: str
     languages: str
-
-
-class ProjectDict:
-    """Load, store & save project-specific spellings.
-
-    Stored internally as two dictionaries for good and bad words for
-    speed of access during spell checks, etc.
-    Saved into json file as two lists, so easier for PPers to read
-    and/or modify if needed.
-    """
-
-    def __init__(self) -> None:
-        """Initialize ProjectDict."""
-        self.reset()
-
-    def save(self, textfile_path: str) -> None:
-        """Save the project dictionary to a file.
-
-        Name of dictionary is basename of main text file, with "_dict"
-        added, and extension `.json`.
-
-        Args:
-            textfile_path: Full pathname of main text file.
-        """
-        dict_name = self._dict_name_from_file_name(textfile_path)
-        project_dict = {}
-        project_dict[GOOD_WORDS_KEY] = list(self.good_words.keys())
-        project_dict[BAD_WORDS_KEY] = list(self.bad_words.keys())
-        with open(dict_name, "w") as fp:
-            json.dump(project_dict, fp, indent=2, ensure_ascii=False)
-
-    def load(self, textfile_path: str) -> None:
-        """Load the project dictionary from a file if it exists.
-
-        Name of dictionary is basename of main text file, with "_dict"
-        added, and extension `.json`.
-
-        Args:
-            textfile_path: Full pathname of main text file.
-        """
-        self.reset()
-        dict_name = self._dict_name_from_file_name(textfile_path)
-        if os.path.exists(dict_name):
-            if project_dict := load_dict_from_json(dict_name):
-                for word in project_dict[GOOD_WORDS_KEY]:
-                    self.good_words[word] = True
-                for word in project_dict[BAD_WORDS_KEY]:
-                    self.bad_words[word] = True
-
-    def reset(self) -> None:
-        """Reset the project dictionary."""
-        self.good_words: dict[str, bool] = {}
-        self.bad_words: dict[str, bool] = {}
-
-    def add_good_bad_words(self, file_name: str, load_good_words: bool) -> bool:
-        """Add words from good/bad_words file to project dictionary.
-
-        Args:
-            load_good_words: True to load good words, False to load bad words.
-
-        Returns:
-            True if good/bad words file exists.
-        """
-        path = Path(
-            os.path.dirname(file_name),
-            GOOD_WORDS_FILENAME if load_good_words else BAD_WORDS_FILENAME,
-        )
-        target_dict = self.good_words if load_good_words else self.bad_words
-        return load_wordfile_into_dict(path, target_dict)
-
-    def _dict_name_from_file_name(self, file_name: str) -> str:
-        """Get dictionary name for given file name.
-
-        Args:
-            file_name: name of main text file.
-
-        Returns:
-            Name of dictionary file.
-        """
-        root, ext = os.path.splitext(file_name)
-        root += "_dict"
-        return root + ".json"
-
-    def contains_words(self) -> bool:
-        """Return whether project dictionary contains any good/bad words.
-
-        Returns:
-            True if dictionary contains any good/bad words.
-        """
-        return len(self.good_words) > 0 or len(self.bad_words) > 0
-
-    def add_good_word(self, word: str) -> None:
-        """Add a good word to the project dictionary.
-
-        Args:
-            word: The word to be added.
-        """
-        self.good_words[word] = True
 
 
 class File:

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -11,10 +11,10 @@ from tkinter import filedialog, messagebox, simpledialog
 from typing import Any, Callable, Final, TypedDict, Literal, Optional
 
 from guiguts.maintext import maintext, PAGE_FLAG_TAG
-from guiguts.mainwindow import root
 import guiguts.page_details as page_details
 from guiguts.page_details import PageDetail, PageDetails, PAGE_LABEL_PREFIX
 from guiguts.preferences import preferences
+from guiguts.root import root
 from guiguts.spell import spell_check_clear_dictionary
 from guiguts.utilities import (
     is_windows,
@@ -145,6 +145,14 @@ class ProjectDict:
             True if dictionary contains any good/bad words.
         """
         return len(self.good_words) > 0 or len(self.bad_words) > 0
+
+    def add_good_word(self, word: str) -> None:
+        """Add a good word to the project dictionary.
+
+        Args:
+            word: The word to be added.
+        """
+        self.good_words[word] = True
 
 
 class File:
@@ -777,6 +785,15 @@ class File:
             logger.error(
                 f"Neither {GOOD_WORDS_FILENAME} nor {BAD_WORDS_FILENAME} was found"
             )
+
+    def add_good_word_to_project_dictionary(self, word: str) -> None:
+        """Add a good word to the project dictionary & save it.
+
+        Args:
+            word: The word to be added.
+        """
+        self.project_dict.add_good_word(word)
+        self.project_dict.save(self.filename)
 
 
 def page_mark_previous(mark: str) -> str:

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1,4 +1,4 @@
-"""Define key components of main window"""
+"""Handle main text widget"""
 
 
 import logging

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -133,7 +133,7 @@ class Preferences:
         if not os.path.isdir(self.prefsdir):
             os.mkdir(self.prefsdir)
         with open(self.prefsfile, "w") as fp:
-            json.dump(self.dict, fp, indent=2)
+            json.dump(self.dict, fp, indent=2, ensure_ascii=False)
 
     def load(self) -> None:
         """Load preferences dictionary from JSON file."""

--- a/src/guiguts/project_dict.py
+++ b/src/guiguts/project_dict.py
@@ -1,0 +1,109 @@
+"""Project dictionary operations"""
+
+import json
+import os.path
+from pathlib import Path
+from guiguts.utilities import load_dict_from_json, load_wordfile_into_dict
+
+GOOD_WORDS_KEY = "good words"
+BAD_WORDS_KEY = "bad words"
+GOOD_WORDS_FILENAME = "good_words.txt"
+BAD_WORDS_FILENAME = "bad_words.txt"
+
+
+class ProjectDict:
+    """Load, store & save project-specific spellings.
+
+    Stored internally as two dictionaries for good and bad words for
+    speed of access during spell checks, etc.
+    Saved into json file as two lists, so easier for PPers to read
+    and/or modify if needed.
+    """
+
+    def __init__(self) -> None:
+        """Initialize ProjectDict."""
+        self.reset()
+
+    def save(self, textfile_path: str) -> None:
+        """Save the project dictionary to a file.
+
+        Name of dictionary is basename of main text file, with "_dict"
+        added, and extension `.json`.
+
+        Args:
+            textfile_path: Full pathname of main text file.
+        """
+        dict_name = self._dict_name_from_file_name(textfile_path)
+        project_dict = {}
+        project_dict[GOOD_WORDS_KEY] = list(self.good_words.keys())
+        project_dict[BAD_WORDS_KEY] = list(self.bad_words.keys())
+        with open(dict_name, "w") as fp:
+            json.dump(project_dict, fp, indent=2, ensure_ascii=False)
+
+    def load(self, textfile_path: str) -> None:
+        """Load the project dictionary from a file if it exists.
+
+        Name of dictionary is basename of main text file, with "_dict"
+        added, and extension `.json`.
+
+        Args:
+            textfile_path: Full pathname of main text file.
+        """
+        self.reset()
+        dict_name = self._dict_name_from_file_name(textfile_path)
+        if os.path.exists(dict_name):
+            if project_dict := load_dict_from_json(dict_name):
+                for word in project_dict[GOOD_WORDS_KEY]:
+                    self.good_words[word] = True
+                for word in project_dict[BAD_WORDS_KEY]:
+                    self.bad_words[word] = True
+
+    def reset(self) -> None:
+        """Reset the project dictionary."""
+        self.good_words: dict[str, bool] = {}
+        self.bad_words: dict[str, bool] = {}
+
+    def add_good_bad_words(self, file_name: str, load_good_words: bool) -> bool:
+        """Add words from good/bad_words file to project dictionary.
+
+        Args:
+            load_good_words: True to load good words, False to load bad words.
+
+        Returns:
+            True if good/bad words file exists.
+        """
+        path = Path(
+            os.path.dirname(file_name),
+            GOOD_WORDS_FILENAME if load_good_words else BAD_WORDS_FILENAME,
+        )
+        target_dict = self.good_words if load_good_words else self.bad_words
+        return load_wordfile_into_dict(path, target_dict)
+
+    def _dict_name_from_file_name(self, file_name: str) -> str:
+        """Get dictionary name for given file name.
+
+        Args:
+            file_name: name of main text file.
+
+        Returns:
+            Name of dictionary file.
+        """
+        root, ext = os.path.splitext(file_name)
+        root += "_dict"
+        return root + ".json"
+
+    def contains_words(self) -> bool:
+        """Return whether project dictionary contains any good/bad words.
+
+        Returns:
+            True if dictionary contains any good/bad words.
+        """
+        return len(self.good_words) > 0 or len(self.bad_words) > 0
+
+    def add_good_word(self, word: str) -> None:
+        """Add a good word to the project dictionary.
+
+        Args:
+            word: The word to be added.
+        """
+        self.good_words[word] = True

--- a/src/guiguts/root.py
+++ b/src/guiguts/root.py
@@ -1,0 +1,83 @@
+"""Define key components of main window"""
+
+
+import logging
+import traceback
+import tkinter as tk
+
+from types import TracebackType
+from typing import Any
+
+from guiguts.maintext import maintext
+from guiguts.preferences import preferences
+from guiguts.widgets import grab_focus
+
+logger = logging.getLogger(__package__)
+
+_the_root = None
+
+
+class Root(tk.Tk):
+    """Inherits from Tk root window"""
+
+    def __init__(self, **kwargs: Any) -> None:
+        global _the_root
+        assert _the_root is None
+        _the_root = self
+
+        super().__init__(**kwargs)
+        self.geometry(preferences.get("RootGeometry"))
+        self.option_add("*tearOff", False)
+        self.rowconfigure(0, weight=1)
+        self.columnconfigure(0, weight=1)
+        self.after_idle(lambda: grab_focus(self, maintext(), True))
+        self.set_tcl_word_characters()
+        self.save_config = False
+        self.bind("<Configure>", self._handle_config)
+
+    def report_callback_exception(
+        self, exc: type[BaseException], val: BaseException, tb: TracebackType | None
+    ) -> None:
+        """Override tkinter exception reporting rather just
+        writing it to stderr.
+        """
+        err = "Tkinter Exception\n" + "".join(traceback.format_exception(exc, val, tb))
+        logger.error(err)
+
+    def set_tcl_word_characters(self) -> None:
+        """Configure which characters are considered word/non-word characters by tcl.
+
+        Alphanumerics & stright/curly apostrophe will be considered word characters.
+        These affect operations such as double-click to select word, Cmd/Ctrl left/right
+        to move forward/backward a word at a time, etc.
+        See https://wiki.tcl-lang.org/page/tcl%5Fwordchars for more info.
+        """
+        # Trigger tcl to autoload library that defines variables we want to override.
+        self.tk.call("tcl_wordBreakAfter", "", 0)
+        # Set word and non-word characters
+        self.tk.call("set", "tcl_wordchars", r"[[:alnum:]'’]")
+        self.tk.call("set", "tcl_nonwordchars", r"[^[:alnum:]'’]")
+
+    def _handle_config(self, event: tk.Event) -> None:
+        """Callback from root dialog <Configure> event.
+
+        By setting flag now, and queuing calls to _save_config,
+        we ensure the flag will be true for the first call to
+        _save_config when process becomes idle."""
+        self.save_config = True
+        self.after_idle(self._save_config)
+
+    def _save_config(self) -> None:
+        """Only save geometry when process becomes idle.
+
+        Several calls to this may be queued by config changes during
+        root dialog creation and resizing. Only the first will actually
+        do a save, because the flag will only be true on the first call."""
+        if self.save_config:
+            preferences.set("RootGeometry", self.geometry())
+
+
+def root() -> Root:
+    """Return the single instance of Root"""
+    assert _the_root is not None
+    return _the_root

--- a/src/guiguts/root.py
+++ b/src/guiguts/root.py
@@ -1,4 +1,4 @@
-"""Define key components of main window"""
+"""Handle Tk root window"""
 
 
 import logging

--- a/src/guiguts/root.py
+++ b/src/guiguts/root.py
@@ -58,7 +58,7 @@ class Root(tk.Tk):
         self.tk.call("set", "tcl_wordchars", r"[[:alnum:]'’]")
         self.tk.call("set", "tcl_nonwordchars", r"[^[:alnum:]'’]")
 
-    def _handle_config(self, event: tk.Event) -> None:
+    def _handle_config(self, _event: tk.Event) -> None:
         """Callback from root dialog <Configure> event.
 
         By setting flag now, and queuing calls to _save_config,

--- a/src/guiguts/spell.py
+++ b/src/guiguts/spell.py
@@ -290,11 +290,15 @@ def spell_check(add_project_word_callback: Callable[[str], None]) -> None:
             add_project_word_callback(checker_entry.text.split(maxsplit=1)[0])
 
     checker_dialog = CheckerDialog.show_dialog(
-        "Spelling Check Results", spell_check, process_spelling
+        "Spelling Check Results",
+        lambda: spell_check(add_project_word_callback),
+        process_spelling,
     )
     frame = checker_dialog.header_frame
     project_dict_button = ttk.Button(
-        frame, text="Add to Project Dict", command=checker_dialog.process_entry_current
+        frame,
+        text="Add to Project Dict",
+        command=lambda: checker_dialog.process_remove_entry_current(all_matching=True),
     )
     project_dict_button.grid(column=0, row=1, sticky="NSW")
 

--- a/src/guiguts/spell.py
+++ b/src/guiguts/spell.py
@@ -3,9 +3,9 @@
 import importlib.resources
 import logging
 from pathlib import Path
-import regex as re
 from tkinter import ttk
 from typing import Callable
+import regex as re
 
 from guiguts.data import dictionaries
 from guiguts.file import ProjectDict
@@ -127,7 +127,7 @@ class SpellChecker:
         """
         word_status = self.spell_check_word_apos(word, project_dict)
         # If it's a bad word or in the dictionary, we're done
-        if word_status == SPELL_CHECK_OK_BAD or word_status == SPELL_CHECK_OK_YES:
+        if word_status in (SPELL_CHECK_OK_BAD, SPELL_CHECK_OK_YES):
             return word_status
 
         # Some languages use l', quest', etc., before word.
@@ -206,7 +206,7 @@ class SpellChecker:
         """
         word_status = self.spell_check_word_case(word, project_dict)
         # If it's a bad word or in the dictionary, we're done
-        if word_status == SPELL_CHECK_OK_BAD or word_status == SPELL_CHECK_OK_YES:
+        if word_status in (SPELL_CHECK_OK_BAD, SPELL_CHECK_OK_YES):
             return word_status
 
         # Otherwise, try swapping apostrophes if there are any, and re-check
@@ -238,23 +238,23 @@ class SpellChecker:
 
         lower_word = word.lower()
         if lower_word == word:
-            lower_word == ""
+            lower_word = ""
         # Caution converting to title case - we want "LONDON" to match "London",
         # but we don't want "london" to match London, so leave first letter case
         # as-is, and lowercase the rest
         if len(word) > 1:
             title_word = word[0:1] + word[1:].lower()
             if title_word == word:
-                title_word == ""
+                title_word = ""
         else:
             title_word = ""
 
         # Now check global & project dictionaries for good words
-        for dict in (self.dictionary, project_dict.good_words):
+        for dictionary in (self.dictionary, project_dict.good_words):
             if (
-                word in dict
-                or (lower_word and lower_word in dict)
-                or (title_word and title_word in dict)
+                word in dictionary
+                or (lower_word and lower_word in dictionary)
+                or (title_word and title_word in dictionary)
             ):
                 return SPELL_CHECK_OK_YES
 

--- a/src/guiguts/spell.py
+++ b/src/guiguts/spell.py
@@ -9,9 +9,7 @@ from guiguts.data import dictionaries
 from guiguts.checkers import CheckerDialog, CheckerEntry
 from guiguts.maintext import maintext, FindMatch
 from guiguts.preferences import preferences
-from guiguts.utilities import IndexRowCol, IndexRange
-
-TraversablePath = importlib.resources.abc.Traversable | Path
+from guiguts.utilities import IndexRowCol, IndexRange, load_wordfile_into_dict
 
 logger = logging.getLogger(__package__)
 
@@ -249,24 +247,6 @@ class SpellChecker:
 
         return SPELL_CHECK_OK_NO
 
-    def add_words_from_dictionary(self, path: TraversablePath) -> bool:
-        """Loads given dictionary into SpellChecker dict.
-
-        Args:
-            filename: Full pathname of dictionary to load.
-
-        Returns:
-            True if dictionary file exists.
-        """
-        try:
-            with path.open("r", encoding="utf-8") as f:
-                for line in f:
-                    word = line.strip()
-                    self.dictionary[word] = True
-            return True
-        except FileNotFoundError:
-            return False
-
     def add_words_from_language(self, lang: str) -> None:
         """Add dictionary words for given language.
 
@@ -278,12 +258,12 @@ class SpellChecker:
             lang: Language to be loaded.
         """
         path = DEFAULT_DICTIONARY_DIR.joinpath(f"dict_{lang}_default.txt")
-        words_loaded = self.add_words_from_dictionary(path)
+        words_loaded = load_wordfile_into_dict(path, self.dictionary)
         if not words_loaded:
             logger.warning(f"No default dictionary for language {lang}")
 
         path = Path(preferences.prefsdir, f"dict_{lang}_user.txt")
-        if self.add_words_from_dictionary(path):
+        if load_wordfile_into_dict(path, self.dictionary):
             words_loaded = True
         if not words_loaded:  # Neither default nor user dictionary exist
             raise DictionaryNotFoundError(lang)

--- a/src/guiguts/spell.py
+++ b/src/guiguts/spell.py
@@ -307,13 +307,26 @@ def spell_check(
         lambda: spell_check(project_dict, add_project_word_callback),
         process_spelling,
     )
-    frame = checker_dialog.header_frame
+    frame = ttk.Frame(checker_dialog.header_frame)
+    frame.grid(column=0, row=1, columnspan=2, sticky="NSEW")
     project_dict_button = ttk.Button(
         frame,
         text="Add to Project Dict",
         command=lambda: checker_dialog.process_remove_entry_current(all_matching=True),
     )
-    project_dict_button.grid(column=0, row=1, sticky="NSW")
+    project_dict_button.grid(column=0, row=0, sticky="NSW")
+    skip_button = ttk.Button(
+        frame,
+        text="Skip",
+        command=lambda: checker_dialog.remove_entry_current(all_matching=False),
+    )
+    skip_button.grid(column=1, row=0, sticky="NSW")
+    skip_all_button = ttk.Button(
+        frame,
+        text="Skip All",
+        command=lambda: checker_dialog.remove_entry_current(all_matching=True),
+    )
+    skip_all_button.grid(column=2, row=0, sticky="NSW")
 
     checker_dialog.reset()
     # Construct opening line describing the search

--- a/src/guiguts/utilities.py
+++ b/src/guiguts/utilities.py
@@ -1,14 +1,18 @@
 """Handy utility functions"""
 
+import importlib.resources
 import json
 import platform
 import logging
+from pathlib import Path
 import os.path
 import regex as re
 from tkinter import _tkinter
 from typing import Any, Optional, Callable
 
 logger = logging.getLogger(__package__)
+
+TraversablePath = importlib.resources.abc.Traversable | Path
 
 # Flag so application code can detect if within a pytest run - only use if really needed
 # See: https://pytest.org/en/7.4.x/example/simple.html#detect-if-running-from-within-a-pytest-run
@@ -66,6 +70,28 @@ def load_dict_from_json(filename: str) -> Optional[dict[str, Any]]:
                     f"Unable to load {filename} -- not valid JSON format\n" + str(exc)
                 )
     return None
+
+
+def load_wordfile_into_dict(path: TraversablePath, target_dict: dict) -> bool:
+    """Load a one-word-per-line word list file into the target dictionary.
+
+    Args:
+        path: File to be loaded - accepts either a pathlib Path or
+            an importlib.resources Traversable object.
+        target_dict: Dictionary to be populated.
+
+    Returns:
+        True if file opened successfully, False if file not found.
+    """
+    try:
+        with path.open("r", encoding="utf-8") as fp:
+            for line in fp:
+                word = line.strip()
+                if word:
+                    target_dict[word] = True
+        return True
+    except FileNotFoundError:
+        return False
 
 
 class IndexRowCol:


### PR DESCRIPTION
1. Project dictionary is a JSON file with two lists (good & bad words).
2. Project dictionary is loaded when file loaded
3. File->Project->Add Good/Bad Words to Project dictionary menu entry does what it says, i.e. it looks for good_words.txt and bad_words.txt, adds them to the project dictionary and re-saves it.
4. Ctrl-clicking (Cmd-click on Mac) on spelling error reported by the Spell Checker to add it as a good word to the project dictionary. 
5. Ctrl-right-clicking (or Cmd-Ctrl-click on Mac) adds the spelling and removes that spelling error message from the list of messages
6. Shift-Ctrl-right-clicking (or Shift-Cmd-Ctrl-click on Mac) adds the spelling and removes all error messages about that spelling.
7. Can also select the spelling error message and click "Add to Project Dict" button in dialog as an alternative to Shift-Ctrl-right-click, i.e. it adds to the dictionary and removes all occurrences of that message.
8. Right-click (or Ctrl-click on Mac) just removes the clicked error message, or use the Skip button
9. Shift-right-click (or Shift-Ctrl-click on Mac) removes all occurrences of the clicked message, or use the Skip All button