### PR TITLE
Checker dialog fixes

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -342,6 +342,9 @@ class CheckerDialog(ToplevelDialog):
             event: Event object containing mouse click position.
         """
         self.highlight_entry(entry_index)
+        self.text.mark_set(tk.INSERT, f"{entry_index+1}.0")
+        self.text.see(tk.INSERT)
+        self.text.focus_set()
         entry = self.entries[entry_index]
         if entry.text_range is not None:
             start = maintext().index(self._mark_from_rowcol(entry.text_range.start))

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -324,7 +324,7 @@ class SearchDialog(ToplevelDialog):
             return
 
         checker_dialog = CheckerDialog.show_dialog(
-            "Search Results", self.findall_clicked
+            "Search Results", destroy=True, rerun_command=self.findall_clicked
         )
         checker_dialog.reset()
         # Construct opening line describing the search

--- a/src/guiguts/spell.py
+++ b/src/guiguts/spell.py
@@ -304,8 +304,9 @@ def spell_check(
 
     checker_dialog = CheckerDialog.show_dialog(
         "Spelling Check Results",
-        lambda: spell_check(project_dict, add_project_word_callback),
-        process_spelling,
+        destroy=True,
+        rerun_command=lambda: spell_check(project_dict, add_project_word_callback),
+        process_command=process_spelling,
     )
     frame = ttk.Frame(checker_dialog.header_frame)
     frame.grid(column=0, row=1, columnspan=2, sticky="NSEW")

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -108,7 +108,11 @@ class ToplevelDialog(tk.Toplevel):
 
     @classmethod
     def show_dialog(
-        cls: type[TlDlg], title: Optional[str] = None, *args: Any, **kwargs: Any
+        cls: type[TlDlg],
+        title: Optional[str] = None,
+        destroy: bool = False,
+        *args: Any,
+        **kwargs: Any,
     ) -> TlDlg:
         """Show the instance of this dialog class, or create it if it doesn't exist.
 
@@ -117,10 +121,15 @@ class ToplevelDialog(tk.Toplevel):
             args: Optional args to pass to dialog constructor.
             kwargs: Optional kwargs to pass to dialog constructor.
         """
+        # If dialog exists, either destroy it or deiconify
         dlg_name = cls.__name__
         if dlg := cls.get_dialog():
-            dlg.deiconify()
-        else:
+            if destroy:
+                dlg.destroy()
+            else:
+                dlg.deiconify()
+        # Now, if dialog doesn't exist (may have been destroyed above) (re-)create it
+        if not cls.get_dialog():
             if title is not None:
                 ToplevelDialog._toplevel_dialogs[dlg_name] = cls(title, *args, **kwargs)  # type: ignore[call-arg]
             else:


### PR DESCRIPTION
Fix #159 - several checker dialog issues

1. Stop confusion between different checker dialogs if a new one is popped before the old is closed, e.g. Spell Check and S&R FInd All dialogs. Checker dialogs are used for a variety of tools, and vary in their appearance and controls. They therefore need destroying and recreating, not just deiconifying, if they already exist. This could be solved by inheriting different dialogs from CheckerDialog, e.g. SpellCheckDialog, FindAllDialog, etc. However, it would still be necessary to deal with things like the language changing or the project dictionary changing while a dialog exists, in which case some functions in the dialog would not work correctly. This seems the best fix for now, with very little cost. Other dialogs that inherit from TopLevelDialog, such as MessageLog, do not need to be destroyed & re-created.

2. Position insert cursor at start of current line in CheckerDialog when line is selected. This makes it easier to use Ctrl+a, Ctrl+c to copy all messages, or use Shift+arrow keys to select specific messages for copying.

3. Keep "Entries" count up-to-date. When entry is removed from CheckerDialog, reduce the count.