### PR TITLE
Word frequency dialog

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,36 +6,46 @@ Guiguts
 =======
 
 .. automodule:: application
-
-MainWindow
-==========
-     
-.. automodule:: mainwindow
+ 
+Checkers
+========
+    
+.. automodule:: checkers
+ 
+File
+=========
+    
+.. automodule:: file
 
 MainText
 ========
      
 .. automodule:: maintext
+
+MainWindow
+==========
+     
+.. automodule:: mainwindow
+ 
+Page Details
+============
+    
+.. automodule:: page_details
  
 Preferences
 ===========
  
 .. automodule:: preferences
  
-Utilities
-=========
-    
-.. automodule:: utilities
- 
-File
-=========
-    
-.. automodule:: file
- 
-Page Details
+Project Dict
 ============
     
-.. automodule:: page_details
+.. automodule:: project_dict
+ 
+Root
+====
+    
+.. automodule:: root
  
 Search
 ======
@@ -47,27 +57,21 @@ Spell
     
 .. automodule:: spell
  
-Checkers
-========
+Utilities
+=========
     
-.. automodule:: checkers
+.. automodule:: utilities
  
 Widgets
 =======
     
 .. automodule:: widgets
  
-Root
-====
+Word Frequency
+==============
     
-.. automodule:: root
- 
-Project Dict
-============
-    
-.. automodule:: project_dict
+.. automodule:: word_frequency
 
- 
 PPtxt
 ============
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,5 @@ disable = [
 
 enable = ["c-extension-no-member"]
 
+[tool.pylint.SIMILARITIES]
+min-similarity-lines = 6

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -29,6 +29,7 @@ from guiguts.spell import spell_check
 from guiguts.tools.pptxt import pptxt
 from guiguts.tools.jeebies import jeebies_check
 from guiguts.utilities import is_mac
+from guiguts.word_frequency import word_frequency, WFDisplayType, WFSortType
 
 logger = logging.getLogger(__package__)
 
@@ -269,6 +270,14 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         preferences.set_default("SearchDialogWholeword", False)
         preferences.set_default("SearchDialogWrap", True)
         preferences.set_default("SearchDialogRegex", False)
+        preferences.set_default("WordFrequencyDialogSuspectsOnly", False)
+        preferences.set_default("WordFrequencyDialogIgnoreCase", False)
+        preferences.set_default(
+            "WordFrequencyDialogDisplayType", WFDisplayType.ALL_WORDS
+        )
+        preferences.set_default("WordFrequencyDialogSortType", WFSortType.ALPHABETIC)
+        preferences.set_default("WordFrequencyDialogItalThreshold", ["4"])
+        preferences.set_default("WordFrequencyDialogRegex", [])
         preferences.set_default("DialogGeometry", {})
         preferences.set_default("RootGeometry", "800x400")
         preferences.set_default("DefaultLanguages", "en")
@@ -392,6 +401,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
     def init_tools_menu(self) -> None:
         """Create the Tools menu."""
         menu_edit = Menu(menubar(), "~Tools")
+        menu_edit.add_button("~Word Frequency", word_frequency)
         menu_edit.add_button(
             "~Spelling Check",
             lambda: spell_check(

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -12,7 +12,6 @@ from guiguts.widgets import ToplevelDialog, TlDlg
 
 MARK_REMOVED_ENTRY = "MarkRemovedEntry"
 HILITE_TAG_NAME = "chk_hilite"
-SELECT_TAG_NAME = "chk_select"
 
 
 class CheckerEntry:
@@ -119,9 +118,6 @@ class CheckerDialog(ToplevelDialog):
             )
 
         self.process_command = process_command
-        self.text.tag_configure(
-            SELECT_TAG_NAME, background="#dddddd", foreground="#000000"
-        )
         self.text.tag_configure(HILITE_TAG_NAME, foreground="#2197ff")
         # Reduce length of common part of mark names
         self.mark_prefix = self.__class__.__name__.removesuffix("Dialog")
@@ -362,9 +358,8 @@ class CheckerDialog(ToplevelDialog):
         Returns:
             Index into self.entries array, or None if no message selected.
         """
-        if tag_range := self.text.tag_nextrange(SELECT_TAG_NAME, "1.0"):
-            return IndexRowCol(tag_range[0]).row - 1
-        return None
+        line_num = self.text.get_select_line_num()
+        return None if line_num is None else line_num - 1
 
     def select_entry(self, entry_index: int) -> None:
         """Select line in dialog corresponding to given entry index,
@@ -373,7 +368,7 @@ class CheckerDialog(ToplevelDialog):
         Args:
             event: Event object containing mouse click position.
         """
-        self.highlight_entry(entry_index)
+        self.text.select_line(entry_index + 1)
         self.text.mark_set(tk.INSERT, f"{entry_index + 1}.0")
         self.text.focus_set()
         entry = self.entries[entry_index]
@@ -385,17 +380,6 @@ class CheckerDialog(ToplevelDialog):
             maintext().do_select(IndexRange(start, end))
             maintext().set_insert_index(IndexRowCol(start), focus=not is_mac())
         self.lift()
-
-    def highlight_entry(self, entry_index: int) -> None:
-        """Highlight the line of text corresponding to the entry_index.
-
-        Args:
-            entry_index: Index into self.entries list.
-        """
-        self.text.tag_remove(SELECT_TAG_NAME, "1.0", tk.END)
-        self.text.tag_add(
-            SELECT_TAG_NAME, f"{entry_index + 1}.0", f"{entry_index + 2}.0"
-        )
 
     def _mark_from_rowcol(self, rowcol: IndexRowCol) -> str:
         """Return name to use to mark given location in text file.

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -7,7 +7,7 @@ from typing import Any, Optional, Callable
 from guiguts.maintext import maintext
 from guiguts.mainwindow import ScrolledReadOnlyText
 from guiguts.root import root
-from guiguts.utilities import IndexRowCol, IndexRange, is_mac
+from guiguts.utilities import IndexRowCol, IndexRange, is_mac, sing_plur
 from guiguts.widgets import ToplevelDialog, TlDlg
 
 MARK_REMOVED_ENTRY = "MarkRemovedEntry"
@@ -204,8 +204,9 @@ class CheckerDialog(ToplevelDialog):
 
     def update_count_label(self) -> None:
         """Update the label showing how many linked entries are in dialog."""
-        word = "Entry" if self.count_linked_entries == 1 else "Entries"
-        self.count_label["text"] = f"{self.count_linked_entries} {word}"
+        self.count_label["text"] = sing_plur(
+            self.count_linked_entries, "Entry", "Entries"
+        )
 
     def select_entry_by_click(self, event: tk.Event) -> str:
         """Select clicked line in dialog, and jump to the line in the

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -48,6 +48,8 @@ PAGE_FLAGS_NONE = 0
 PAGE_FLAGS_SOME = 1
 PAGE_FLAGS_ALL = 2
 
+PAGE_SEPARATOR_REGEX = r"File:.+?([^/\\ ]+)\.(png|jpg)"
+
 
 class BinDict(TypedDict):
     """Dictionary for saving to bin file."""
@@ -413,11 +415,10 @@ class File:
         page_num_style = STYLE_ARABIC
         page_num = "1"
 
-        page_separator_regex = r"File:.+?([^/\\ ]+)\.(png|jpg)"
-        pattern = re.compile(page_separator_regex)
+        pattern = re.compile(PAGE_SEPARATOR_REGEX)
         search_start = "1.0"
         while page_index := maintext().search(
-            page_separator_regex, search_start, regexp=True, stopindex="end"
+            PAGE_SEPARATOR_REGEX, search_start, regexp=True, stopindex="end"
         ):
             line_start = maintext().index(page_index + " linestart")
             line_end = page_index + " lineend"

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -451,13 +451,13 @@ class MainText(tk.Text):
         """Clear any current text selection."""
         self.tag_remove("sel", "1.0", tk.END)
 
-    def do_select(self, _range: IndexRange) -> None:
+    def do_select(self, sel_range: IndexRange) -> None:
         """Select the given range of text.
 
         Args:
-            IndexRange containing start and end of text to be selected."""
+            sel_range: IndexRange containing start and end of text to be selected."""
         self.clear_selection()
-        self.tag_add("sel", _range.start.index(), _range.end.index())
+        self.tag_add("sel", sel_range.start.index(), sel_range.end.index())
 
     def selected_ranges(self) -> list[IndexRange]:
         """Get the ranges of text marked with the `sel` tag.
@@ -890,6 +890,16 @@ class MainText(tk.Text):
         start_index = match.rowcol.index()
         end_index = maintext().index(start_index + f"+{match.count}c")
         return maintext().get(start_index, end_index)
+
+    def select_match_text(self, match: FindMatch) -> None:
+        """Select text indicated by given match.
+
+        Args:
+            match: Start and length of matched text - assumed to be valid.
+        """
+        start_index = match.rowcol.index()
+        end_index = maintext().index(start_index + f"+{match.count}c")
+        maintext().do_select(IndexRange(start_index, end_index))
 
     def transform_selection(self, fn: Callable[[str], str]) -> None:
         """Transform a text selection by applying a function or method.

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -881,6 +881,16 @@ class MainText(tk.Text):
                 start += f"+{count_var.get()}c"
         return matches
 
+    def get_match_text(self, match: FindMatch) -> str:
+        """Return text indicated by given match.
+
+        Args:
+            match: Start and length of matched text - assumed to be valid.
+        """
+        start_index = match.rowcol.index()
+        end_index = maintext().index(start_index + f"+{match.count}c")
+        return maintext().get(start_index, end_index)
+
     def transform_selection(self, fn: Callable[[str], str]) -> None:
         """Transform a text selection by applying a function or method.
 

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -169,7 +169,24 @@ class PersistentBoolean(tk.BooleanVar):
             prefs_key: Preferences key associated with the variable.
         """
         super().__init__(value=preferences.get(prefs_key))
-        self.trace_add("write", lambda *args: preferences.set(prefs_key, self.get()))
+        self.trace_add("write", lambda *_args: preferences.set(prefs_key, self.get()))
+
+
+class PersistentString(tk.StringVar):
+    """Tk string variable whose value is stored in user prefs file.
+
+    Note that, like all prefs, the default value must be set in
+    `initialize_preferences`
+    """
+
+    def __init__(self, prefs_key: str) -> None:
+        """Initialize persistent string.
+
+        Args:
+            prefs_key: Preferences key associated with the variable.
+        """
+        super().__init__(value=preferences.get(prefs_key))
+        self.trace_add("write", lambda *_args: preferences.set(prefs_key, self.get()))
 
 
 preferences = Preferences()

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -10,7 +10,14 @@ import regex as re
 from guiguts.checkers import CheckerDialog
 from guiguts.maintext import maintext, TclRegexCompileError
 from guiguts.preferences import preferences, PersistentBoolean
-from guiguts.utilities import sound_bell, IndexRowCol, IndexRange, process_accel, is_mac
+from guiguts.utilities import (
+    sound_bell,
+    IndexRowCol,
+    IndexRange,
+    process_accel,
+    is_mac,
+    sing_plur,
+)
 from guiguts.widgets import ToplevelDialog, Combobox
 
 logger = logging.getLogger(__package__)
@@ -287,8 +294,8 @@ class SearchDialog(ToplevelDialog):
                 sound_bell()
                 return
             count = len(matches)
-            match_str = "match" if count == 1 else "matches"
-            self.display_message(f"Count: {count} {match_str} {range_name}")
+            match_str = sing_plur(count, "match", "matches")
+            self.display_message(f"Count: {match_str} {range_name}")
         else:
             self.display_message('No text selected for "In selection" count')
             sound_bell()
@@ -315,8 +322,8 @@ class SearchDialog(ToplevelDialog):
                 sound_bell()
                 return
             count = len(matches)
-            match_str = "match" if count == 1 else "matches"
-            self.display_message(f"Found: {count} {match_str} {range_name}")
+            match_str = sing_plur(count, "match", "matches")
+            self.display_message(f"Found: {match_str} {range_name}")
         else:
             matches = []
             self.display_message('No text selected for "In selection" find')
@@ -454,8 +461,8 @@ class SearchDialog(ToplevelDialog):
                     MARK_END_RANGE
                 )  # Refresh end index
                 count += 1
-            match_str = "match" if count == 1 else "matches"
-            self.display_message(f"Replaced: {count} {match_str} {range_name}")
+            match_str = sing_plur(count, "match", "matches")
+            self.display_message(f"Replaced: {match_str} {range_name}")
         else:
             self.display_message('No text selected for "In selection" replace')
             sound_bell()

--- a/src/guiguts/utilities.py
+++ b/src/guiguts/utilities.py
@@ -7,7 +7,8 @@ import logging
 from pathlib import Path
 import os.path
 from tkinter import _tkinter
-from typing import Any, Optional, Callable
+from typing import Any, Optional, Callable, Mapping
+from unicodedata import combining, normalize
 
 import regex as re
 
@@ -184,6 +185,28 @@ class IndexRange:
         return (self.start, self.end) == (other.start, other.end)
 
 
+def sing_plur(count: int, singular: str, plural: str = "") -> str:
+    """Return singular/plural phrase depending on count.
+
+    Args:
+        count: Number of items.
+        singular: Singular version of item name.
+        plural: Plural version of item name (default - add `s` to singular).
+
+    Examples:
+        sing_plur(1, "word") -> "1 word"
+        sing_plur(2, "error") -> "2 errors"
+        sing_plur(3, "match", "matches") -> "3 matches"
+    """
+    if count == 1:
+        word = singular
+    elif plural == "":
+        word = singular + "s"
+    else:
+        word = plural
+    return f"{count} {word}"
+
+
 # Store callback that sounds bell, and provide function to call it.
 # This is necessary since the bell requires various Tk features/widgets,
 # like root and the status bar. We don't want to have to import those
@@ -278,3 +301,40 @@ def convert_to_tcl_regex(regex: str) -> str:
         Converted regex.
     """
     return re.sub(r"(?<!\\)\\b", r"\\y", regex)
+
+
+class DiacriticRemover:
+    """Supports removal of diacritics from strings."""
+
+    outliers: Mapping
+    source_outliers = "ä  æ  ǽ  đ ð ƒ ħ ı ł ø ǿ ö  œ  ß  ŧ ü  Ä  Æ  Ǽ  Đ Ð Ƒ Ħ I Ł Ø Ǿ Ö  Œ  ẞ  Ŧ Ü  Þ  þ"
+    target_outliers = "ae ae ae d d f h i l o o oe oe ss t ue AE AE AE D D F H I L O O OE OE SS T UE TH th"
+
+    @classmethod
+    def setup_outliers(cls, source_outliers: str, target_outliers: str) -> None:
+        """Setup the outliers mapping from source & target strings.
+
+        Should be called with the relevant outliers when the language is changed."""
+        DiacriticRemover.outliers = str.maketrans(
+            dict(zip(source_outliers.split(), target_outliers.split()))
+        )
+
+    @classmethod
+    def remove_diacritics(cls, string: str) -> str:
+        """Remove accents, etc., from string.
+
+        Based on https://stackoverflow.com/a/71408065
+        First fixes a few outliers, like ǿ --> o, then uses Unicode Normalization
+        to decompose string, then discards combining characters.
+        """
+        try:
+            DiacriticRemover.outliers
+        except AttributeError:
+            DiacriticRemover.setup_outliers(
+                DiacriticRemover.source_outliers, DiacriticRemover.target_outliers
+            )
+        return "".join(
+            char
+            for char in normalize("NFD", string.translate(DiacriticRemover.outliers))
+            if not combining(char)
+        )

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -243,6 +243,8 @@ class Combobox(ttk.Combobox):
         super().__init__(parent, *args, **kwargs)
         self.prefs_key = prefs_key
         self["values"] = preferences.get(self.prefs_key)
+        # If user selects value from dropdown, add it to top of history list
+        self.bind("<<ComboboxSelected>>", lambda *_: self.add_to_history(self.get()))
 
     def add_to_history(self, string: str) -> None:
         """Store given string in history list.
@@ -262,6 +264,13 @@ class Combobox(ttk.Combobox):
             del history[NUM_HISTORY:]
             preferences.set(self.prefs_key, history)
             self["values"] = history
+
+    def display_latest_value(self) -> None:
+        """Display most recent value (if any) from history list."""
+        try:
+            self.current(0)
+        except tk.TclError:
+            self.set("")
 
 
 def grab_focus(

--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -1,0 +1,841 @@
+"""Store, analyze and report on word frequency and inconsistencies."""
+
+from enum import StrEnum, auto
+import tkinter as tk
+from tkinter import ttk
+from typing import Any, Callable
+
+import regex as re
+
+from guiguts.file import PAGE_SEPARATOR_REGEX
+from guiguts.maintext import maintext
+from guiguts.mainwindow import ScrolledReadOnlyText
+from guiguts.preferences import preferences, PersistentBoolean, PersistentString
+from guiguts.utilities import sing_plur, DiacriticRemover, IndexRange
+from guiguts.widgets import ToplevelDialog, Combobox
+
+_the_word_lists = None  # pylint: disable=invalid-name
+
+RETURN_ARROW = "⏎"
+
+
+class WFDisplayType(StrEnum):
+    """Enum class to store Word Frequency display types."""
+
+    ALL_WORDS = auto()
+    EMDASHES = auto()
+    HYPHENS = auto()
+    ALPHANUM = auto()
+    ALL_CAPS = auto()
+    MIXED_CASE = auto()
+    INITIAL_CAPS = auto()
+    ACCENTS = auto()
+    LIGATURES = auto()
+    MARKEDUP = auto()
+    CHAR_COUNTS = auto()
+    REGEXP = auto()
+
+
+class WFSortType(StrEnum):
+    """Enum class to store Word Frequency sort types."""
+
+    ALPHABETIC = auto()
+    FREQUENCY = auto()
+    LENGTH = auto()
+
+
+class WFDict(dict[str, int]):
+    """Dictionary containing word and frequency."""
+
+
+class WFWordLists:
+    """Word lists used for Word Frequency analysis.
+
+    Attributes:
+        all_words: All the words in the file.
+        emdash_words: All pairs of words separated by an emdash/double hyphen.
+        word_pairs: All consecutive pairs of words - used to check for
+            hyphenation/non-hyphenation suspects.
+    """
+
+    def __init__(self) -> None:
+        """Initialize a WFWordLists object to hold word frequency information."""
+        self.reset()
+
+    def reset(self) -> None:
+        """Reset the word lists."""
+        self.all_words: WFDict = WFDict()
+        self.emdash_words: WFDict = WFDict()
+        self.word_pairs: WFDict = WFDict()
+
+    def ensure_file_analyzed(self) -> None:
+        """Analyze file to create word lists, unless already done.
+
+        Call reset method first to force reanalysis."""
+        if self.all_words:
+            return
+        for line, _ in maintext().get_lines():
+            if re.search(PAGE_SEPARATOR_REGEX, line):
+                continue
+            if preferences.get("WordFrequencyDialogIgnoreCase"):
+                line = line.lower()
+            line = re.sub(r"<\/?[a-z]*>", " ", line)  # throw away DP tags
+            # get rid of nonalphanumeric (retaining combining characters)
+            line = re.sub(r"[^'’\.,\p{Alnum}\p{Mark}\*-]", " ", line)
+
+            def strip_punc(word: str) -> str:
+                """Strip relevant leading/trailing punctuation from word."""
+                return re.sub(r"^[\.,'’-]+|[\.,'’-]+$", "", word)
+
+            # Build a list of emdash words, i.e. "word1--word2"
+            words = re.split(r"\s+", line)
+            for word in words:
+                if re.search(r"[^-](--|—)[^-]", word) and "---" not in word:
+                    word = strip_punc(word)
+                    tally_word(self.emdash_words, word)
+
+            line = re.sub(r"(--|—)", " ", line)  # double-hyphen/emdash
+
+            words = re.split(r"\s+", line)
+            previous_word = ""
+            for word in words:
+                word = re.sub(r"(?<!\-)\*", "", word)  # * not preceded by hyphen
+                word = re.sub(r"^\*$", "", word)  # just *
+                word = strip_punc(word)
+                # Tally single word
+                tally_word(self.all_words, word)
+                # Tally the pair of previous word plus this one
+                if word and previous_word:
+                    tally_word(self.word_pairs, f"{previous_word} {word}")
+                previous_word = word
+
+    def get_all_words(self) -> WFDict:
+        """Return the list of all words in the file.
+
+        Returns:
+            Dictionary of words with their frequencies."""
+        self.ensure_file_analyzed()
+        return self.all_words
+
+    def get_emdash_words(self) -> WFDict:
+        """Return the list of emdash words (word1--word2) in the file.
+
+        Returns:
+            Dictionary of emdash words with their frequencies."""
+        self.ensure_file_analyzed()
+        return self.emdash_words
+
+    def get_word_pairs(self) -> WFDict:
+        """Return the list of word pairs ("word1 word2") in the file.
+
+        Returns:
+            Dictionary of word pairs with their frequencies."""
+        self.ensure_file_analyzed()
+        return self.word_pairs
+
+
+class WordFrequencyEntry:
+    """Class to hold one entry in the Word Frequency dialog.
+
+    Attributes:
+        text: Single line of text to display in dialog.
+        count: Number of occurrences.
+        suspect: True if entry is a "suspect".
+    """
+
+    SUSPECT = "****"
+
+    def __init__(self, word: str, frequency: int, suspect: bool) -> None:
+        """Initialize WordFrequencyEntry object.
+
+        Args:
+            word: Word for this entry.
+            frequency: Number of occurrences of word.
+        """
+        self.word = word
+        self.frequency = frequency
+        self.suspect = suspect
+
+
+class WordFrequencyDialog(ToplevelDialog):
+    """Dialog to show results of word frequency analysis.
+
+    Attributes:
+        text: Text widget to contain results.
+    """
+
+    # Cannot be initialized here, since Tk root may not yet be created yet
+    suspects_only: PersistentBoolean
+    ignore_case: PersistentBoolean
+    display_type: PersistentString
+    sort_type: PersistentString
+
+    CHAR_DISPLAY: dict[str, str] = {
+        " ": "*space*",
+        "\u00a0": "*nbsp*",
+        "\n": RETURN_ARROW,
+    }
+
+    def __init__(
+        self,
+    ) -> None:
+        """Initialize the dialog."""
+        # Initialize class variables on first instantiation, then remember
+        # values for subsequent uses of dialog.
+        try:
+            WordFrequencyDialog.suspects_only
+        except AttributeError:
+            WordFrequencyDialog.suspects_only = PersistentBoolean(
+                "WordFrequencyDialogSuspectsOnly"
+            )
+            WordFrequencyDialog.ignore_case = PersistentBoolean(
+                "WordFrequencyDialogIgnoreCase"
+            )
+            WordFrequencyDialog.display_type = PersistentString(
+                "WordFrequencyDialogDisplayType"
+            )
+            WordFrequencyDialog.sort_type = PersistentString(
+                "WordFrequencyDialogSortType"
+            )
+
+        super().__init__("Word Frequency")
+        self.top_frame.rowconfigure(0, weight=0)
+        header_frame = ttk.Frame(self.top_frame, padding=2)
+        header_frame.grid(row=0, column=0, sticky="NSEW")
+        header_frame.columnconfigure(0, weight=1)
+
+        # Message label
+        label_frame = ttk.Frame(header_frame, borderwidth=1, relief=tk.GROOVE)
+        label_frame.grid(row=0, column=0, sticky="NSEW")
+        # label_frame.columnconfigure(0, weight=1)
+        self.message = tk.StringVar()
+        ttk.Label(label_frame, textvariable=self.message).grid(
+            row=0, column=0, sticky="NSW", padx=5, pady=2
+        )
+
+        # Re-run buttons
+        rerun_frame = ttk.Frame(header_frame, borderwidth=1, relief=tk.GROOVE)
+        rerun_frame.grid(row=0, column=1, rowspan=2, padx=(0, 15))
+        ttk.Button(rerun_frame, text="Re-run", command=word_frequency).grid(
+            row=0, column=0, sticky="NSEW", padx=5, pady=2
+        )
+        ttk.Checkbutton(
+            rerun_frame,
+            text="Ignore Case",
+            command=word_frequency,
+            variable=WordFrequencyDialog.ignore_case,
+            takefocus=False,
+        ).grid(row=1, column=0, sticky="NSEW", padx=5, pady=2)
+
+        # Options
+        options_frame = ttk.Frame(
+            header_frame, borderwidth=1, relief=tk.GROOVE, padding=2
+        )
+        options_frame.grid(row=1, column=0, sticky="NSEW")
+        options_frame.columnconfigure(0, weight=1)
+        ttk.Checkbutton(
+            options_frame,
+            text="Suspects Only",
+            variable=WordFrequencyDialog.suspects_only,
+            command=lambda: wf_populate(self),
+            takefocus=False,
+        ).grid(row=0, column=0, sticky="NSW", padx=5)
+        ttk.Label(
+            options_frame,
+            text="Sort:",
+        ).grid(row=0, column=1, sticky="NSE", padx=5)
+        ttk.Radiobutton(
+            options_frame,
+            text="Alph",
+            command=lambda: wf_populate(self),
+            variable=WordFrequencyDialog.sort_type,
+            value=WFSortType.ALPHABETIC,
+            takefocus=False,
+        ).grid(row=0, column=2, sticky="NSE", padx=2)
+        ttk.Radiobutton(
+            options_frame,
+            text="Freq",
+            command=lambda: wf_populate(self),
+            variable=WordFrequencyDialog.sort_type,
+            value=WFSortType.FREQUENCY,
+            takefocus=False,
+        ).grid(row=0, column=3, sticky="NSE", padx=2)
+        ttk.Radiobutton(
+            options_frame,
+            text="Len",
+            command=lambda: wf_populate(self),
+            variable=WordFrequencyDialog.sort_type,
+            value=WFSortType.LENGTH,
+            takefocus=False,
+        ).grid(row=0, column=4, sticky="NSE", padx=(2, 5))
+
+        # Display type radio buttons
+        display_frame = ttk.Frame(
+            header_frame, borderwidth=1, relief=tk.GROOVE, padding=2
+        )
+        display_frame.grid(row=2, column=0, columnspan=2, sticky="NSEW", padx=(0, 15))
+        for col in range(0, 4):
+            display_frame.columnconfigure(index=col, weight=1)
+
+        def display_radio(
+            row: int,
+            column: int,
+            text: str,
+            value: str,
+            frame: ttk.Frame = display_frame,
+        ) -> None:
+            """Add a radio button to change display type.
+
+            Args:
+                row: Row to place button.
+                column: Column to place button.
+                text: Text for button.
+                value: Value to be set when button is selected - a constant from WFDisplayType
+            """
+            ttk.Radiobutton(
+                frame,
+                text=text,
+                command=lambda: wf_populate(self),
+                variable=WordFrequencyDialog.display_type,
+                value=value,
+                takefocus=False,
+            ).grid(row=row, column=column, sticky="NSW", padx=5)
+
+        display_radio(0, 0, "All Words", WFDisplayType.ALL_WORDS)
+        display_radio(0, 1, "Emdashes", WFDisplayType.EMDASHES)
+        display_radio(0, 2, "Hyphens", WFDisplayType.HYPHENS)
+        display_radio(1, 0, "ALL CAPITALS", WFDisplayType.ALL_CAPS)
+        display_radio(1, 1, "MiXeD CasE", WFDisplayType.MIXED_CASE)
+        display_radio(1, 2, "Initial Capitals", WFDisplayType.INITIAL_CAPS)
+        display_radio(2, 0, "Alpha/Num", WFDisplayType.ALPHANUM)
+        display_radio(2, 1, "Accents", WFDisplayType.ACCENTS)
+        display_radio(2, 2, "Ligatures", WFDisplayType.LIGATURES)
+        display_radio(3, 0, "Character Cnts", WFDisplayType.CHAR_COUNTS)
+        italic_frame = ttk.Frame(display_frame)
+        italic_frame.grid(row=3, column=1, columnspan=2, sticky="NSEW")
+        italic_frame.columnconfigure(index=1, weight=1)
+        display_radio(
+            0,
+            0,
+            "Ital/Bold/SC/etc - Word Threshold:",
+            WFDisplayType.MARKEDUP,
+            italic_frame,
+        )
+
+        def is_nonnegative_int(new_value: str) -> bool:
+            """Validation routine for Combobox - check value is a non-negative integer,
+            also allowing empty string."""
+            return re.fullmatch(r"\d*", new_value) is not None
+
+        self.threshold_box = Combobox(
+            italic_frame,
+            "WordFrequencyDialogItalThreshold",
+            width=6,
+            validate="all",
+            validatecommand=(self.register(is_nonnegative_int), "%P"),
+        )
+        self.threshold_box.grid(row=0, column=1, sticky="NSEW", padx=(0, 5))
+        self.threshold_box.display_latest_value()
+
+        def display_markedup(*_args: Any) -> None:
+            """Callback to display the marked up words with new threshold value."""
+            WordFrequencyDialog.display_type.set(WFDisplayType.MARKEDUP)
+            wf_populate(self)
+
+        self.threshold_box.bind("<Return>", display_markedup)
+        self.threshold_box.bind("<<ComboboxSelected>>", display_markedup)
+
+        display_radio(4, 0, "Regular Expression", WFDisplayType.REGEXP)
+        self.regex_box = Combobox(display_frame, "WordFrequencyDialogRegex")
+        self.regex_box.grid(row=4, column=1, columnspan=2, sticky="NSEW", padx=(0, 5))
+
+        def display_regexp(*_args: Any) -> None:
+            """Callback to display the regex-matching words with new regex."""
+            WordFrequencyDialog.display_type.set(WFDisplayType.REGEXP)
+            wf_populate(self)
+
+        self.regex_box.bind("<Return>", display_regexp)
+        self.regex_box.bind("<<ComboboxSelected>>", display_regexp)
+        self.regex_box.display_latest_value()
+
+        # Main display list
+        self.top_frame.rowconfigure(1, weight=1)
+        self.text = ScrolledReadOnlyText(
+            self.top_frame, context_menu=False, wrap=tk.NONE
+        )
+        self.text.grid(row=1, column=0, sticky="NSEW")
+
+        self.minsize(450, 100)
+        self.reset()
+
+    def reset(self) -> None:
+        """Reset dialog."""
+        self.entries: list[WordFrequencyEntry] = []
+        self.text.delete("1.0", tk.END)
+        self.message.set("")
+
+    def add_entry(self, word: str, frequency: int, suspect: bool = False) -> None:
+        """Add an entry to be displayed in the dialog.
+
+        Args:
+            word: Word for this entry.
+            frequency: Number of occurrences of word.
+            suspect: Optional bool to flag this word as "suspect".
+        """
+        entry = WordFrequencyEntry(word, frequency, suspect)
+        self.entries.append(entry)
+
+    def display_entries(self) -> None:
+        """Display all the stored entries in the dialog according to
+        the sort setting."""
+
+        def sort_key_alpha(entry: WordFrequencyEntry) -> tuple[str, str, str]:
+            no_dia = DiacriticRemover.remove_diacritics(entry.word)
+            return (no_dia.lower(), no_dia, entry.word)
+
+        def sort_key_freq(entry: WordFrequencyEntry) -> tuple[int, str, str, str]:
+            no_dia = DiacriticRemover.remove_diacritics(entry.word)
+            return (-entry.frequency, no_dia.lower(), no_dia, entry.word)
+
+        def sort_key_len(entry: WordFrequencyEntry) -> tuple[int, str, str, str]:
+            no_dia = DiacriticRemover.remove_diacritics(entry.word)
+            return (-len(entry.word), no_dia.lower(), no_dia, entry.word)
+
+        key: Callable[[WordFrequencyEntry], tuple]
+        match self.sort_type.get():
+            case WFSortType.ALPHABETIC:
+                key = sort_key_alpha
+            case WFSortType.FREQUENCY:
+                key = sort_key_freq
+            case WFSortType.LENGTH:
+                key = sort_key_len
+            case _ as bad_value:
+                assert False, f"Invalid WFSortType: {bad_value}"
+
+        for entry in sorted(self.entries, key=key):
+            suspect = f" {WordFrequencyEntry.SUSPECT}" if entry.suspect else ""
+            # Single whitespace characters are replaced with a visible label
+            try:
+                word = WordFrequencyDialog.CHAR_DISPLAY[entry.word]
+            except KeyError:
+                word = entry.word
+            message = f"{entry.frequency:<7} {word}{suspect}\n"
+            self.text.insert(tk.END, message)
+
+
+def word_frequency() -> None:
+    """Do word frequency analysis on file."""
+    global _the_word_lists
+
+    _the_word_lists = WFWordLists()
+
+    wf_dialog = WordFrequencyDialog.show_dialog()
+    wf_populate(wf_dialog)
+
+
+def wf_populate(wf_dialog: WordFrequencyDialog) -> None:
+    """Populate the WF dialog with words based on the display type.
+
+    Args:
+        wf_dialog: The word frequency dialog.
+    """
+    match WordFrequencyDialog.display_type.get():
+        case WFDisplayType.ALL_WORDS:
+            wf_populate_all(wf_dialog)
+        case WFDisplayType.EMDASHES:
+            wf_populate_emdashes(wf_dialog)
+        case WFDisplayType.HYPHENS:
+            wf_populate_hyphens(wf_dialog)
+        case WFDisplayType.ALPHANUM:
+            wf_populate_alphanum(wf_dialog)
+        case WFDisplayType.ALL_CAPS:
+            wf_populate_allcaps(wf_dialog)
+        case WFDisplayType.MIXED_CASE:
+            wf_populate_mixedcase(wf_dialog)
+        case WFDisplayType.INITIAL_CAPS:
+            wf_populate_initialcaps(wf_dialog)
+        case WFDisplayType.MARKEDUP:
+            wf_populate_markedup(wf_dialog)
+        case WFDisplayType.ACCENTS:
+            wf_populate_accents(wf_dialog)
+        case WFDisplayType.LIGATURES:
+            wf_populate_ligatures(wf_dialog)
+        case WFDisplayType.CHAR_COUNTS:
+            wf_populate_charcounts(wf_dialog)
+        case WFDisplayType.REGEXP:
+            wf_populate_regexps(wf_dialog)
+        case _ as bad_value:
+            assert False, f"Invalid WFDisplayType: {bad_value}"
+
+
+def wf_populate_all(wf_dialog: WordFrequencyDialog) -> None:
+    """Populate the WF dialog with the list of all words.
+
+    Args:
+        wf_dialog: The word frequency dialog.
+    """
+    assert _the_word_lists is not None
+    wf_dialog.reset()
+
+    all_words = _the_word_lists.get_all_words()
+    total_cnt = 0
+    for word, freq in all_words.items():
+        wf_dialog.add_entry(word, freq)
+        total_cnt += freq
+    wf_dialog.display_entries()
+    wf_dialog.message.set(
+        f"{sing_plur(total_cnt, 'total word')}; {sing_plur(len(all_words), 'distinct word')}"
+    )
+
+
+def wf_populate_emdashes(wf_dialog: WordFrequencyDialog) -> None:
+    """Populate the WF dialog with the list of emdashed words.
+
+    Args:
+        wf_dialog: The word frequency dialog.
+    """
+    assert _the_word_lists is not None
+    wf_dialog.reset()
+
+    all_words = _the_word_lists.get_all_words()
+    emdash_words = _the_word_lists.get_emdash_words()
+    suspect_cnt = 0
+    for emdash_word, freq in emdash_words.items():
+        # Check for suspect, i.e. also seen with a single hyphen
+        word = re.sub("(--|—)", "-", emdash_word)
+        word_output = False
+        if not WordFrequencyDialog.suspects_only.get():
+            wf_dialog.add_entry(emdash_word, freq)
+            word_output = True
+        if word in all_words:
+            if not word_output:
+                wf_dialog.add_entry(emdash_word, freq)
+            wf_dialog.add_entry(word, all_words[word], suspect=True)
+            suspect_cnt += 1
+    wf_dialog.display_entries()
+    wf_dialog.message.set(
+        f"{sing_plur(len(emdash_words), 'emdash phrase')}; {sing_plur(suspect_cnt, 'suspect')} ({WordFrequencyEntry.SUSPECT})"
+    )
+
+
+def wf_populate_hyphens(wf_dialog: WordFrequencyDialog) -> None:
+    """Populate the WF dialog with the list of word pairs.
+
+    Args:
+        wf_dialog: The word frequency dialog.
+    """
+    assert _the_word_lists is not None
+    wf_dialog.reset()
+
+    all_words = _the_word_lists.get_all_words()
+    emdash_words = _the_word_lists.get_emdash_words()
+    word_pairs = _the_word_lists.get_word_pairs()
+    suspect_cnt = 0
+    total_cnt = 0
+    for word, freq in all_words.items():
+        if "-" in word:
+            total_cnt += 1
+            word_output = False
+            if not WordFrequencyDialog.suspects_only.get():
+                wf_dialog.add_entry(word, freq)
+                word_output = True
+            # Check for suspects - given "w1-w2", then "w1w2", "w1 w2" and "w1--w2" are suspects.
+            word_pair = re.sub("-", " ", word)
+            if word_pair in word_pairs:
+                if not word_output:
+                    wf_dialog.add_entry(word, freq)
+                    word_output = True
+                wf_dialog.add_entry(word_pair, word_pairs[word_pair], suspect=True)
+                suspect_cnt += 1
+            nohyp_word = re.sub("-", "", word)
+            if nohyp_word in all_words:
+                if not word_output:
+                    wf_dialog.add_entry(word, freq)
+                    word_output = True
+                wf_dialog.add_entry(nohyp_word, all_words[nohyp_word], suspect=True)
+                suspect_cnt += 1
+            twohyp_word = re.sub("-", "--", word)
+            if twohyp_word in emdash_words:
+                if not word_output:
+                    wf_dialog.add_entry(word, freq)
+                    word_output = True
+                wf_dialog.add_entry(
+                    twohyp_word, emdash_words[twohyp_word], suspect=True
+                )
+                suspect_cnt += 1
+    wf_dialog.display_entries()
+    wf_dialog.message.set(
+        f"{sing_plur(total_cnt, 'hyphenated word')}; {sing_plur(suspect_cnt, 'suspect')} ({WordFrequencyEntry.SUSPECT})"
+    )
+
+
+def wf_populate_by_match(
+    wf_dialog: WordFrequencyDialog,
+    desc: str,
+    match_func: Callable[[str], Any],
+) -> None:
+    """Populate the WF dialog with the list of all words that match_func matches.
+
+    Args:
+        wf_dialog: The word frequency dialog.
+        desc: Description for message, e.g. desc "ALLCAPS" -> message "27 ALLCAPS words"
+        match_func: Function that returns Truthy result if word matches the required criteria
+    """
+    assert _the_word_lists is not None
+    wf_dialog.reset()
+
+    all_words = _the_word_lists.get_all_words()
+    count = 0
+    for word, freq in all_words.items():
+        if match_func(word):
+            wf_dialog.add_entry(word, freq)
+            count += 1
+    wf_dialog.display_entries()
+    wf_dialog.message.set(f"{sing_plur(count, desc + ' word')}")
+
+
+def wf_populate_alphanum(wf_dialog: WordFrequencyDialog) -> None:
+    """Populate the WF dialog with the list of all alphanumeric words.
+
+    Args:
+        wf_dialog: The word frequency dialog.
+    """
+    wf_populate_by_match(
+        wf_dialog,
+        "alphanumeric",
+        lambda word: re.search(r"\d", word) and re.search(r"\p{Alpha}", word),
+    )
+
+
+def wf_populate_allcaps(wf_dialog: WordFrequencyDialog) -> None:
+    """Populate the WF dialog with the list of all ALLCAPS words.
+
+    Args:
+        wf_dialog: The word frequency dialog.
+    """
+    wf_populate_by_match(
+        wf_dialog,
+        "ALLCAPS",
+        lambda word: re.search(r"\p{IsUpper}", word)
+        and not re.search(r"\p{IsLower}", word),
+    )
+
+
+def wf_populate_mixedcase(wf_dialog: WordFrequencyDialog) -> None:
+    """Populate the WF dialog with the list of all MiXeD CasE words.
+
+    Args:
+        wf_dialog: The word frequency dialog.
+    """
+    wf_populate_by_match(
+        wf_dialog,
+        "MiXeD CasE",
+        lambda word: re.search(r"\p{IsUpper}", word)
+        and re.search(r"\p{IsLower}", word)
+        and not re.fullmatch(r"\p{Upper}[\p{IsLower}\p{Mark}\d'’-]+", word),
+    )
+
+
+def wf_populate_initialcaps(wf_dialog: WordFrequencyDialog) -> None:
+    """Populate the WF dialog with the list of all Initial Caps words.
+
+    Args:
+        wf_dialog: The word frequency dialog.
+    """
+    wf_populate_by_match(
+        wf_dialog,
+        "Initial Caps",
+        lambda word: re.fullmatch(r"\p{Upper}\P{Upper}+", word),
+    )
+
+
+def wf_populate_markedup(wf_dialog: WordFrequencyDialog) -> None:
+    """Populate the WF dialog with the list of all phrases marked up
+    with DP markup, e.g. <i>, <b>, etc.
+
+    Args:
+        wf_dialog: The word frequency dialog.
+    """
+    wf_dialog.reset()
+
+    marked_dict: WFDict = WFDict()
+    markup_types = "i|b|sc|f|g|u"
+    matches = maintext().find_matches(
+        rf"<({markup_types})>([^<]|\n)+</\1>",
+        IndexRange(maintext().start(), maintext().end()),
+        nocase=False,
+        regexp=True,
+        wholeword=False,
+    )
+    for match in matches:
+        marked_phrase = maintext().get_match_text(match)
+        marked_phrase = marked_phrase.replace("\n", RETURN_ARROW)
+        tally_word(marked_dict, marked_phrase)
+
+    total_cnt = 0
+    suspect_cnt = 0
+    for marked_phrase, marked_count in marked_dict.items():
+        # Suspect if the bare phrase appears an excess number of times,
+        # i.e. all occurrences > marked up occurrences
+        unmarked_phrase = re.sub(rf"^<({markup_types})>", "", marked_phrase)
+        unmarked_phrase = re.sub(rf"</({markup_types})>$", "", unmarked_phrase)
+        unmarked_search = unmarked_phrase.replace(RETURN_ARROW, "\n")
+        num_words = len(unmarked_search.split())
+        # If phrase is longer than "threshold" words, skip it - zero/empty threshold allows any length
+        threshold_str = wf_dialog.threshold_box.get()
+        wf_dialog.threshold_box.add_to_history(threshold_str)
+        threshold = int(threshold_str) if threshold_str else 0
+        if num_words > threshold > 0:
+            continue
+        total_cnt += 1
+        matches = maintext().find_matches(
+            unmarked_search,
+            IndexRange(maintext().start(), maintext().end()),
+            nocase=False,
+            regexp=True,
+            wholeword=True,
+        )
+        unmarked_count = len(matches) - marked_count
+        if unmarked_count > 0:
+            suspect_cnt += 1
+            wf_dialog.add_entry(marked_phrase, marked_count)
+            wf_dialog.add_entry(unmarked_phrase, unmarked_count, suspect=True)
+        elif not WordFrequencyDialog.suspects_only.get():
+            wf_dialog.add_entry(marked_phrase, marked_count)
+    wf_dialog.display_entries()
+    wf_dialog.message.set(
+        f"{sing_plur(total_cnt, 'marked-up phrase')}; {sing_plur(suspect_cnt, 'suspect')} ({WordFrequencyEntry.SUSPECT})"
+    )
+
+
+def wf_populate_accents(wf_dialog: WordFrequencyDialog) -> None:
+    """Populate the WF dialog with the list of all accented words.
+
+    Args:
+        wf_dialog: The word frequency dialog.
+    """
+    assert _the_word_lists is not None
+    wf_dialog.reset()
+
+    all_words = _the_word_lists.get_all_words()
+    suspect_cnt = 0
+    total_cnt = 0
+    for word, freq in all_words.items():
+        no_accent_word = DiacriticRemover.remove_diacritics(word)
+        if no_accent_word != word:
+            total_cnt += 1
+            word_output = False
+            if not WordFrequencyDialog.suspects_only.get():
+                wf_dialog.add_entry(word, freq)
+                word_output = True
+            # Check for suspect, i.e. also seen without accents
+            if no_accent_word in all_words:
+                if not word_output:
+                    wf_dialog.add_entry(word, freq)
+                wf_dialog.add_entry(
+                    no_accent_word, all_words[no_accent_word], suspect=True
+                )
+                suspect_cnt += 1
+    wf_dialog.display_entries()
+    wf_dialog.message.set(
+        f"{sing_plur(total_cnt, 'accented word')}; {sing_plur(suspect_cnt, 'suspect')} ({WordFrequencyEntry.SUSPECT})"
+    )
+
+
+def wf_populate_ligatures(wf_dialog: WordFrequencyDialog) -> None:
+    """Populate the WF dialog with the list of all ligature words.
+
+    Args:
+        wf_dialog: The word frequency dialog.
+    """
+    assert _the_word_lists is not None
+    wf_dialog.reset()
+
+    all_words = _the_word_lists.get_all_words()
+    suspect_cnt = 0
+    total_cnt = 0
+    for word, freq in all_words.items():
+        if re.search("(ae|AE|Ae|oe|OE|Oe|æ|Æ|œ|Œ)", word):
+            total_cnt += 1
+            # If actual ligature, only output it here if not suspects-only
+            if re.search("(æ|Æ|œ|Œ)", word):
+                if not WordFrequencyDialog.suspects_only.get():
+                    wf_dialog.add_entry(word, freq)
+            # Use the non-ligature version to check for suspects - because AE and Ae are both Æ
+            else:
+                lig_word = re.sub("ae", "æ", word)
+                lig_word = re.sub("(AE|Ae)", "Æ", lig_word)
+                lig_word = re.sub("oe", "œ", lig_word)
+                lig_word = re.sub("(OE|Oe)", "Œ", lig_word)
+                if lig_word in all_words:
+                    suspect_cnt += 1
+                    if WordFrequencyDialog.suspects_only.get():
+                        wf_dialog.add_entry(lig_word, all_words[lig_word])
+                    wf_dialog.add_entry(word, freq, suspect=True)
+                else:
+                    wf_dialog.add_entry(word, freq)
+    wf_dialog.display_entries()
+    wf_dialog.message.set(
+        f"{sing_plur(total_cnt, 'ligature word')}; {sing_plur(suspect_cnt, 'suspect')} ({WordFrequencyEntry.SUSPECT})"
+    )
+
+
+def wf_populate_charcounts(wf_dialog: WordFrequencyDialog) -> None:
+    """Populate the WF dialog with the list of all the characters.
+
+    Args:
+        wf_dialog: The word frequency dialog.
+    """
+    wf_dialog.reset()
+
+    char_dict: WFDict = WFDict()
+
+    total_cnt = 0
+    for line, _ in maintext().get_lines():
+        total_cnt += len(line)
+        for char in line:
+            tally_word(char_dict, char)
+
+    for char, count in char_dict.items():
+        wf_dialog.add_entry(char, count)
+
+    wf_dialog.display_entries()
+    wf_dialog.message.set(
+        f"{sing_plur(total_cnt, 'character')}; {sing_plur(len(char_dict), 'distinct character')}"
+    )
+
+
+def wf_populate_regexps(wf_dialog: WordFrequencyDialog) -> None:
+    """Populate the WF dialog with the list of all words that match the regexp.
+
+    Args:
+        wf_dialog: The word frequency dialog.
+    """
+    wf_dialog.reset()
+
+    regexp = wf_dialog.regex_box.get()
+    wf_dialog.regex_box.add_to_history(regexp)
+    try:
+        wf_populate_by_match(
+            wf_dialog,
+            "regex-matching",
+            lambda word: re.search(regexp, word),
+        )
+    except re.error as exc:
+        wf_dialog.message.set("Bad regex: " + str(exc))
+
+
+def tally_word(wf_dict: WFDict, word: str) -> None:
+    """Tally word in given WF dictionary, unless word is empty.
+
+    If word already in dictionary, increment the count.
+    If not, add word and set count to 1.
+
+    Args:
+        wf_dict: WFDict to tally word in.
+        word: Word to be tallied."""
+    if word:
+        try:
+            wf_dict[word] += 1
+        except KeyError:
+            wf_dict[word] = 1

--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -476,9 +476,12 @@ class WordFrequencyDialog(ToplevelDialog):
             start.col += 1
         else:
             start = maintext().start()
+        # Special handling for newline characters (displayed as RETURN_ARROW)
+        match_word = re.sub(RETURN_ARROW, "\n", word) if RETURN_ARROW in word else word
+
         # Generally want "wholeword" search, but not for character count or marked-up phrases
         match = maintext().find_match(
-            word,
+            match_word,
             IndexRange(start, maintext().end()),
             nocase=self.ignore_case.get(),
             regexp=False,
@@ -502,8 +505,11 @@ class WordFrequencyDialog(ToplevelDialog):
         self.text.select_line(entry_index + 1)
         word = self.entries[entry_index].word
 
+        # Special handling for newline characters (displayed as RETURN_ARROW)
+        match_word = re.sub(RETURN_ARROW, "\n", word) if RETURN_ARROW in word else word
+
         dlg = SearchDialog.show_dialog()
-        dlg.search_box_set(word)
+        dlg.search_box_set(match_word)
         SearchDialog.matchcase.set(not WordFrequencyDialog.ignore_case.get())
         SearchDialog.wholeword.set(self.whole_word_search(word))
         SearchDialog.regex.set(False)
@@ -796,7 +802,7 @@ def wf_populate_markedup(wf_dialog: WordFrequencyDialog) -> None:
             unmarked_search,
             IndexRange(maintext().start(), maintext().end()),
             nocase=False,
-            regexp=True,
+            regexp=False,
             wholeword=True,
         )
         unmarked_count = len(matches) - marked_count


### PR DESCRIPTION
1. Implement all WF display types as per GG1, except for "Check Spelling" (use normal spell check), "Unicode > FF" (no longer needed - chars shown in Character Count), "Stealtho Check" (use normal Stealtho feature - NYI), "Check , Upper" & "Check . lower" (they aren't WF checks, just normal checks - NYI)
2. Left click to go to word: first time clicking a word will go to the first occurrence in the file; subsequent clicks will go to the next occurrence, etc. Clicking on a new word resets to starting from the beginning of the file again (similar to GG1 behavior, though there it requires double-click).
3. Right click to pop Search dialog with the word already entered.
4. Also, increase pylint's idea of how much code needs to be similar before reporting it as duplicate from 4 lines to 6. The previous value was too small - it was reporting something like the following occurring in 2 places:
```python
try:
    my_func()
except ValueError:
    return None
```