### PR TITLE
Centralize most of the mouse binding

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -465,46 +465,42 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             return f"L:{row} C:{col}"
 
         the_statusbar.add("rowcol", update=rowcol_str)
-        the_statusbar.add_binding("rowcol", "<ButtonRelease-1>", self.file.goto_line)
+        the_statusbar.add_binding("rowcol", "ButtonRelease-1", self.file.goto_line)
         the_statusbar.add_binding(
-            "rowcol", "<ButtonRelease-3>", maintext().toggle_line_numbers
+            "rowcol", "ButtonRelease-3", maintext().toggle_line_numbers
         )
 
         the_statusbar.add(
             "img",
             update=lambda: "Img: " + self.file.get_current_image_name(),
         )
-        the_statusbar.add_binding("img", "<ButtonRelease-1>", self.file.goto_image)
+        the_statusbar.add_binding("img", "ButtonRelease-1", self.file.goto_image)
 
         the_statusbar.add("prev img", text="<", width=1)
-        the_statusbar.add_binding("prev img", "<ButtonRelease-1>", self.file.prev_page)
+        the_statusbar.add_binding("prev img", "ButtonRelease-1", self.file.prev_page)
 
         the_statusbar.add("see img", text="See Img", width=9)
         the_statusbar.add_binding(
             "see img",
-            "<ButtonRelease-1>",
+            "ButtonRelease-1",
             self.show_image,
         )
         the_statusbar.add_binding(
-            "see img", "<ButtonRelease-3>", self.file.choose_image_dir
+            "see img", "ButtonRelease-3", self.file.choose_image_dir
         )
-        the_statusbar.add_binding(
-            "see img", "<Double-Button-1>", self.toggle_auto_image
-        )
+        the_statusbar.add_binding("see img", "Double-Button-1", self.toggle_auto_image)
 
         the_statusbar.add("next img", text=">", width=1)
-        the_statusbar.add_binding("next img", "<ButtonRelease-1>", self.file.next_page)
+        the_statusbar.add_binding("next img", "ButtonRelease-1", self.file.next_page)
 
         the_statusbar.add(
             "page label",
             text="Lbl: ",
             update=lambda: "Lbl: " + self.file.get_current_page_label(),
         )
+        the_statusbar.add_binding("page label", "ButtonRelease-1", self.file.goto_page)
         the_statusbar.add_binding(
-            "page label", "<ButtonRelease-1>", self.file.goto_page
-        )
-        the_statusbar.add_binding(
-            "page label", "<ButtonRelease-3>", self.show_page_details_dialog
+            "page label", "ButtonRelease-3", self.show_page_details_dialog
         )
 
         def selection_str() -> str:
@@ -525,12 +521,12 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
 
         the_statusbar.add("selection", update=selection_str, width=16)
         the_statusbar.add_binding(
-            "selection", "<ButtonRelease-1>", maintext().restore_selection_ranges
+            "selection", "ButtonRelease-1", maintext().restore_selection_ranges
         )
 
         the_statusbar.add("languages label", text="Lang: ")
         the_statusbar.add_binding(
-            "languages label", "<ButtonRelease-1>", self.file.set_languages
+            "languages label", "ButtonRelease-1", self.file.set_languages
         )
 
         def ordinal_str() -> str:

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -8,7 +8,7 @@ from guiguts.maintext import maintext
 from guiguts.mainwindow import ScrolledReadOnlyText
 from guiguts.root import root
 from guiguts.utilities import IndexRowCol, IndexRange, is_mac, sing_plur
-from guiguts.widgets import ToplevelDialog, TlDlg
+from guiguts.widgets import ToplevelDialog, TlDlg, mouse_bind
 
 MARK_REMOVED_ENTRY = "MarkRemovedEntry"
 HILITE_TAG_NAME = "chk_hilite"
@@ -73,49 +73,20 @@ class CheckerDialog(ToplevelDialog):
         )
         self.text.grid(column=0, row=1, sticky="NSEW")
 
-        self.text.bind("<1>", self.select_entry_by_click)
-        # On Mac, equivalent of mouse button 3 is button 2 (2-button mice) or
-        # Control with button 1 (1 button mice), so 2 bindings per function
-        if is_mac():
-            self.text.bind("<2>", self.remove_entry_by_click)
-            self.text.bind("<Control-1>", self.remove_entry_by_click)
-            self.text.bind(
-                "<Shift-2>",
-                lambda event: self.remove_entry_by_click(event, all_matching=True),
-            )
-            self.text.bind(
-                "<Shift-Control-1>",
-                lambda event: self.remove_entry_by_click(event, all_matching=True),
-            )
-            self.text.bind("<Command-1>", self.process_entry_by_click)
-            self.text.bind("<Command-2>", self.process_remove_entry_by_click)
-            self.text.bind("<Command-Control-1>", self.process_remove_entry_by_click)
-            self.text.bind(
-                "<Shift-Command-2>",
-                lambda event: self.process_remove_entry_by_click(
-                    event, all_matching=True
-                ),
-            )
-            self.text.bind(
-                "<Shift-Command-Control-1>",
-                lambda event: self.process_remove_entry_by_click(
-                    event, all_matching=True
-                ),
-            )
-        else:
-            self.text.bind("<3>", self.remove_entry_by_click)
-            self.text.bind(
-                "<Shift-3>",
-                lambda event: self.remove_entry_by_click(event, all_matching=True),
-            )
-            self.text.bind("<Control-1>", self.process_entry_by_click)
-            self.text.bind("<Control-3>", self.process_remove_entry_by_click)
-            self.text.bind(
-                "<Shift-Control-3>",
-                lambda event: self.process_remove_entry_by_click(
-                    event, all_matching=True
-                ),
-            )
+        mouse_bind(self.text, "1", self.select_entry_by_click)
+        mouse_bind(self.text, "3", self.remove_entry_by_click)
+        mouse_bind(
+            self.text,
+            "Shift+3",
+            lambda event: self.remove_entry_by_click(event, all_matching=True),
+        )
+        mouse_bind(self.text, "Cmd/Ctrl+1", self.process_entry_by_click)
+        mouse_bind(self.text, "Cmd/Ctrl+3", self.process_remove_entry_by_click)
+        mouse_bind(
+            self.text,
+            "Shift+Cmd/Ctrl+3",
+            lambda event: self.process_remove_entry_by_click(event, all_matching=True),
+        )
 
         self.process_command = process_command
         self.text.tag_configure(HILITE_TAG_NAME, foreground="#2197ff")

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -10,7 +10,6 @@ from tkinter import ttk, messagebox
 from typing import Any, Callable, Optional
 
 from PIL import Image, ImageTk
-import regex as re
 
 from guiguts.maintext import MainText, maintext
 from guiguts.preferences import preferences, PrefKey
@@ -23,7 +22,7 @@ from guiguts.utilities import (
     process_label,
     IndexRowCol,
 )
-from guiguts.widgets import ToplevelDialog
+from guiguts.widgets import ToplevelDialog, mouse_bind
 
 logger = logging.getLogger(__package__)
 
@@ -702,27 +701,6 @@ class MainWindow:
         mainimage().clear_image()
 
 
-def mouse_bind(
-    widget: tk.Widget, event: str, callback: Callable[[tk.Event], object]
-) -> None:
-    """Bind mouse button callback to event on widget.
-
-    If binding is to mouse button 2 or 3, also bind the other button
-    to support all platforms and 2-button mice.
-
-    Args:
-        widget: Widget to bind to
-        event: Event string to trigger callback
-        callback: Function to be called when event occurs
-    """
-    widget.bind(event, callback)
-
-    if match := re.match(r"(<.*Button.*)([23])(>)", event):
-        other_button = "2" if match.group(2) == "3" else "3"
-        other_event = match.group(1) + other_button + match.group(3)
-        widget.bind(other_event, callback)
-
-
 def do_sound_bell() -> None:
     """Sound warning bell audibly and/or visually.
 
@@ -775,11 +753,7 @@ def add_text_context_menu(text_widget: tk.Text, read_only: bool = False) -> None
         event.widget.focus_set()
         menu_context.post(event.x_root, event.y_root)
 
-    if is_mac():
-        text_widget.bind("<2>", post_context_menu)
-        text_widget.bind("<Control-1>", post_context_menu)
-    else:
-        text_widget.bind("<3>", post_context_menu)
+    mouse_bind(text_widget, "3", post_context_menu)
 
 
 def mainimage() -> MainImage:

--- a/src/guiguts/page_details.py
+++ b/src/guiguts/page_details.py
@@ -6,7 +6,7 @@ from tkinter import simpledialog, ttk
 import roman  # type: ignore[import-untyped]
 
 from guiguts.maintext import maintext
-from guiguts.widgets import OkCancelDialog
+from guiguts.widgets import OkCancelDialog, mouse_bind
 
 STYLE_COLUMN = "#2"
 STYLE_ARABIC = "Arabic"
@@ -142,7 +142,7 @@ class PageDetailsDialog(OkCancelDialog):
             )
             self.list.heading(f"#{col + 1}", text=column)
 
-        self.list.bind("<ButtonRelease-1>", self.item_clicked)
+        mouse_bind(self.list, "1", self.item_clicked)
         self.list.grid(row=0, column=0, sticky=tk.NSEW)
 
         self.scrollbar = ttk.Scrollbar(

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -18,7 +18,7 @@ from guiguts.utilities import (
     is_mac,
     sing_plur,
 )
-from guiguts.widgets import ToplevelDialog, Combobox
+from guiguts.widgets import ToplevelDialog, Combobox, mouse_bind
 
 logger = logging.getLogger(__package__)
 
@@ -100,8 +100,9 @@ class SearchDialog(ToplevelDialog):
             command=self.search_clicked,
         )
         search_button.grid(row=0, column=1, pady=(5, 0), sticky="NSEW")
-        search_button.bind(
-            "<Shift-Button-1>",
+        mouse_bind(
+            search_button,
+            "Shift+1",
             lambda *args: self.search_clicked(opposite_dir=True),
         )
         self.bind("<Return>", lambda *args: self.search_clicked())
@@ -178,8 +179,9 @@ class SearchDialog(ToplevelDialog):
             command=lambda *args: self.replace_clicked(search_again=True),
         )
         rands_button.grid(row=0, column=0, padx=(0, 2), pady=(2, 6), sticky="NSEW")
-        rands_button.bind(
-            "<Shift-Button-1>",
+        mouse_bind(
+            rands_button,
+            "Shift+1",
             lambda *args: self.replace_clicked(opposite_dir=True, search_again=True),
         )
         ttk.Button(

--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -25,7 +25,7 @@ from guiguts.utilities import (
     sound_bell,
     process_accel,
 )
-from guiguts.widgets import ToplevelDialog, Combobox
+from guiguts.widgets import ToplevelDialog, Combobox, mouse_bind
 
 _the_word_lists = None  # pylint: disable=invalid-name
 
@@ -375,7 +375,7 @@ class WordFrequencyDialog(ToplevelDialog):
             self.top_frame, context_menu=False, wrap=tk.NONE
         )
         self.text.grid(row=1, column=0, sticky="NSEW")
-        self.text.bind("<1>", self.goto_word)
+        mouse_bind(self.text, "1", self.goto_word)
         _, event = process_accel("Cmd/Ctrl+1")
         self.text.bind(event, self.search_word)
 


### PR DESCRIPTION
In particular this is to consolidate the need for Mouse-3 to be interpreted as Mouse-2 and Control-Mouse-1 on Macs. Previously, these were done in different places, and not all places did both bindings.

One place that may not have had support for Control+1 (one-button mouse equivalent of right-button) is popping the context menu in text widgets on Macs. May have got away with it through default Mac behavior.