### PR TITLE
Clear Count message when S/R dialog shown

### DIFF
--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -483,6 +483,7 @@ def show_search_dialog() -> None:
     to the selected text if any (up to first newline)."""
     dlg = SearchDialog.show_dialog()
     dlg.search_box_set(maintext().selected_text().split("\n", 1)[0])
+    dlg.display_message()
 
 
 def find_next(backwards: bool = False) -> None:

--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -558,6 +558,7 @@ class WordFrequencyDialog(ToplevelDialog):
         SearchDialog.matchcase.set(not WordFrequencyDialog.ignore_case.get())
         SearchDialog.wholeword.set(self.whole_word_search(word))
         SearchDialog.regex.set(False)
+        dlg.display_message()
 
         return "break"
 


### PR DESCRIPTION
Problem occurred when dialog was already visible, with a message showing, e.g. the latest Count, then was displayed "again" with a new word in it, either from a word selected in the main window, or from the WF dialog. In both cases, dialog message needed clearing.

Fixes #204 