### PR TITLE
Further small checker dialog fixes

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -398,6 +398,6 @@ class CheckerDialog(ToplevelDialog):
             rowcol: Location in text file to be marked.
 
         Returns:
-            Name for mark, e.g. "chk123.45"
+            Name for mark, e.g. "Checker123.45"
         """
         return f"{self.mark_prefix}{rowcol.index()}"

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -9,7 +9,6 @@ from guiguts.mainwindow import ScrolledReadOnlyText
 from guiguts.utilities import IndexRowCol, IndexRange, is_mac
 from guiguts.widgets import ToplevelDialog, TlDlg
 
-MARK_PREFIX = "chk"
 MARK_REMOVED_ENTRY = "MarkRemovedEntry"
 HILITE_TAG_NAME = "chk_hilite"
 SELECT_TAG_NAME = "chk_select"
@@ -123,6 +122,8 @@ class CheckerDialog(ToplevelDialog):
             SELECT_TAG_NAME, background="#dddddd", foreground="#000000"
         )
         self.text.tag_configure(HILITE_TAG_NAME, foreground="#2197ff")
+        # Reduce length of common part of mark names
+        self.mark_prefix = self.__class__.__name__.removesuffix("Dialog")
         self.reset()
 
     @classmethod
@@ -149,7 +150,7 @@ class CheckerDialog(ToplevelDialog):
         self.update_count_label()
         self.text.delete("1.0", tk.END)
         for mark in maintext().mark_names():
-            if mark.startswith(MARK_PREFIX):
+            if mark.startswith(self.mark_prefix):
                 maintext().mark_unset(mark)
 
     def add_entry(
@@ -399,4 +400,4 @@ class CheckerDialog(ToplevelDialog):
         Returns:
             Name for mark, e.g. "chk123.45"
         """
-        return f"{MARK_PREFIX}{rowcol.index()}"
+        return f"{self.mark_prefix}{rowcol.index()}"

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -130,7 +130,6 @@ class CheckerDialog(ToplevelDialog):
         cls: type[TlDlg],
         title: Optional[str] = None,
         destroy: bool = True,
-        *args: Any,
         **kwargs: Any,
     ) -> TlDlg:
         """Show the instance of this dialog class, or create it if it doesn't exist.
@@ -141,7 +140,7 @@ class CheckerDialog(ToplevelDialog):
             args: Optional args to pass to dialog constructor.
             kwargs: Optional kwargs to pass to dialog constructor.
         """
-        return super().show_dialog(title, destroy, *args, **kwargs)
+        return super().show_dialog(title, destroy, **kwargs)
 
     def reset(self) -> None:
         """Reset dialog and associated structures & marks."""

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -7,7 +7,7 @@ from typing import Any, Optional, Callable
 from guiguts.maintext import maintext
 from guiguts.mainwindow import ScrolledReadOnlyText
 from guiguts.utilities import IndexRowCol, IndexRange, is_mac
-from guiguts.widgets import ToplevelDialog
+from guiguts.widgets import ToplevelDialog, TlDlg
 
 MARK_PREFIX = "chk"
 MARK_REMOVED_ENTRY = "MarkRemovedEntry"
@@ -124,6 +124,24 @@ class CheckerDialog(ToplevelDialog):
         )
         self.text.tag_configure(HILITE_TAG_NAME, foreground="#2197ff")
         self.reset()
+
+    @classmethod
+    def show_dialog(
+        cls: type[TlDlg],
+        title: Optional[str] = None,
+        destroy: bool = True,
+        *args: Any,
+        **kwargs: Any,
+    ) -> TlDlg:
+        """Show the instance of this dialog class, or create it if it doesn't exist.
+
+        Args:
+            title: Dialog title.
+            destroy: True (default) if dialog should be destroyed & re-created, rather than re-used
+            args: Optional args to pass to dialog constructor.
+            kwargs: Optional kwargs to pass to dialog constructor.
+        """
+        return super().show_dialog(title, destroy, *args, **kwargs)
 
     def reset(self) -> None:
         """Reset dialog and associated structures & marks."""

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -324,7 +324,7 @@ class SearchDialog(ToplevelDialog):
             return
 
         checker_dialog = CheckerDialog.show_dialog(
-            "Search Results", destroy=True, rerun_command=self.findall_clicked
+            "Search Results", rerun_command=self.findall_clicked
         )
         checker_dialog.reset()
         # Construct opening line describing the search

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -323,7 +323,11 @@ class SearchDialog(ToplevelDialog):
             sound_bell()
             return
 
-        checker_dialog = CheckerDialog.show_dialog(
+        class FindAllCheckerDialog(CheckerDialog):
+            """Minimal class inheriting from CheckerDialog so that it can exist
+            simultaneously with other checker dialogs."""
+
+        checker_dialog = FindAllCheckerDialog.show_dialog(
             "Search Results", rerun_command=self.findall_clicked
         )
         checker_dialog.reset()

--- a/src/guiguts/spell.py
+++ b/src/guiguts/spell.py
@@ -304,7 +304,6 @@ def spell_check(
 
     checker_dialog = CheckerDialog.show_dialog(
         "Spelling Check Results",
-        destroy=True,
         rerun_command=lambda: spell_check(project_dict, add_project_word_callback),
         process_command=process_spelling,
     )

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -116,6 +116,7 @@ class ToplevelDialog(tk.Toplevel):
 
         Args:
             title: Dialog title.
+            destroy: True (default is False) if dialog should be destroyed & re-created, rather than re-used
             args: Optional args to pass to dialog constructor.
             kwargs: Optional kwargs to pass to dialog constructor.
         """


### PR DESCRIPTION
1. Make "destroy" True by default for checker dialogs - it is False by default for other Toplevel dialogs. The pptxt work was merged without the correct setting for "destroy", which is what prompted this edit. The bug which this fixes is that if spellcheck is run, and then pptxt, then pptxt re-uses the spellcheck dialog, with the consequence that clicking "re-run" re-runs spellcheck instead of pptxt.
2. Make FindAll independent of the other checker dialogs, so that it can be displayed at the same time. It is a more general tool, rather than a "checker", so deserves it's own life, otherwise you can't do Spellcheck, followed by Find All occurrences of word.