### PR TITLE
Run GitHub Actions for more events

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,9 +5,8 @@ name: Python application
 
 on:
   push:
-    branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Previously only ran the CI jobs on push to `master`, on pull_request to `master`.

This commit changes to run on push or pull_request regardless of the target branch. Also adds `workflow_dispatch` which allows project owners to launch the CI jobs from the web UI.

(Testing pro tip: the button to run in the web UI will appear only after this change is merged to master.)

https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow