### PR TITLE
Close dialogs when file is closed or opened

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -123,6 +123,13 @@ class CheckerDialog(ToplevelDialog):
         self.mark_prefix = self.__class__.__name__.removesuffix("Dialog")
         self.reset()
 
+        def delete_dialog() -> None:
+            """Call its reset method, then destroy the dialog"""
+            self.reset()
+            self.destroy()
+
+        self.wm_protocol("WM_DELETE_WINDOW", delete_dialog)
+
     @classmethod
     def show_dialog(
         cls: type[TlDlg],
@@ -145,7 +152,8 @@ class CheckerDialog(ToplevelDialog):
         self.entries: list[CheckerEntry] = []
         self.count_linked_entries = 0  # Not the same as len(self.entries)
         self.update_count_label()
-        self.text.delete("1.0", tk.END)
+        if self.text.winfo_exists():
+            self.text.delete("1.0", tk.END)
         for mark in maintext().mark_names():
             if mark.startswith(self.mark_prefix):
                 maintext().mark_unset(mark)
@@ -200,9 +208,10 @@ class CheckerDialog(ToplevelDialog):
 
     def update_count_label(self) -> None:
         """Update the label showing how many linked entries are in dialog."""
-        self.count_label["text"] = sing_plur(
-            self.count_linked_entries, "Entry", "Entries"
-        )
+        if self.count_label.winfo_exists():
+            self.count_label["text"] = sing_plur(
+                self.count_linked_entries, "Entry", "Entries"
+            )
 
     def select_entry_by_click(self, event: tk.Event) -> str:
         """Select clicked line in dialog, and jump to the line in the

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -29,7 +29,7 @@ from guiguts.utilities import (
     IndexRange,
     sound_bell,
 )
-from guiguts.widgets import grab_focus
+from guiguts.widgets import grab_focus, ToplevelDialog
 
 logger = logging.getLogger(__package__)
 
@@ -134,11 +134,14 @@ class File:
         spell_check_clear_dictionary()
 
     def reset(self) -> None:
-        """Reset file internals to defaults, e.g. filename, page markers, etc"""
+        """Reset file internals to defaults, e.g. filename, page markers, etc.
+
+        Also close any open dialogs, since they will refer to the previous file."""
         self.filename = ""
         self.image_dir = ""
         self.remove_page_marks()
         self.page_details = PageDetails()
+        ToplevelDialog.close_all()
 
     def open_file(self, filename: str = "") -> str:
         """Open and load a text file.

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -151,6 +151,21 @@ class ToplevelDialog(tk.Toplevel):
             return ToplevelDialog._toplevel_dialogs[dlg_name]  # type: ignore[return-value]
         return None
 
+    def reset(self) -> None:
+        """Reset the dialog, including tidying up when it is closed.
+
+        Can be overridden if derived dialog creates marks, tags, etc., that need removing.
+        """
+
+    @classmethod
+    def close_all(cls) -> None:
+        """Close all open ToplevelDialogs."""
+        for dlg in ToplevelDialog._toplevel_dialogs.values():
+            if dlg.winfo_exists():
+                dlg.destroy()
+                dlg.reset()
+        ToplevelDialog._toplevel_dialogs.clear()
+
     def _do_config(self) -> None:
         """Configure the geometry of the ToplevelDialog.
 

--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -387,6 +387,8 @@ class WordFrequencyDialog(ToplevelDialog):
     def reset(self) -> None:
         """Reset dialog."""
         self.entries: list[WordFrequencyEntry] = []
+        if not self.winfo_exists():
+            return
         self.text.delete("1.0", tk.END)
         self.message.set("")
 


### PR DESCRIPTION
If any dialogs are popped, close them when user loads a new text file, or closes the current one.

This work revealed that the marks that are created in the main text window by checker dialogs like find all, etc., were being left behind. If there were several thousand of these, then once all the text was deleted when the file was closed and/or a new one re-loaded, all those marks ended up on the first line, and the Text widget choked. Now dialogs can have a reset method that cleans up after them, and it is called when the dialog is destroyed.

Fixes #203
Fixes #200