### PR TITLE
Update manual page link

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -244,7 +244,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
 
     def show_help_manual(self) -> None:
         """Display the manual."""
-        webbrowser.open("https://www.pgdp.net/wiki/PPTools/Guiguts/Guiguts_Manual")
+        webbrowser.open("https://www.pgdp.net/wiki/PPTools/Guiguts/Guiguts_2_Manual")
 
     def initialize_preferences(self) -> None:
         """Set default preferences and load settings from the GGPrefs file."""


### PR DESCRIPTION
Help -> Guiguts Manual now links to a placeholder for the top level of the GG2 manual, rather than the GG1 manual.

No real point in beginning work on the manual yet since things are still too fluid for screenshots and detailed text.