### PR TITLE
Icon focus

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -382,7 +382,7 @@ class CheckerDialog(ToplevelDialog):
             start = maintext().index(self._mark_from_rowcol(entry.text_range.start))
             end = maintext().index(self._mark_from_rowcol(entry.text_range.end))
             maintext().do_select(IndexRange(start, end))
-            maintext().set_insert_index(IndexRowCol(start), focus=False)
+            maintext().set_insert_index(IndexRowCol(start), focus=not is_mac())
         self.lift()
 
     def highlight_entry(self, entry_index: int) -> None:

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -6,6 +6,7 @@ from typing import Any, Optional, Callable
 
 from guiguts.maintext import maintext
 from guiguts.mainwindow import ScrolledReadOnlyText
+from guiguts.root import root
 from guiguts.utilities import IndexRowCol, IndexRange, is_mac
 from guiguts.widgets import ToplevelDialog, TlDlg
 
@@ -376,6 +377,8 @@ class CheckerDialog(ToplevelDialog):
         self.text.focus_set()
         entry = self.entries[entry_index]
         if entry.text_range is not None:
+            if root().state() == "iconic":
+                root().deiconify()
             start = maintext().index(self._mark_from_rowcol(entry.text_range.start))
             end = maintext().index(self._mark_from_rowcol(entry.text_range.end))
             maintext().do_select(IndexRange(start, end))

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -7,6 +7,7 @@ from typing import Any, Optional, TypeVar
 import regex as re
 
 from guiguts.preferences import preferences
+from guiguts.utilities import is_windows
 
 NUM_HISTORY = 10
 
@@ -275,10 +276,10 @@ def grab_focus(
     Args:
         toplevel: Toplevel widget to receive focus
         focus_widget: Optional widget within the toplevel tree to take keyboard focus
-        icon_deicon: True if iconify/deiconify hack required
+        icon_deicon: True if iconify/deiconify Windows hack required
     """
     toplevel.lift()
-    if icon_deicon:
+    if icon_deicon and is_windows():
         toplevel.iconify()
         toplevel.deiconify()
     toplevel.focus_force()


### PR DESCRIPTION
If entry in checker dialog is selected, then ensure main window is deiconified (but not force-focused)

Because "deiconify" does not work on (some) X-based systems, and may not be needed on macOS, make the iconify/deiconify hack when the program starts, specific to Windows.

Also, when clicking on a checker dialog message, macOS users would expect focus to remain on the checker dialog, but other users would find it helpful to focus on the main window, so make that OS-specific too.

Fixes [#180](https://github.com/DistributedProofreaders/guiguts-py/issues/180)
