### PR TITLE
More lint fixes

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -32,7 +32,6 @@ jobs:
     - name: Lint with pylint
       run: |
         poetry run pylint --recursive y .
-      continue-on-error: true
     - name: Check format with black
       run: |
         poetry run black --check --verbose ./src

--- a/README.md
+++ b/README.md
@@ -144,14 +144,8 @@ All of the above tools will be installed via `poetry` as described above.
 
 `poetry run black .` will reformat all `src` & `tests` python files where necessary.
 
-This project uses Github Actions to ensure neither flake8 nor black report any
+This project uses Github Actions to ensure none of the above tools report any
 error.
-
-> **NOTE:** At this time, `pylint` is running in GitHub Actions in an advisory
-mode only.  That means that any warning or error reported by `pylint` will not
-cause the Action to fail. Over time, as we make changes in Guiguts and/or the
-`pylint` configuration, the aim is to clear all of `pylint`'s warnings. At that
-point perhaps it can run in an enforcement mode.
 
 Naming conventions from [PEP8](https://pep8.org/#prescriptive-naming-conventions)
 are used. To summarize, class names use CapWords; constants are ALL_UPPERCASE;

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,8 @@
 import os
 import sys
 
+# pylint: disable=invalid-name
+
 project = "Guiguts 2.0"
 
 sys.path.insert(0, os.path.abspath("../src/guiguts/"))

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,3 +66,9 @@ Project Dict
 ============
     
 .. automodule:: project_dict
+
+ 
+PPtxt
+============
+    
+.. automodule:: tools.pptxt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,16 @@ disable = [
   "logging-not-lazy",
   "too-few-public-methods",
   "too-many-ancestors",
-  "too-many-public-methods"
+  "too-many-public-methods",
+  "too-many-statements",
+  "too-many-instance-attributes",
+  "too-many-locals",
+  "too-many-arguments",
+  "too-many-return-statements",
+  "too-many-lines",
+  "too-many-branches",
+  "too-many-nested-blocks",
+  "global-statement"
 ]
 
 enable = ["c-extension-no-member"]

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -294,7 +294,7 @@ class File:
         """
         binfile_name = bin_name(basename)
         bin_dict = self.create_bin()
-        with open(binfile_name, "w") as fp:
+        with open(binfile_name, "w", encoding="utf-8") as fp:
             json.dump(bin_dict, fp, indent=2, ensure_ascii=False)
 
     def interpret_bin(self, bin_dict: BinDict) -> bool:
@@ -563,7 +563,7 @@ class File:
         if image_num is not None:
             try:
                 index = maintext().rowcol(page_mark_from_img(image_num))
-            except tk._tkinter.TclError:  # type: ignore[attr-defined]
+            except tk.TclError:
                 # Bad image number
                 return
             maintext().set_insert_index(index)

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -105,6 +105,8 @@ class MainText(tk.Text):
         super().__init__(self.frame, **kwargs)
         tk.Text.grid(self, column=1, row=0, sticky="NSEW")
 
+        self.languages = ""
+
         # Create Line Numbers widget and bind update routine to all
         # events that might change which line numbers should be displayed
         self.linenumbers = TextLineNumbers(self.frame, self)
@@ -132,6 +134,7 @@ class MainText(tk.Text):
         self["yscrollcommand"] = vscroll_set
 
         # Set up response to text being modified
+        # pylint: disable-next=invalid-name
         self.modifiedCallbacks: list[Callable[[], None]] = []
         self.bind_event(
             "<<Modified>>", lambda _event: self.modify_flag_changed_callback()
@@ -171,7 +174,7 @@ class MainText(tk.Text):
         self.tag_configure(PAGE_FLAG_TAG, background="yellow")
 
         # Ensure text still shows selected when focus is in another dialog
-        if "inactiveselect" not in kwargs.keys():
+        if "inactiveselect" not in kwargs:
             self["inactiveselect"] = self["selectbackground"]
 
         maintext(self)  # Register this single instance of MainText
@@ -227,7 +230,7 @@ class MainText(tk.Text):
             self.linenumbers.redraw()
         self.numbers_need_updating = False
 
-    def _on_change(self, *args: Any) -> None:
+    def _on_change(self, *_args: Any) -> None:
         """Callback when visible region of file may have changed.
 
         By setting flag now, and queuing calls to _do_linenumbers_redraw,
@@ -781,7 +784,7 @@ class MainText(tk.Text):
             )
         except tk.TclError as exc:
             if str(exc).startswith("couldn't compile regular expression pattern"):
-                raise TclRegexCompileError(str(exc))
+                raise TclRegexCompileError(str(exc)) from exc
             match_start = None
 
         if match_start:
@@ -831,7 +834,7 @@ class MainText(tk.Text):
                 )
             except tk.TclError as exc:
                 if str(exc).startswith("couldn't compile regular expression pattern"):
-                    raise TclRegexCompileError(str(exc))
+                    raise TclRegexCompileError(str(exc)) from exc
                 break
             if start:
                 matches.append(FindMatch(IndexRowCol(start), count_var.get()))
@@ -950,7 +953,7 @@ class TclRegexCompileError(Exception):
 
 # For convenient access, store the single MainText instance here,
 # with a function to set/query it.
-_single_widget = None
+_single_widget = None  # pylint: disable=invalid-name
 
 
 def maintext(text_widget: Optional[MainText] = None) -> MainText:

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -135,7 +135,7 @@ class Menu(tk.Menu):
         # If key binding given, then bind it
         if accel:
 
-            def accel_command(*args: Any) -> None:
+            def accel_command(_event: tk.Event) -> None:
                 """Command to simulate checkbox click via shortcut key.
 
                 Because key hasn't been clicked, variable hasn't been toggled.
@@ -235,6 +235,8 @@ class MainImage(tk.Frame):
         self.imageid = None
         self.container: int = 0
         self.filename = ""
+        self.width = 0
+        self.height = 0
 
     def scroll_y(self, *args: Any, **kwargs: Any) -> None:
         """Scroll canvas vertically and redraw the image"""
@@ -281,7 +283,7 @@ class MainImage(tk.Frame):
         self.canvas.scale("all", x, y, scale, scale)  # rescale all canvas objects
         self.show_image()
 
-    def show_image(self, event=None):  # type: ignore[no-untyped-def]
+    def show_image(self, _event=None):  # type: ignore[no-untyped-def]
         """Show image on the Canvas"""
         # get image area & remove 1 pixel shift
         if self.image is None:
@@ -471,7 +473,7 @@ class ScrolledReadOnlyText(tk.Text):
     http://stackoverflow.com/questions/3842155/is-there-a-way-to-make-the-tkinter-text-widget-read-only
     """
 
-    def __init__(self, parent, context_menu=True, *args, **kwargs):  # type: ignore[no-untyped-def]
+    def __init__(self, parent, context_menu=True, **kwargs):  # type: ignore[no-untyped-def]
         """Init the class and set the insert and delete event bindings."""
 
         self.frame = ttk.Frame(parent)
@@ -479,7 +481,7 @@ class ScrolledReadOnlyText(tk.Text):
         self.frame.columnconfigure(0, weight=1)
         self.frame.rowconfigure(0, weight=1)
 
-        super().__init__(self.frame, *args, **kwargs)
+        super().__init__(self.frame, **kwargs)
         super().grid(column=0, row=0, sticky="NSEW")
         self.redirector = WidgetRedirector(self)
         self.insert = self.redirector.register("insert", lambda *args, **kw: "break")
@@ -624,7 +626,7 @@ class MainWindow:
         root().wm_forget(mainimage())  # type: ignore[arg-type]
         self.paned_window.forget(mainimage())
 
-    def float_image(self, *args: Any) -> None:
+    def float_image(self, _event: Optional[tk.Event] = None) -> None:
         """Float the image into a separate window"""
         mainimage().grid_remove()
         if mainimage().is_image_loaded():
@@ -635,7 +637,7 @@ class MainWindow:
             root().wm_forget(mainimage())  # type: ignore[arg-type]
         preferences.set("ImageWindow", "Floated")
 
-    def dock_image(self, *args: Any) -> None:
+    def dock_image(self, _event: Optional[tk.Event] = None) -> None:
         """Dock the image back into the main window"""
         root().wm_forget(mainimage())  # type: ignore[arg-type]
         if mainimage().is_image_loaded():

--- a/src/guiguts/page_details.py
+++ b/src/guiguts/page_details.py
@@ -56,10 +56,6 @@ class PageDetail(dict):
 class PageDetails(dict[str, PageDetail]):
     """Dictionary of Page Detail objects: key is png name."""
 
-    def __init__(self) -> None:
-        """Initialize dictionary."""
-        super().__init__()
-
     def recalculate(self) -> None:
         """Recalculate labels from details."""
         number = 0
@@ -125,18 +121,18 @@ class PageDetailsDialog(OkCancelDialog):
         self.changed = False
         super().__init__(parent, "Configure Page Labels")
 
-    def body(self, frame: tk.Frame) -> tk.Frame:
+    def body(self, master: tk.Frame) -> tk.Frame:
         """Override default to construct widgets needed to show page labels"""
-        frame.columnconfigure(0, weight=1)
-        frame.rowconfigure(0, weight=1)
-        frame.pack(expand=True, fill=tk.BOTH)
+        master.columnconfigure(0, weight=1)
+        master.rowconfigure(0, weight=1)
+        master.pack(expand=True, fill=tk.BOTH)
 
         columns = (COL_HEAD_IMG, COL_HEAD_STYLE, COL_HEAD_NUMBER, COL_HEAD_LABEL)
         widths = (50, 80, 80, 120)
         self.list = ttk.Treeview(
-            frame, columns=columns, show="headings", height=10, selectmode=tk.BROWSE
+            master, columns=columns, show="headings", height=10, selectmode=tk.BROWSE
         )
-        for col in range(len(columns)):
+        for col, column in enumerate(columns):
             self.list.column(
                 f"#{col + 1}",
                 minwidth=10,
@@ -144,19 +140,19 @@ class PageDetailsDialog(OkCancelDialog):
                 stretch=False,
                 anchor=tk.CENTER,
             )
-            self.list.heading(f"#{col + 1}", text=columns[col])
+            self.list.heading(f"#{col + 1}", text=column)
 
         self.list.bind("<ButtonRelease-1>", self.item_clicked)
         self.list.grid(row=0, column=0, sticky=tk.NSEW)
 
         self.scrollbar = ttk.Scrollbar(
-            frame, orient=tk.VERTICAL, command=self.list.yview
+            master, orient=tk.VERTICAL, command=self.list.yview
         )
         self.list.configure(yscroll=self.scrollbar.set)  # type: ignore[call-overload]
         self.scrollbar.grid(row=0, column=1, sticky=tk.NS)
 
         self.populate_list(self.details)
-        return frame
+        return master
 
     def populate_list(self, details: PageDetails, see_index: int = 0) -> None:
         """Populate the page details list from the given details.

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -132,7 +132,7 @@ class Preferences:
         """Save preferences dictionary to JSON file."""
         if not os.path.isdir(self.prefsdir):
             os.mkdir(self.prefsdir)
-        with open(self.prefsfile, "w") as fp:
+        with open(self.prefsfile, "w", encoding="utf-8") as fp:
             json.dump(self.dict, fp, indent=2, ensure_ascii=False)
 
     def load(self) -> None:
@@ -145,8 +145,7 @@ class Preferences:
         """Run all defined callbacks, passing value as argument.
 
         Should be called after prefs are loaded and UI is ready"""
-        for key in self.callbacks.keys():
-            callback = self.callbacks[key]
+        for key, callback in self.callbacks.items():
             if callback is not None:
                 callback(self.get(key))
 

--- a/src/guiguts/project_dict.py
+++ b/src/guiguts/project_dict.py
@@ -37,7 +37,7 @@ class ProjectDict:
         project_dict = {}
         project_dict[GOOD_WORDS_KEY] = list(self.good_words.keys())
         project_dict[BAD_WORDS_KEY] = list(self.bad_words.keys())
-        with open(dict_name, "w") as fp:
+        with open(dict_name, "w", encoding="utf-8") as fp:
             json.dump(project_dict, fp, indent=2, ensure_ascii=False)
 
     def load(self, textfile_path: str) -> None:
@@ -88,7 +88,7 @@ class ProjectDict:
         Returns:
             Name of dictionary file.
         """
-        root, ext = os.path.splitext(file_name)
+        root, _ = os.path.splitext(file_name)
         root += "_dict"
         return root + ".json"
 

--- a/src/guiguts/root.py
+++ b/src/guiguts/root.py
@@ -14,7 +14,7 @@ from guiguts.widgets import grab_focus
 
 logger = logging.getLogger(__package__)
 
-_the_root = None
+_the_root = None  # pylint: disable=invalid-name
 
 
 class Root(tk.Tk):

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -384,7 +384,9 @@ class SearchDialog(ToplevelDialog):
 
         match_text = maintext().get(start_index, end_index)
         if SearchDialog.regex.get():
-            replace_string = replace_regex(search_string, replace_string, match_text)
+            replace_string = get_regex_replacement(
+                search_string, replace_string, match_text
+            )
         maintext().replace(start_index, end_index, replace_string)
         # "Reverse flag XOR Shift-key" searches backwards
         backwards = SearchDialog.reverse.get() ^ opposite_dir
@@ -437,7 +439,7 @@ class SearchDialog(ToplevelDialog):
                 end_index = maintext().index(start_index + f"+{match.count}c")
                 match_text = maintext().get(start_index, end_index)
                 if SearchDialog.regex.get():
-                    replace_match = replace_regex(
+                    replace_match = get_regex_replacement(
                         search_string, replace_string, match_text
                     )
                 maintext().replace(start_index, end_index, replace_match)
@@ -565,7 +567,9 @@ def get_search_start(backwards: bool) -> IndexRowCol:
     return start_rowcol
 
 
-def replace_regex(search_regex: str, replace_regex: str, match_text: str) -> str:
+def get_regex_replacement(
+    search_regex: str, replace_regex: str, match_text: str
+) -> str:
     """Find actual replacement string, given the search & replace regexes
     and the matching text.
 

--- a/src/guiguts/spell.py
+++ b/src/guiguts/spell.py
@@ -22,7 +22,7 @@ SPELL_CHECK_OK_YES = 0
 SPELL_CHECK_OK_NO = 1
 SPELL_CHECK_OK_BAD = 2
 
-_the_spell_checker = None
+_the_spell_checker = None  # pylint: disable=invalid-name
 
 
 class DictionaryNotFoundError(Exception):
@@ -154,7 +154,7 @@ class SpellChecker:
         # Now check numbers
         if (
             # word is all digits
-            re.fullmatch(r"\d+", word)
+            re.fullmatch(r"\d+", word)  # pylint: disable=too-many-boolean-expressions
             # ...1st, ...21st, ...31st, etc
             or re.fullmatch(r"(\d*[02-9])?1st", word, flags=re.IGNORECASE)
             # ...2nd, ...22nd, ...32nd, etc (also 2d, 22d, etc)

--- a/src/guiguts/utilities.py
+++ b/src/guiguts/utilities.py
@@ -17,7 +17,7 @@ TraversablePath = importlib.resources.abc.Traversable | Path
 
 # Flag so application code can detect if within a pytest run - only use if really needed
 # See: https://pytest.org/en/7.4.x/example/simple.html#detect-if-running-from-within-a-pytest-run
-called_from_test = False
+called_from_test = False  # pylint: disable=invalid-name
 
 
 #
@@ -46,10 +46,10 @@ def _is_system(system: str) -> bool:
     """
     try:
         return _is_system.system == system
-    except AttributeError:
+    except AttributeError as exc:
         _is_system.system = platform.system()
         if _is_system.system not in ["Darwin", "Linux", "Windows"]:
-            raise Exception("Unknown windowing system")
+            raise RuntimeError("Unknown windowing system") from exc
         return _is_system.system == system
 
 
@@ -63,7 +63,7 @@ def load_dict_from_json(filename: str) -> Optional[dict[str, Any]]:
         Dictionary if loaded successfully, or None.
     """
     if os.path.isfile(filename):
-        with open(filename, "r") as fp:
+        with open(filename, "r", encoding="utf-8") as fp:
             try:
                 return json.load(fp)
             except json.decoder.JSONDecodeError as exc:
@@ -176,7 +176,7 @@ class IndexRange:
 # This is necessary since the bell requires various Tk features/widgets,
 # like root and the status bar. We don't want to have to import those
 # into every module that wants to sound the bell, e.g. Search.
-_bell_callback = None
+_bell_callback = None  # pylint: disable=invalid-name
 
 
 def bell_set_callback(callback: Callable[[], None]) -> None:

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -78,7 +78,6 @@ class ToplevelDialog(tk.Toplevel):
         title: str,
         resize_x: bool = True,
         resize_y: bool = True,
-        *args: Any,
         **kwargs: Any,
     ) -> None:
         """Initialize the dialog.
@@ -88,7 +87,7 @@ class ToplevelDialog(tk.Toplevel):
             resize_x: True(default) to allow resizing and remembering of the dialog width.
             resize_y: True(default) to allow resizing and remembering of the dialog height.
         """
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.bind("<Escape>", lambda event: self.destroy())
         self.title(title)
         self.resizable(resize_x, resize_y)
@@ -111,7 +110,6 @@ class ToplevelDialog(tk.Toplevel):
         cls: type[TlDlg],
         title: Optional[str] = None,
         destroy: bool = False,
-        *args: Any,
         **kwargs: Any,
     ) -> TlDlg:
         """Show the instance of this dialog class, or create it if it doesn't exist.
@@ -131,9 +129,9 @@ class ToplevelDialog(tk.Toplevel):
         # Now, if dialog doesn't exist (may have been destroyed above) (re-)create it
         if not cls.get_dialog():
             if title is not None:
-                ToplevelDialog._toplevel_dialogs[dlg_name] = cls(title, *args, **kwargs)  # type: ignore[call-arg]
+                ToplevelDialog._toplevel_dialogs[dlg_name] = cls(title, **kwargs)  # type: ignore[call-arg]
             else:
-                ToplevelDialog._toplevel_dialogs[dlg_name] = cls(*args, **kwargs)  # type: ignore[call-arg]
+                ToplevelDialog._toplevel_dialogs[dlg_name] = cls(**kwargs)  # type: ignore[call-arg]
         return ToplevelDialog._toplevel_dialogs[dlg_name]  # type: ignore[return-value]
 
     @classmethod
@@ -149,8 +147,7 @@ class ToplevelDialog(tk.Toplevel):
             and ToplevelDialog._toplevel_dialogs[dlg_name].winfo_exists()
         ):
             return ToplevelDialog._toplevel_dialogs[dlg_name]  # type: ignore[return-value]
-        else:
-            return None
+        return None
 
     def _do_config(self) -> None:
         """Configure the geometry of the ToplevelDialog.
@@ -208,7 +205,7 @@ class ToplevelDialog(tk.Toplevel):
         except KeyError:
             return ""
 
-    def _handle_config(self, event: tk.Event) -> None:
+    def _handle_config(self, _event: tk.Event) -> None:
         """Callback from dialog <Configure> event.
 
         By setting flag now, and queuing calls to _save_config,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import guiguts.utilities
 
 
-def pytest_configure(config: pytest.Config) -> None:
+def pytest_configure(config: pytest.Config) -> None:  # pylint: disable=unused-argument
     """Set flag so application code can detect if within a pytest run
 
     See: https://pytest.org/en/7.4.x/example/simple.html#detect-if-running-from-within-a-pytest-run


### PR DESCRIPTION
1. Disabled some messages completely, mostly "too-many..." code-style messages, but also "global-statement" warnings - see below for discussion.
2. Retained "too-many-boolean-expressions" as I thought it was a good thing to avoid, and also not likely to happen often, so ok to disable on a per-line basis.
3. Several warnings about improved way to access dictionaries, e.g. using `.items()` acted on.
4. More `*args` arguments removed.
5. Enforced encoding when opening files - good to find, since .json file wasn't being written with utf-8 encoding, so failed to read with utf-8 encoding, depending on contents.

For discussion and advice, please:

- Is disabling the "global-statement" warnings ok with you. We use globals in a few places, and IMO, our code review process should be sufficient to pick up on cases where a developer uses globals inappropriately, rather than warnings from pylint, but I'm happy to be guided by more experienced python/pylint users.
- This brings the list of lint errors down to 9, consisting of two types: complaints about global "constants" not being all UPPER_CASE, and suggestions about re-raising exceptions differently.
    - For the first, they aren't uppercase because they aren't actually constant - do you think it best to disable that warning, or to keep the warning and make the "constants" uppercase, or add comments to disable the warning on those 5 specific lines?
    - For the second, I don't understand the difference (if any) or advantage in the suggestion to re-raise those Exceptions differently, so would value advice on the best way to tackle those: do what pylint suggests, or disable the warning, or disable on a per-line basis. Similarly for the one "too general exception" warning.

For reference, here's the output from pylint:
```
************* Module maintext
src\guiguts\maintext.py:787:16: W0707: Consider explicitly re-raising using 'raise TclRegexCompileError(str(exc)) from exc' (raise-missing-from)
src\guiguts\maintext.py:837:20: W0707: Consider explicitly re-raising using 'raise TclRegexCompileError(str(exc)) from exc' (raise-missing-from)
src\guiguts\maintext.py:956:0: C0103: Constant name "_single_widget" doesn't conform to UPPER_CASE naming style (invalid-name)
************* Module root
src\guiguts\root.py:17:0: C0103: Constant name "_the_root" doesn't conform to UPPER_CASE naming style (invalid-name)
************* Module spell
src\guiguts\spell.py:25:0: C0103: Constant name "_the_spell_checker" doesn't conform to UPPER_CASE naming style (invalid-name)
************* Module utilities
src\guiguts\utilities.py:20:0: C0103: Constant name "called_from_test" doesn't conform to UPPER_CASE naming style (invalid-name)
src\guiguts\utilities.py:52:12: W0707: Consider explicitly re-raising using 'except AttributeError as exc' and 'raise Exception('Unknown windowing system') from exc' (raise-missing-from)
src\guiguts\utilities.py:52:12: W0719: Raising too general exception: Exception (broad-exception-raised)
src\guiguts\utilities.py:179:0: C0103: Constant name "_bell_callback" doesn't conform to UPPER_CASE naming style (invalid-name)

```

Regarding the last few pylint messages, I'm very happy to make suggested changes, or for someone else to add a commit, or to leave them for a future PR, possibly one which also makes a clean pylint compulsory instead of advisory as it is at present, as @tangledhelix suggested we could when all the lint was fixed. 