### PR TITLE
Status bar improvements

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -479,6 +479,11 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             "page label", "<ButtonRelease-3>", self.show_page_details_dialog
         )
 
+        the_statusbar.add("languages label", text="Lang: ")
+        the_statusbar.add_binding(
+            "languages label", "<ButtonRelease-1>", self.file.set_languages
+        )
+
         def ordinal_str() -> str:
             """Format ordinal of char at current insert index for statusbar."""
             char = maintext().get(maintext().get_insert_index().index())
@@ -491,11 +496,6 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             return f"U+{ord(char):04x}: {name}"
 
         the_statusbar.add("ordinal", update=ordinal_str)
-
-        the_statusbar.add("languages label", text="Lang: ")
-        the_statusbar.add_binding(
-            "languages label", "<ButtonRelease-1>", self.file.set_languages
-        )
 
     def logging_init(self) -> None:
         """Set up basic logger until GUI is ready."""

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -479,6 +479,27 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             "page label", "<ButtonRelease-3>", self.show_page_details_dialog
         )
 
+        def selection_str() -> str:
+            """Format current selection range for statusbar.
+
+            Returns:
+                "Start-End" for a regualar selection, and "R:rows C:cols" for column selection.
+            """
+            ranges = maintext().selected_ranges()
+            maintext().save_selection_ranges()
+            if not ranges:
+                return "No selection"
+            if len(ranges) == 1:
+                return f"{ranges[0].start.index()}-{ranges[-1].end.index()}"
+            row_diff = abs(ranges[-1].end.row - ranges[0].start.row) + 1
+            col_diff = abs(ranges[-1].end.col - ranges[0].start.col)
+            return f"R:{row_diff} C:{col_diff}"
+
+        the_statusbar.add("selection", update=selection_str, width=16)
+        the_statusbar.add_binding(
+            "selection", "<ButtonRelease-1>", maintext().restore_selection_ranges
+        )
+
         the_statusbar.add("languages label", text="Lang: ")
         the_statusbar.add_binding(
             "languages label", "<ButtonRelease-1>", self.file.set_languages

--- a/src/guiguts/utilities.py
+++ b/src/guiguts/utilities.py
@@ -135,6 +135,12 @@ class IndexRowCol:
         """Return row, col tuple."""
         return self.row, self.col
 
+    def __eq__(self, other: object) -> bool:
+        """Override equality test to check row and col."""
+        if not isinstance(other, IndexRowCol):
+            return NotImplemented
+        return (self.row, self.col) == (other.row, other.col)
+
 
 class IndexRange:
     """Class to store/manipulate a Text range defined by two indexes.
@@ -170,6 +176,12 @@ class IndexRange:
         else:
             assert isinstance(start, IndexRowCol)
             self.end = end
+
+    def __eq__(self, other: object) -> bool:
+        """Override equality test to check start and end of range."""
+        if not isinstance(other, IndexRange):
+            return NotImplemented
+        return (self.start, self.end) == (other.start, other.end)
 
 
 # Store callback that sounds bell, and provide function to call it.


### PR DESCRIPTION
1. Put "ordinal" at the end so its length-changes don't make everything else jump around.
2. Add "current selection" label to status bar
3. Show range, e.g. "12.5-13.8", for regular selection.
4. Show rows/cols, e.g. "R:3 C:6", for column selection.
5. Click on label to revert to previous selection.

Due to the issue of drag selection consisting of several selections of increasing length, and we don't want these to fill the previous selection slot, we only store previous selection if both the start and end of the selection are different to the previous ones. This will work in almost every real-life circumstance, and I can't find a reasonable way to avoid it. I investigated whether it was possible to detect if the mouse button was pressed (not easily without interfering with existing click/double-click functionality) and if it was possible to override every method of doing a selection (possible, but lots of code to write, attempting to mimic native widget behavior, which is not written in Python) and if it was possible to use the `<<Selection>>` event (no, because of drag selection generating several of these).