### PR TITLE
Implement tooltips

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -464,7 +464,11 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             row, col = maintext().get_insert_index().rowcol()
             return f"L:{row} C:{col}"
 
-        the_statusbar.add("rowcol", update=rowcol_str)
+        the_statusbar.add(
+            "rowcol",
+            tooltip="Left click: Go to line\nRight click: Toggle line numbers",
+            update=rowcol_str,
+        )
         the_statusbar.add_binding("rowcol", "ButtonRelease-1", self.file.goto_line)
         the_statusbar.add_binding(
             "rowcol", "ButtonRelease-3", maintext().toggle_line_numbers
@@ -472,14 +476,20 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
 
         the_statusbar.add(
             "img",
+            tooltip="Left click: Go to image",
             update=lambda: "Img: " + self.file.get_current_image_name(),
         )
         the_statusbar.add_binding("img", "ButtonRelease-1", self.file.goto_image)
 
-        the_statusbar.add("prev img", text="<", width=1)
+        the_statusbar.add("prev img", tooltip="Previous image", text="<", width=1)
         the_statusbar.add_binding("prev img", "ButtonRelease-1", self.file.prev_page)
 
-        the_statusbar.add("see img", text="See Img", width=9)
+        the_statusbar.add(
+            "see img",
+            tooltip="Left click: See image\nDouble click: Toggle auto-image\nRight click: Choose scans folder",
+            text="See Img",
+            width=9,
+        )
         the_statusbar.add_binding(
             "see img",
             "ButtonRelease-1",
@@ -490,11 +500,12 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         )
         the_statusbar.add_binding("see img", "Double-Button-1", self.toggle_auto_image)
 
-        the_statusbar.add("next img", text=">", width=1)
+        the_statusbar.add("next img", tooltip="Next image", text=">", width=1)
         the_statusbar.add_binding("next img", "ButtonRelease-1", self.file.next_page)
 
         the_statusbar.add(
             "page label",
+            tooltip="Left click: Go to page\nRight click: Configure page labels",
             text="Lbl: ",
             update=lambda: "Lbl: " + self.file.get_current_page_label(),
         )
@@ -519,12 +530,19 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             col_diff = abs(ranges[-1].end.col - ranges[0].start.col)
             return f"R:{row_diff} C:{col_diff}"
 
-        the_statusbar.add("selection", update=selection_str, width=16)
+        the_statusbar.add(
+            "selection",
+            tooltip="Left click: Restore previous selection",
+            update=selection_str,
+            width=16,
+        )
         the_statusbar.add_binding(
             "selection", "ButtonRelease-1", maintext().restore_selection_ranges
         )
 
-        the_statusbar.add("languages label", text="Lang: ")
+        the_statusbar.add(
+            "languages label", tooltip="Left click: Set language(s)", text="Lang: "
+        )
         the_statusbar.add_binding(
             "languages label", "ButtonRelease-1", self.file.set_languages
         )
@@ -540,7 +558,9 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
                 name = "LINE FEED" if char == "\n" else ""
             return f"U+{ord(char):04x}: {name}"
 
-        the_statusbar.add("ordinal", update=ordinal_str)
+        the_statusbar.add(
+            "ordinal", tooltip="Character after the cursor", update=ordinal_str
+        )
 
     def logging_init(self) -> None:
         """Set up basic logger until GUI is ready."""

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -22,7 +22,7 @@ from guiguts.utilities import (
     process_label,
     IndexRowCol,
 )
-from guiguts.widgets import ToplevelDialog, mouse_bind
+from guiguts.widgets import ToplevelDialog, mouse_bind, ToolTip
 
 logger = logging.getLogger(__package__)
 
@@ -422,7 +422,11 @@ class StatusBar(ttk.Frame):
         self._update()
 
     def add(
-        self, key: str, update: Optional[Callable[[], str]] = None, **kwargs: Any
+        self,
+        key: str,
+        tooltip: str = "",
+        update: Optional[Callable[[], str]] = None,
+        **kwargs: Any,
     ) -> None:
         """Add field to status bar
 
@@ -436,6 +440,8 @@ class StatusBar(ttk.Frame):
         self.fields[key] = ttk.Button(self, takefocus=0, **kwargs)
         self.callbacks[key] = update
         self.fields[key].grid(column=len(self.fields), row=0)
+        if tooltip:
+            ToolTip(self.fields[key], msg=tooltip)
 
     def set(self, key: str, value: str) -> None:
         """Set field in statusbar to given value.

--- a/src/guiguts/page_details.py
+++ b/src/guiguts/page_details.py
@@ -135,6 +135,7 @@ class PageDetailsDialog(OkCancelDialog):
         ToolTip(
             self.list,
             "Click in style column to cycle Arabic/Roman/Ditto\nClick in number column to cycle +1/No Count/Set Number",
+            use_pointer_pos=True,
         )
         for col, column in enumerate(columns):
             self.list.column(

--- a/src/guiguts/page_details.py
+++ b/src/guiguts/page_details.py
@@ -6,7 +6,7 @@ from tkinter import simpledialog, ttk
 import roman  # type: ignore[import-untyped]
 
 from guiguts.maintext import maintext
-from guiguts.widgets import OkCancelDialog, mouse_bind
+from guiguts.widgets import OkCancelDialog, mouse_bind, ToolTip
 
 STYLE_COLUMN = "#2"
 STYLE_ARABIC = "Arabic"
@@ -131,6 +131,10 @@ class PageDetailsDialog(OkCancelDialog):
         widths = (50, 80, 80, 120)
         self.list = ttk.Treeview(
             master, columns=columns, show="headings", height=10, selectmode=tk.BROWSE
+        )
+        ToolTip(
+            self.list,
+            "Click in style column to cycle Arabic/Roman/Ditto\nClick in number column to cycle +1/No Count/Set Number",
         )
         for col, column in enumerate(columns):
             self.list.column(

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -372,18 +372,6 @@ class ToolTip(tk.Toplevel):
             ):
                 y_pos = self.widget.winfo_rooty() - self.height
         self.geometry(f"+{x_pos}+{y_pos}")
-        print(
-            f"tooltip: geom: +{x_pos}+{y_pos}, size: {self.width}x{self.height}",
-            flush=True,
-        )
-        print(
-            f"widget: pos: {self.widget.winfo_rootx()},{self.widget.winfo_rootx()}, size: {self.widget.winfo_width()}x{self.widget.winfo_height()}",
-            flush=True,
-        )
-        print(
-            f"widget_tl: pos: {self.widget_tl.winfo_rootx()},{self.widget_tl.winfo_rootx()}, size: {self.widget_tl.winfo_width()}x{self.widget_tl.winfo_height()}",
-            flush=True,
-        )
         self.deiconify()
 
     def destroy(self) -> None:

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -350,6 +350,22 @@ class ToolTip(tk.Toplevel):
         ):
             y_pos = self.widget.winfo_rooty() - self.height
         self.geometry(f"+{x_pos}+{y_pos}")
+        print(
+            f"tooltip: geom: +{x_pos}+{y_pos}, size: {self.width}x{self.height}",
+            flush=True,
+        )
+        print(
+            f"widget: pos: {self.widget.winfo_rootx()},{self.widget.winfo_rootx()}, size: {self.widget.winfo_width()}x{self.widget.winfo_height()}",
+            flush=True,
+        )
+        print(
+            f"widget_tl: pos: {self.widget_tl.winfo_rootx()},{self.widget_tl.winfo_rootx()}, size: {self.widget_tl.winfo_width()}x{self.widget_tl.winfo_height()}",
+            flush=True,
+        )
+        print(
+            f"screen: {self.winfo_screenwidth()}x{self.winfo_screenheight()}\n",
+            flush=True,
+        )
         self.deiconify()
 
     def destroy(self) -> None:

--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -25,7 +25,7 @@ from guiguts.utilities import (
     sound_bell,
     process_accel,
 )
-from guiguts.widgets import ToplevelDialog, Combobox, mouse_bind
+from guiguts.widgets import ToplevelDialog, Combobox, ToolTip, mouse_bind
 
 _the_word_lists = None  # pylint: disable=invalid-name
 
@@ -347,6 +347,10 @@ class WordFrequencyDialog(ToplevelDialog):
         )
         self.threshold_box.grid(row=0, column=1, sticky="NSEW", padx=(0, 5))
         self.threshold_box.display_latest_value()
+        ToolTip(
+            self.threshold_box,
+            "Only show marked up phrases with no more than this number of words",
+        )
 
         def display_markedup(*_args: Any) -> None:
             """Callback to display the marked up words with new threshold value."""
@@ -359,6 +363,7 @@ class WordFrequencyDialog(ToplevelDialog):
         display_radio(4, 0, "Regular Expression", WFDisplayType.REGEXP)
         self.regex_box = Combobox(display_frame, PrefKey.WFDIALOGREGEX)
         self.regex_box.grid(row=4, column=1, columnspan=2, sticky="NSEW", padx=(0, 5))
+        ToolTip(self.regex_box, "Only show words matching this regular expression")
 
         def display_regexp(*_args: Any) -> None:
             """Callback to display the regex-matching words with new regex."""


### PR DESCRIPTION
1. Default tooltip position is centered below widget
2. If tooltip would extend off the left or right of screen, it is kept on screen by shifting it right or left.
3. If tooltip would extend below bottom of the mainwindow or dialog that contains the widget, then tooltip is centered above widget instead of below.
4. Accepts string which can contain newline characters for multi-line tooltip.
5. Added to status bar items and to the page details dialog which is accessed by right-clicking the "Lbl" button in the status bar.
6. Other tooltips will be added as new features are added.