### PR TITLE
Add sort options, etc to checker dialogs

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -10,7 +10,7 @@ from typing import Optional
 import unicodedata
 import webbrowser
 
-
+from guiguts.checkers import CheckerSortType
 from guiguts.file import File, NUM_RECENT_FILES
 from guiguts.maintext import maintext
 from guiguts.mainwindow import (
@@ -278,6 +278,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         preferences.set_default(PrefKey.WFDIALOGIGNORECASE, False)
         preferences.set_default(PrefKey.WFDIALOGDISPLAYTYPE, WFDisplayType.ALL_WORDS)
         preferences.set_default(PrefKey.WFDIALOGSORTTYPE, WFSortType.ALPHABETIC)
+        preferences.set_default(PrefKey.CHECKERDIALOGSORTTYPE, CheckerSortType.ROWCOL)
         preferences.set_default(PrefKey.WFDIALOGITALTHRESHOLD, ["4"])
         preferences.set_default(PrefKey.WFDIALOGREGEX, [])
         preferences.set_default(

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -1,36 +1,83 @@
 """Support running of checking tools"""
 
+from enum import Enum, StrEnum, auto
 import tkinter as tk
 from tkinter import ttk
 from typing import Any, Optional, Callable
 
 from guiguts.maintext import maintext
 from guiguts.mainwindow import ScrolledReadOnlyText
+from guiguts.preferences import PersistentString, PrefKey
 from guiguts.root import root
-from guiguts.utilities import IndexRowCol, IndexRange, is_mac, sing_plur
+from guiguts.utilities import (
+    IndexRowCol,
+    IndexRange,
+    is_mac,
+    sing_plur,
+)
 from guiguts.widgets import ToplevelDialog, TlDlg, mouse_bind
 
-MARK_REMOVED_ENTRY = "MarkRemovedEntry"
+MARK_ENTRY_TO_SELECT = "MarkEntryToSelect"
 HILITE_TAG_NAME = "chk_hilite"
+
+
+class CheckerEntryType(Enum):
+    """Enum class to store Checker Entry types."""
+
+    HEADER = auto()
+    CONTENT = auto()
+    FOOTER = auto()
 
 
 class CheckerEntry:
     """Class to hold one entry in the Checker dialog.
 
+    Current implementation enforces (on creation) and assumes (in use) that
+    no section contains Entries of more than one type.
+
     Attributes:
-        text: Single line of text to display in checker dialog.
-        text_range: Start and end of point of interest in main text widget.
+            text: Single line of text to display in checker dialog.
+            text_range: Optional start and end of point of interest in main text widget.
+            hilite_start: Optional column to begin higlighting entry in dialog.
+            hilite_end: Optional column to end higlighting entry in dialog.
+            section: Section entry belongs to.
+            initial_pos: Position of entry during initial creation.
     """
 
-    def __init__(self, text: str, text_range: Optional[IndexRange]) -> None:
+    def __init__(
+        self,
+        text: str,
+        text_range: Optional[IndexRange],
+        hilite_start: Optional[int],
+        hilite_end: Optional[int],
+        section: int,
+        initial_pos: int,
+        entry_type: CheckerEntryType,
+    ) -> None:
         """Initialize CheckerEntry object.
 
         Args:
             text: Single line of text to display in checker dialog.
             text_range: Optional start and end of point of interest in main text widget.
+            hilite_start: Optional column to begin higlighting entry in dialog.
+            hilite_end: Optional column to end higlighting entry in dialog.
+            section: Section entry belongs to.
+            initial_pos: Position of entry during initial creation.
         """
         self.text = text
         self.text_range = text_range
+        self.hilite_start = hilite_start
+        self.hilite_end = hilite_end
+        self.section = section
+        self.initial_pos = initial_pos
+        self.entry_type = entry_type
+
+
+class CheckerSortType(StrEnum):
+    """Enum class to store Checker Dialog sort types."""
+
+    ALPHABETIC = auto()
+    ROWCOL = auto()
 
 
 class CheckerDialog(ToplevelDialog):
@@ -42,11 +89,15 @@ class CheckerDialog(ToplevelDialog):
         count_label: Label showing how many linked entries there are in the dialog
     """
 
+    sort_type: PersistentString
+
     def __init__(
         self,
         title: str,
         rerun_command: Callable[[], None],
         process_command: Optional[Callable[[CheckerEntry], None]] = None,
+        sort_key_rowcol: Optional[Callable[[CheckerEntry], tuple]] = None,
+        sort_key_alpha: Optional[Callable[[CheckerEntry], tuple]] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the dialog.
@@ -56,23 +107,61 @@ class CheckerDialog(ToplevelDialog):
             rerun_command: Function to call to re-run the check.
             process_command: Function to call to "process" the current error, e.g. swap he/be
         """
+        # Initialize class variables on first instantiation, then remember
+        # values for subsequent uses of dialog.
+        try:
+            CheckerDialog.sort_type
+        except AttributeError:
+            CheckerDialog.sort_type = PersistentString(PrefKey.CHECKERDIALOGSORTTYPE)
+
         super().__init__(title, **kwargs)
         self.top_frame.rowconfigure(0, weight=0)
         self.header_frame = ttk.Frame(self.top_frame, padding=2)
         self.header_frame.grid(column=0, row=0, sticky="NSEW")
+
         self.header_frame.columnconfigure(0, weight=1)
-        self.count_label = ttk.Label(self.header_frame, text="No results")
+        left_frame = ttk.Frame(self.header_frame)
+        left_frame.grid(column=0, row=0, sticky="NSEW")
+        left_frame.columnconfigure(0, weight=1)
+        self.count_label = ttk.Label(left_frame, text="No results")
         self.count_label.grid(column=0, row=0, sticky="NSW")
+        ttk.Label(
+            left_frame,
+            text="Sort:",
+        ).grid(row=0, column=1, sticky="NSE", padx=5)
+        ttk.Radiobutton(
+            left_frame,
+            text="Line & Col",
+            command=self.display_entries,
+            variable=CheckerDialog.sort_type,
+            value=CheckerSortType.ROWCOL,
+            takefocus=False,
+        ).grid(row=0, column=2, sticky="NSE", padx=2)
+        ttk.Radiobutton(
+            left_frame,
+            text="Alpha/Type",
+            command=self.display_entries,
+            variable=CheckerDialog.sort_type,
+            value=CheckerSortType.ALPHABETIC,
+            takefocus=False,
+        ).grid(row=0, column=3, sticky="NSE", padx=2)
+
         self.rerun_button = ttk.Button(
             self.header_frame, text="Re-run", command=rerun_command
         )
         self.rerun_button.grid(column=1, row=0, sticky="NSE", padx=20)
+
         self.top_frame.rowconfigure(1, weight=1)
         self.text = ScrolledReadOnlyText(
             self.top_frame, context_menu=False, wrap=tk.NONE
         )
         self.text.grid(column=0, row=1, sticky="NSEW")
 
+        # 3 binary choices:
+        #     remove/not_remove (just select) - controlled by button 3 or button 1
+        #     process/not_process - controlled by Cmd/Ctrl pressed or not
+        #     match/not_match - controlled by Shift pressed or not
+        # Only 7 of the 8 possibilities needed, since "select not_process match" makes no sense
         mouse_bind(self.text, "1", self.select_entry_by_click)
         mouse_bind(self.text, "3", self.remove_entry_by_click)
         mouse_bind(
@@ -81,6 +170,11 @@ class CheckerDialog(ToplevelDialog):
             lambda event: self.remove_entry_by_click(event, all_matching=True),
         )
         mouse_bind(self.text, "Cmd/Ctrl+1", self.process_entry_by_click)
+        mouse_bind(
+            self.text,
+            "Shift+Cmd/Ctrl+1",
+            lambda event: self.process_entry_by_click(event, all_matching=True),
+        )
         mouse_bind(self.text, "Cmd/Ctrl+3", self.process_remove_entry_by_click)
         mouse_bind(
             self.text,
@@ -89,7 +183,13 @@ class CheckerDialog(ToplevelDialog):
         )
 
         self.process_command = process_command
+        self.rowcol_key = sort_key_rowcol or CheckerDialog.sort_key_rowcol
+        self.alpha_key = sort_key_alpha or CheckerDialog.sort_key_alpha
         self.text.tag_configure(HILITE_TAG_NAME, foreground="#2197ff")
+        self.count_linked_entries = 0  # Not the same as len(self.entries)
+        self.section_count = 0
+        self.selected_text = ""
+        self.selected_text_range: Optional[IndexRange] = None
         self.reset()
 
         def delete_dialog() -> None:
@@ -116,10 +216,90 @@ class CheckerDialog(ToplevelDialog):
         """
         return super().show_dialog(title, destroy, **kwargs)
 
+    @classmethod
+    def sort_key_rowcol(
+        cls,
+        entry: CheckerEntry,
+    ) -> tuple[int, int, int]:
+        """Default sort key function to sort entries by row/col.
+
+        Preserve entries in sections.
+        If header/footer, then preserve original order
+        If no row/col, place content lines before those with row/col
+        If row/col, sort by row, then col.
+        """
+        if entry.entry_type == CheckerEntryType.HEADER:
+            return (entry.section, entry.initial_pos, 0)
+        if entry.entry_type == CheckerEntryType.FOOTER:
+            return (entry.section, entry.initial_pos, 0)
+
+        # Content without row/col comes before content with, and preserves its original order
+        if entry.text_range is None:
+            return (entry.section, 0, entry.initial_pos)
+        # Content with row/col is ordered by row, then col
+        return (
+            entry.section,
+            entry.text_range.start.row,
+            entry.text_range.start.col,
+        )
+
+    @classmethod
+    def sort_key_alpha(
+        cls,
+        entry: CheckerEntry,
+    ) -> tuple[int, str, str, int, int]:
+        """Default sort key function to sort entries by text, putting identical upper
+            and lower case versions together.
+
+        If text is highlighted, use that, otherwise use whole line of text
+        Preserve entries in sections.
+        If header/footer, then preserve original order, putting header first & footer last.
+        Place text with no row/col before identical text with row/col.
+        """
+        # Force header before content, and footer after content (though should be
+        # unnecessary since in different sections) preserving original order
+        if entry.entry_type == CheckerEntryType.HEADER:
+            return (
+                entry.section,
+                "",
+                "",
+                0,
+                entry.initial_pos,
+            )
+        if entry.entry_type == CheckerEntryType.FOOTER:
+            return (
+                entry.section,
+                "\ufeff",
+                "\ufeff",
+                0,
+                entry.initial_pos,
+            )
+
+        # Get text for comparison
+        if entry.hilite_start is None:
+            text = entry.text
+        else:
+            text = entry.text[entry.hilite_start : entry.hilite_end]
+        text_low = text.lower()
+
+        # Content without row/col comes before identical content with row/col
+        if entry.text_range is None:
+            return (entry.section, text_low, text, 0, 0)
+        return (
+            entry.section,
+            text_low,
+            text,
+            entry.text_range.start.row,
+            entry.text_range.start.col,
+        )
+
     def reset(self) -> None:
         """Reset dialog and associated structures & marks."""
         self.entries: list[CheckerEntry] = []
-        self.count_linked_entries = 0  # Not the same as len(self.entries)
+        self.count_linked_entries = 0
+        self.section_count = 0
+        self.selected_text = ""
+        self.selected_text_range = None
         self.update_count_label()
         if self.text.winfo_exists():
             self.text.delete("1.0", tk.END)
@@ -127,39 +307,77 @@ class CheckerDialog(ToplevelDialog):
             if mark.startswith(self.get_mark_prefix()):
                 maintext().mark_unset(mark)
 
+    def new_section(self) -> None:
+        """Start a new section in the dialog.
+
+        When entries are sorted, entries within a section remain in the section.
+        It's not a problem if a section is empty.
+        """
+        self.section_count += 1
+
+    def _add_headfoot(self, hf_type: CheckerEntryType, *headfoot_lines: str) -> None:
+        """Internal method to add header or footer to dialog.
+
+        Args:
+            hf_type: Either header or footer type
+            headfoot_lines: Section header or footer (tuple, list, or string with newlines)
+        """
+        assert hf_type in (CheckerEntryType.HEADER, CheckerEntryType.FOOTER)
+        self.new_section()
+        if isinstance(headfoot_lines, str):
+            headfoot_lines = headfoot_lines.split("\n")
+        for line in headfoot_lines:
+            self.add_entry(line, None, None, None, hf_type)
+        self.new_section()
+
+    def add_header(self, *header_lines: str) -> None:
+        """Add header to dialog.
+
+        Args:
+            header_lines: strings to add as header lines (strings may contain newlines)
+        """
+        self._add_headfoot(CheckerEntryType.HEADER, *header_lines)
+
+    def add_footer(self, *footer_lines: str) -> None:
+        """Add footer to dialog.
+
+        Args:
+            footer_lines: strings to add as footer lines (strings may contain newlines)
+        """
+        self._add_headfoot(CheckerEntryType.FOOTER, *footer_lines)
+
     def add_entry(
         self,
         msg: str,
         text_range: Optional[IndexRange] = None,
         hilite_start: Optional[int] = None,
         hilite_end: Optional[int] = None,
+        entry_type: CheckerEntryType = CheckerEntryType.CONTENT,
     ) -> None:
-        """Add an entry to the dialog.
+        """Add an entry ready to be displayed in the dialog.
 
-        Also set marks in main text at locations of start & end of point of interest
+        Also set marks in main text at locations of start & end of point of interest.
+        Use this for content; use add_header & add_footer for headers & footers.
 
         Args:
-            msg: Entry to display in the dialog - only first line is displayed.
-            text_range: Optional Start & end of point of interest in main text widget.
+            msg: Entry to be displayed - only first line will be displayed.
+            text_range: Optional start & end of point of interest in main text widget.
             hilite_start: Optional column to begin higlighting entry in dialog.
             hilite_end: Optional column to end higlighting entry in dialog.
+            entry_type: Defaults to content
         """
         line = msg.splitlines()[0] if msg else ""
-        rowcol_str = ""
-        if text_range is not None:
-            rowcol_str = f"{text_range.start.row}.{text_range.start.col}: "
-            if text_range.start.col < 10:
-                rowcol_str += " "
-            self.count_linked_entries += 1
-
-        self.text.insert(tk.END, rowcol_str + line + "\n")
-        if hilite_start is not None and hilite_end is not None:
-            start_rowcol = IndexRowCol(self.text.index(tk.END + "-2line"))
-            start_rowcol.col = hilite_start + len(rowcol_str)
-            end_rowcol = IndexRowCol(start_rowcol.row, hilite_end + len(rowcol_str))
-            self.text.tag_add(HILITE_TAG_NAME, start_rowcol.index(), end_rowcol.index())
-        entry = CheckerEntry(line, text_range)
+        entry = CheckerEntry(
+            line,
+            text_range,
+            hilite_start,
+            hilite_end,
+            self.section_count,
+            len(self.entries),
+            entry_type,
+        )
         self.entries.append(entry)
+
         if text_range is not None:
             maintext().mark_set(
                 self.mark_from_rowcol(text_range.start), text_range.start.index()
@@ -167,12 +385,53 @@ class CheckerDialog(ToplevelDialog):
             maintext().mark_set(
                 self.mark_from_rowcol(text_range.end), text_range.end.index()
             )
-            # If none selected, select the first message with a text range
-            if self.current_entry_index() is None:
-                for index, entry in enumerate(self.entries):
-                    if entry.text_range:
-                        self.select_entry(index)
-                        break
+
+    def display_entries(self) -> None:
+        """Display all the stored entries in the dialog according to
+        the sort setting."""
+
+        sort_key: Callable[[CheckerEntry], tuple]
+        if CheckerDialog.sort_type.get() == CheckerSortType.ALPHABETIC:
+            sort_key = self.alpha_key
+        else:
+            sort_key = self.rowcol_key
+        self.entries.sort(key=sort_key)
+        self.text.delete("1.0", tk.END)
+        self.count_linked_entries = 0
+
+        for entry in self.entries:
+            rowcol_str = ""
+            if entry.text_range is not None:
+                rowcol_str = (
+                    f"{entry.text_range.start.row}.{entry.text_range.start.col}: "
+                )
+                if entry.text_range.start.col < 10:
+                    rowcol_str += " "
+                self.count_linked_entries += 1
+            self.text.insert(tk.END, rowcol_str + entry.text + "\n")
+            if entry.hilite_start is not None and entry.hilite_end is not None:
+                start_rowcol = IndexRowCol(self.text.index(tk.END + "-2line"))
+                start_rowcol.col = entry.hilite_start + len(rowcol_str)
+                end_rowcol = IndexRowCol(
+                    start_rowcol.row, entry.hilite_end + len(rowcol_str)
+                )
+                self.text.tag_add(
+                    HILITE_TAG_NAME, start_rowcol.index(), end_rowcol.index()
+                )
+        # Highlight previously selected line, or if none, the first suitable line
+        if self.selected_text:
+            for index, entry in enumerate(self.entries):
+                if (
+                    entry.text == self.selected_text
+                    and entry.text_range == self.selected_text_range
+                ):
+                    self.select_entry(index)
+                    break
+        else:
+            for index, entry in enumerate(self.entries):
+                if entry.text_range:
+                    self.select_entry(index)
+                    break
         self.update_count_label()
 
     def update_count_label(self) -> None:
@@ -199,7 +458,9 @@ class CheckerDialog(ToplevelDialog):
         self.select_entry(entry_index)
         return "break"
 
-    def process_entry_by_click(self, event: tk.Event) -> str:
+    def process_entry_by_click(
+        self, event: tk.Event, all_matching: bool = False
+    ) -> str:
         """Select clicked line in dialog, and jump to the line in the
         main text widget that corresponds to it. Finally call the
         "process" callback function, if any.
@@ -215,7 +476,7 @@ class CheckerDialog(ToplevelDialog):
         except IndexError:
             return "break"
         self.select_entry(entry_index)
-        self.process_entry_current()
+        self.process_entry_current(all_matching=all_matching)
         return "break"
 
     def remove_entry_by_click(self, event: tk.Event, all_matching: bool = False) -> str:
@@ -234,7 +495,7 @@ class CheckerDialog(ToplevelDialog):
         except IndexError:
             return "break"
         self.select_entry(entry_index)
-        self.remove_entry_current(all_matching)
+        self.remove_entry_current(all_matching=all_matching)
         return "break"
 
     def process_remove_entry_by_click(
@@ -257,8 +518,7 @@ class CheckerDialog(ToplevelDialog):
         except IndexError:
             return "break"
         self.select_entry(entry_index)
-        self.process_entry_current()
-        self.remove_entry_current(all_matching)
+        self.process_remove_entry_current(all_matching=all_matching)
         return "break"
 
     def entry_index_from_click(self, event: tk.Event) -> int:
@@ -278,57 +538,78 @@ class CheckerDialog(ToplevelDialog):
             raise IndexError
         return entry_index
 
-    def process_entry_current(self) -> None:
+    def process_remove_entries(
+        self, process: bool, remove: bool, all_matching: bool
+    ) -> None:
+        """Process and/or remove the current entry, if any.
+
+        Args:
+            process: If True, process the current entry.
+            remove: If True, remove the current entry.
+            all_matching: If True, repeat for all entries that have the same
+                message as the current entry (e.g. same spelling error).
+        """
+        entry_index = self.current_entry_index()
+        if entry_index is None:
+            return
+        # Mark before starting so location can be selected later
+        self.text.mark_set(MARK_ENTRY_TO_SELECT, f"{entry_index + 1}.0")
+        match_text = self.entries[entry_index].text
+        if all_matching:
+            # Work in reverse since may be deleting from list while iterating
+            indices = range(len(self.entries) - 1, -1, -1)
+        else:
+            indices = range(entry_index, entry_index + 1)
+        for ii in indices:
+            if self.entries[ii].text == match_text:
+                if process and self.process_command:
+                    self.process_command(self.entries[ii])
+                if remove:
+                    if self.entries[ii].text_range:
+                        self.count_linked_entries -= 1
+                    del self.entries[ii]
+                    self.text.delete(f"{ii + 1}.0", f"{ii + 2}.0")
+        self.update_count_label()
+        # Select line that is now where the first processed/removed line was
+        entry_rowcol = IndexRowCol(self.text.index(MARK_ENTRY_TO_SELECT))
+        entry_index = min(entry_rowcol.row - 1, len(self.entries) - 1)
+        if len(self.entries) > 0:
+            self.select_entry(entry_index)
+
+    def process_entry_current(self, all_matching: bool = False) -> None:
         """Call the "process" callback function, if any, on the
-        currently selected entry, if any."""
-        if self.process_command:
-            entry_index = self.current_entry_index()
-            if entry_index is not None:
-                self.process_command(self.entries[entry_index])
+        currently selected entry, if any.
+
+        Args:
+            all_matching: If True process all other entries that have the same
+                message as the chosen entry
+        """
+        self.process_remove_entries(
+            process=True, remove=False, all_matching=all_matching
+        )
 
     def remove_entry_current(self, all_matching: bool = False) -> None:
         """Remove the current entry, if any.
 
         Args:
             all_matching: If True remove all other entries that have the same
-                message as the chosen entry (e.g. same spelling error)
+                message as the chosen entry
         """
-        entry_index = self.current_entry_index()
-        if entry_index is not None:
-            # Mark before removing in case earlier entries get removed due to
-            # all_matching being True
-            self.text.mark_set(MARK_REMOVED_ENTRY, f"{entry_index + 1}.0")
-            del_text = self.entries[entry_index].text
-            if all_matching:
-                # Work in reverse since deleting from list while iterating
-                for ii in range(len(self.entries) - 1, -1, -1):
-                    if self.entries[ii].text == del_text:
-                        if self.entries[ii].text_range:
-                            self.count_linked_entries -= 1
-                        del self.entries[ii]
-                        self.text.delete(f"{ii + 1}.0", f"{ii + 2}.0")
-            else:
-                if self.entries[entry_index].text_range:
-                    self.count_linked_entries -= 1
-                del self.entries[entry_index]
-                self.text.delete(f"{entry_index + 1}.0", f"{entry_index + 2}.0")
-            self.update_count_label()
-            # Select line after first deleted line
-            entry_rowcol = IndexRowCol(self.text.index(MARK_REMOVED_ENTRY))
-            entry_index = min(entry_rowcol.row - 1, len(self.entries) - 1)
-            if len(self.entries) > 0:
-                self.select_entry(entry_index)
+        self.process_remove_entries(
+            process=False, remove=True, all_matching=all_matching
+        )
 
     def process_remove_entry_current(self, all_matching: bool = False) -> None:
         """Call the "process" callback function, if any, for the current entry, if any,
         then remove the entry.
 
         Args:
-            all_matching: If True remove all other entries that have the same
-                message as the chosen entry (e.g. same spelling error)
+            all_matching: If True process & remove all other entries that have the same
+                message as the chosen entry
         """
-        self.process_entry_current()
-        self.remove_entry_current(all_matching)
+        self.process_remove_entries(
+            process=True, remove=True, all_matching=all_matching
+        )
 
     def current_entry_index(self) -> Optional[int]:
         """Get the index entry of the currently selected error message.
@@ -350,6 +631,8 @@ class CheckerDialog(ToplevelDialog):
         self.text.mark_set(tk.INSERT, f"{entry_index + 1}.0")
         self.text.focus_set()
         entry = self.entries[entry_index]
+        self.selected_text = entry.text
+        self.selected_text_range = entry.text_range
         if entry.text_range is not None:
             if root().state() == "iconic":
                 root().deiconify()

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -690,13 +690,13 @@ class File:
             )
 
     def add_good_word_to_project_dictionary(self, word: str) -> None:
-        """Add a good word to the project dictionary & save it.
+        """Add a good word to the project dictionary. Save if word was added.
 
         Args:
             word: The word to be added.
         """
-        self.project_dict.add_good_word(word)
-        self.project_dict.save(self.filename)
+        if self.project_dict.add_good_word(word):
+            self.project_dict.save(self.filename)
 
 
 def page_mark_previous(mark: str) -> str:

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -533,6 +533,7 @@ class ScrolledReadOnlyText(tk.Text):
         self.tag_add(
             ScrolledReadOnlyText.SELECT_TAG_NAME, f"{line_num}.0", f"{line_num + 1}.0"
         )
+        self.see(f"{line_num}.0")
 
     def get_select_line_num(self) -> Optional[int]:
         """Get the line number of the currently selected line.

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -37,6 +37,7 @@ class PrefKey(StrEnum):
     WFDIALOGSORTTYPE = auto()
     WFDIALOGITALTHRESHOLD = auto()
     WFDIALOGREGEX = auto()
+    CHECKERDIALOGSORTTYPE = auto()
     DIALOGGEOMETRY = auto()
     ROOTGEOMETRY = auto()
     DEFAULTLANGUAGES = auto()

--- a/src/guiguts/project_dict.py
+++ b/src/guiguts/project_dict.py
@@ -100,10 +100,17 @@ class ProjectDict:
         """
         return len(self.good_words) > 0 or len(self.bad_words) > 0
 
-    def add_good_word(self, word: str) -> None:
+    def add_good_word(self, word: str) -> bool:
         """Add a good word to the project dictionary.
 
         Args:
             word: The word to be added.
+
+        Returns:
+            True if word was added, False if word was already in dictionary.
         """
-        self.good_words[word] = True
+        try:
+            return not self.good_words[word]
+        except KeyError:
+            self.good_words[word] = True
+        return True

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -18,7 +18,7 @@ from guiguts.utilities import (
     is_mac,
     sing_plur,
 )
-from guiguts.widgets import ToplevelDialog, Combobox, mouse_bind
+from guiguts.widgets import ToplevelDialog, Combobox, mouse_bind, ToolTip
 
 logger = logging.getLogger(__package__)
 
@@ -339,6 +339,17 @@ class SearchDialog(ToplevelDialog):
         checker_dialog = FindAllCheckerDialog.show_dialog(
             "Search Results", rerun_command=self.findall_clicked
         )
+        ToolTip(
+            checker_dialog.text,
+            "\n".join(
+                [
+                    "Left click: Select & find string",
+                    "Right click: Remove string from this list",
+                    "Shift Right click: Remove all occurrences of string from this list",
+                ]
+            ),
+            use_pointer_pos=True,
+        )
         checker_dialog.reset()
         # Construct opening line describing the search
         desc_reg = "regex" if SearchDialog.regex.get() else "string"
@@ -350,8 +361,7 @@ class SearchDialog(ToplevelDialog):
             desc += ", whole words only"
         if SearchDialog.selection.get():
             desc += ", within selection"
-        checker_dialog.add_entry(desc, None, len(prefix), len(prefix + search_string))
-        checker_dialog.add_entry("")
+        checker_dialog.add_header(desc, "")
 
         for match in matches:
             line = maintext().get(
@@ -368,8 +378,8 @@ class SearchDialog(ToplevelDialog):
             checker_dialog.add_entry(
                 line, IndexRange(match.rowcol, end_rowcol), hilite_start, hilite_end
             )
-        checker_dialog.add_entry("")
-        checker_dialog.add_entry("End of search results")
+        checker_dialog.add_footer("", "End of search results")
+        checker_dialog.display_entries()
 
     def replace_clicked(
         self, opposite_dir: bool = False, search_again: bool = False

--- a/src/guiguts/spell.py
+++ b/src/guiguts/spell.py
@@ -12,7 +12,13 @@ from guiguts.file import ProjectDict
 from guiguts.checkers import CheckerDialog, CheckerEntry
 from guiguts.maintext import maintext, FindMatch
 from guiguts.preferences import preferences
-from guiguts.utilities import IndexRowCol, IndexRange, load_wordfile_into_dict
+from guiguts.utilities import (
+    IndexRowCol,
+    IndexRange,
+    load_wordfile_into_dict,
+    cmd_ctrl_string,
+)
+from guiguts.widgets import ToolTip
 
 logger = logging.getLogger(__package__)
 
@@ -307,6 +313,18 @@ def spell_check(
         rerun_command=lambda: spell_check(project_dict, add_project_word_callback),
         process_command=process_spelling,
     )
+    ToolTip(
+        checker_dialog.text,
+        "\n".join(
+            [
+                "Left click: Select & find spelling error",
+                "Right click: Remove spelling error from list",
+                "Shift Right click: Remove all occurrences of spelling error from list",
+                f"With {cmd_ctrl_string()} key: Also add spelling to project dictionary",
+            ]
+        ),
+        use_pointer_pos=True,
+    )
     frame = ttk.Frame(checker_dialog.header_frame)
     frame.grid(column=0, row=1, columnspan=2, sticky="NSEW")
     project_dict_button = ttk.Button(
@@ -330,8 +348,7 @@ def spell_check(
 
     checker_dialog.reset()
     # Construct opening line describing the search
-    checker_dialog.add_entry("Start of Spelling Check")
-    checker_dialog.add_entry("")
+    checker_dialog.add_header("Start of Spelling Check", "")
 
     for spelling in bad_spellings:
         end_rowcol = IndexRowCol(
@@ -344,8 +361,8 @@ def spell_check(
             0,
             spelling.count,
         )
-    checker_dialog.add_entry("")
-    checker_dialog.add_entry("End of Spelling Check")
+    checker_dialog.add_footer("", "End of Spelling Check")
+    checker_dialog.display_entries()
 
 
 def spell_check_clear_dictionary() -> None:

--- a/src/guiguts/tools/jeebies.py
+++ b/src/guiguts/tools/jeebies.py
@@ -16,6 +16,7 @@ from guiguts.preferences import (
     PrefKey,
 )
 from guiguts.utilities import IndexRowCol, IndexRange
+from guiguts.widgets import ToolTip
 
 logger = logging.getLogger(__package__)
 
@@ -94,6 +95,17 @@ class JeebiesChecker:
             value=JeebiesParanoiaLevel.TOLERANT,
             takefocus=False,
         ).grid(row=0, column=4, sticky="NSE", padx=2)
+        ToolTip(
+            checker_dialog.text,
+            "\n".join(
+                [
+                    "Left click: Select & find he/be error",
+                    "Right click: Remove he/be error from list",
+                    "Shift Right click: Remove all matching he/be errors",
+                ]
+            ),
+            use_pointer_pos=True,
+        )
         checker_dialog.reset()
 
         # Check level used last time Jeebies was run or default if first run.
@@ -128,16 +140,16 @@ class JeebiesChecker:
         # the words 'he' and 'be' don't appear in a text. Pretty rare!
 
         if (be_cnt_in_file + he_cnt_in_file) == 0:
-            checker_dialog.add_entry(
+            checker_dialog.add_header(
                 f"  --> 'be' counted {be_cnt_in_file} times and 'he' counted {he_cnt_in_file} times in file."
             )
-            checker_dialog.add_entry("")
-            checker_dialog.add_entry("    There are no he/be phrases to check.")
+            checker_dialog.add_header("")
+            checker_dialog.add_header("    There are no he/be phrases to check.")
         else:
-            checker_dialog.add_entry(
+            checker_dialog.add_header(
                 f"  --> 'be' counted {be_cnt_in_file} times and 'he' counted {he_cnt_in_file} times in file."
             )
-            checker_dialog.add_entry("")
+            checker_dialog.add_header("")
 
             # For each paragraph in book ...
 
@@ -185,7 +197,9 @@ class JeebiesChecker:
             # Tell user if no suspect hebe phrases found in the paragraphs.
 
             if suspects_count == 0:
-                checker_dialog.add_entry("    No suspect phrases found.")
+                checker_dialog.add_footer("    No suspect phrases found.")
+
+        checker_dialog.display_entries()
 
     def build_paragraph_structures(self) -> tuple[List, List, List, List]:
         """Make the paragraph strings and the ancillary lists that allow

--- a/src/guiguts/tools/pptxt.py
+++ b/src/guiguts/tools/pptxt.py
@@ -4,9 +4,10 @@ from typing import Dict, Sequence, List
 import regex as re
 
 from guiguts.checkers import CheckerDialog
+from guiguts.file import ProjectDict
 from guiguts.maintext import maintext
 from guiguts.utilities import IndexRowCol, IndexRange
-from guiguts.file import ProjectDict
+from guiguts.widgets import ToolTip
 
 REPORT_LIMIT = 5  # Max number of times to report same issue for some checks
 
@@ -169,7 +170,7 @@ def get_words_on_line(line: str) -> list[str]:
 def spacing_check() -> None:
     """Blank line spacing check that flags other than 4121, 421 or 411 spacing."""
 
-    checker_dialog.add_entry(
+    checker_dialog.add_header(
         "----- Paragraph spacing check - expecting 4121, 421 or 411 spacing -------------"
     )
 
@@ -260,18 +261,16 @@ def spacing_check() -> None:
             checker_dialog.add_entry(record, IndexRange(start_rowcol, end_rowcol))
 
     if not four_line_spacing_found:
-        checker_dialog.add_entry("")
-        checker_dialog.add_entry(
-            "    No 4-line spacing found in book - that is unusual."
+        checker_dialog.add_footer(
+            "", "    No 4-line spacing found in book - that is unusual."
         )
     elif no_other_spacing_issues:
-        checker_dialog.add_entry("")
-        checker_dialog.add_entry(
-            "    Book appears to conform to DP paragraph/block spacing standards."
+        checker_dialog.add_footer(
+            "", "    Book appears to conform to DP paragraph/block spacing standards."
         )
 
     # Add line spacer at end of this checker section.
-    checker_dialog.add_entry("")
+    checker_dialog.add_footer("")
 
 
 ######################################################################
@@ -282,7 +281,7 @@ def spacing_check() -> None:
 def repeated_words_check() -> None:
     """Repeated words check."""
 
-    checker_dialog.add_entry(
+    checker_dialog.add_header(
         "----- Repeated words check - can be last word on a line and first on next ------"
     )
 
@@ -454,11 +453,10 @@ def repeated_words_check() -> None:
                 )
 
     if none_found:
-        checker_dialog.add_entry("")
-        checker_dialog.add_entry("    No repeated words found.")
+        checker_dialog.add_footer("", "    No repeated words found.")
 
     # Add line spacer at end of this checker section.
-    checker_dialog.add_entry("")
+    checker_dialog.add_footer("")
 
 
 ######################################################################
@@ -469,7 +467,7 @@ def repeated_words_check() -> None:
 def hyphenated_words_check() -> None:
     """Repeated words check."""
 
-    checker_dialog.add_entry(
+    checker_dialog.add_header(
         "----- Hyphenated/non-hyphenated words check ------------------------------------"
     )
 
@@ -492,9 +490,9 @@ def hyphenated_words_check() -> None:
                 if first_header:
                     first_header = False
                 else:
-                    checker_dialog.add_entry("")
+                    checker_dialog.add_header("")
                 # Add header record to dialog.
-                checker_dialog.add_entry(record)
+                checker_dialog.add_header(record)
 
                 # Under the header add to the dialog every line containing an instance of the
                 # hyphenated word. If there are more than 5 lines we stop reporting them and warn.
@@ -528,13 +526,13 @@ def hyphenated_words_check() -> None:
                     prev_line_number = line_number
 
                 if count < 0:
-                    checker_dialog.add_entry("  ...more")
+                    checker_dialog.add_footer("  ...more")
 
                 # We do the same for the non-hyphenated version of the word. Separate this
                 # list of lines from the ones above with a rule. Limit the number of lines
                 # reported to REPORT_LIMIT (5).
 
-                checker_dialog.add_entry("-----")
+                checker_dialog.add_header("-----")
 
                 line_number_list = word_list_map_lines[word_with_no_hyphen]
                 prev_line_number = -1
@@ -561,16 +559,16 @@ def hyphenated_words_check() -> None:
                     prev_line_number = line_number
 
                 if count < 0:
-                    checker_dialog.add_entry("  ...more")
+                    checker_dialog.add_footer("  ...more")
 
     if none_found:
-        checker_dialog.add_entry("")
-        checker_dialog.add_entry(
+        checker_dialog.add_footer("")
+        checker_dialog.add_footer(
             "    No non-hyphenated versions of hyphenated words found."
         )
 
     # Add line spacer at end of this checker section.
-    checker_dialog.add_entry("")
+    checker_dialog.add_footer("")
 
 
 ######################################################################
@@ -585,7 +583,7 @@ def weird_characters() -> None:
     are grouped by unusual character and each instance of the character
     on a report line is highlighted."""
 
-    checker_dialog.add_entry(
+    checker_dialog.add_header(
         "----- Character checks ---------------------------------------------------------"
     )
 
@@ -628,9 +626,9 @@ def weird_characters() -> None:
             if first_header:
                 first_header = False
             else:
-                checker_dialog.add_entry("")
+                checker_dialog.add_header("")
             # Add header record to dialog.
-            checker_dialog.add_entry(record)
+            checker_dialog.add_header(record)
 
             # Under the header add to the dialog every line containing an instance of the weirdo.
             # If there are multiple instances of a weirdo on a line then the line will appear in
@@ -659,14 +657,13 @@ def weird_characters() -> None:
                 prev_line_number = line_number
 
             if count < 0:
-                checker_dialog.add_entry("  ...more")
+                checker_dialog.add_footer("  ...more")
 
     if none_found:
-        checker_dialog.add_entry("")
-        checker_dialog.add_entry("    No unusual characters found.")
+        checker_dialog.add_footer("", "    No unusual characters found.")
 
     # Add line spacer at end of this checker section.
-    checker_dialog.add_entry("")
+    checker_dialog.add_footer("")
 
 
 ######################################################################
@@ -678,7 +675,7 @@ def weird_characters() -> None:
 def specials_check(project_dict: ProjectDict) -> None:
     """A series of textual checks done on a single read of the book lines."""
 
-    checker_dialog.add_entry(
+    checker_dialog.add_header(
         "----- Special situations checks ------------------------------------------------"
     )
 
@@ -1113,9 +1110,9 @@ def specials_check(project_dict: ProjectDict) -> None:
         if first_header:
             first_header = False
         else:
-            checker_dialog.add_entry("")
+            checker_dialog.add_header("")
         # Add header record to dialog.
-        checker_dialog.add_entry(header_line)
+        checker_dialog.add_header(header_line)
         # Generate the dialog messages
         for tple in tuples_list:
             line = tple[0]
@@ -1134,11 +1131,11 @@ def specials_check(project_dict: ProjectDict) -> None:
             )
 
     if none_found:
-        checker_dialog.add_entry("")
-        checker_dialog.add_entry("    No special situations reports.")
+        checker_dialog.add_footer("")
+        checker_dialog.add_footer("    No special situations reports.")
 
     # Add line spacer at end of this checker section.
-    checker_dialog.add_entry("")
+    checker_dialog.add_footer("")
 
 
 ######################################################################
@@ -1149,7 +1146,7 @@ def specials_check(project_dict: ProjectDict) -> None:
 def html_check() -> None:
     """Abandoned HTML tag check."""
 
-    checker_dialog.add_entry(
+    checker_dialog.add_header(
         "----- Abandoned HTML tag check -------------------------------------------------"
     )
 
@@ -1174,10 +1171,8 @@ def html_check() -> None:
         # number of HTML tags found so far then exit loop.
 
         if abandoned_html_tag_count > courtesy_limit:
-            checker_dialog.add_entry("")
             record = f"Source file not plain text: {lines_with_html_tags} book lines with {abandoned_html_tag_count} markup instances so far..."
-            checker_dialog.add_entry(record)
-            checker_dialog.add_entry("...abandoning check.")
+            checker_dialog.add_footer("", record, "...abandoning check.")
             # Don't search any more book lines for HTML tags.
             break
 
@@ -1185,11 +1180,10 @@ def html_check() -> None:
 
     # All book lines scanned or scanning abandoned.
     if abandoned_html_tag_count == 0:
-        checker_dialog.add_entry("")
-        checker_dialog.add_entry("    No abandoned HTML tags found.")
+        checker_dialog.add_footer("", "    No abandoned HTML tags found.")
 
     # Add line spacer at end of this checker section.
-    checker_dialog.add_entry("")
+    checker_dialog.add_footer("")
 
 
 ######################################################################
@@ -1200,7 +1194,7 @@ def html_check() -> None:
 def unicode_numeric_character_check() -> None:
     """Unicode numeric character references check."""
 
-    checker_dialog.add_entry(
+    checker_dialog.add_header(
         "----- Unicode numeric character references check -------------------------------"
     )
 
@@ -1236,11 +1230,12 @@ def unicode_numeric_character_check() -> None:
 
     # All book lines scanned.
     if numeric_char_reference_count == 0:
-        checker_dialog.add_entry("")
-        checker_dialog.add_entry("    No unicode numeric character references found.")
+        checker_dialog.add_footer(
+            "", "    No unicode numeric character references found."
+        )
 
     # Add line spacer at end of this checker section.
-    checker_dialog.add_entry("")
+    checker_dialog.add_footer("")
 
 
 ######################################################################
@@ -1252,7 +1247,7 @@ def unicode_numeric_character_check() -> None:
 def adjacent_spaces_check() -> None:
     """Scans text of each book line for adjacent spaces."""
 
-    checker_dialog.add_entry(
+    checker_dialog.add_header(
         "----- Adjacent spaces check (poetry, block-quotes, etc., are ignored) ----------"
     )
 
@@ -1275,11 +1270,10 @@ def adjacent_spaces_check() -> None:
 
     # All book lines scanned.
     if no_adjacent_spaces_found:
-        checker_dialog.add_entry("")
-        checker_dialog.add_entry("    No lines with adjacent spaces found.")
+        checker_dialog.add_footer("", "    No lines with adjacent spaces found.")
 
     # Add line spacer at end of this checker section.
-    checker_dialog.add_entry("")
+    checker_dialog.add_footer("")
 
 
 ######################################################################
@@ -1290,7 +1284,7 @@ def adjacent_spaces_check() -> None:
 def trailing_spaces_check() -> None:
     """Scans each book line for trailing spaces."""
 
-    checker_dialog.add_entry(
+    checker_dialog.add_header(
         "----- Trailing spaces check ----------------------------------------------------"
     )
 
@@ -1319,11 +1313,10 @@ def trailing_spaces_check() -> None:
 
     # All book lines scanned.
     if no_trailing_spaces_found:
-        checker_dialog.add_entry("")
-        checker_dialog.add_entry("    No lines with trailing spaces found.")
+        checker_dialog.add_footer("", "    No lines with trailing spaces found.")
 
     # Add line spacer at end of this checker section.
-    checker_dialog.add_entry("")
+    checker_dialog.add_footer("")
 
 
 def double_dash_replace(matchobj: re.Match) -> str:
@@ -1376,7 +1369,7 @@ def report_all_occurrences_on_line(pattern: str, line: str, line_number: int) ->
 def ellipsis_check() -> None:
     """Ellipses check."""
 
-    checker_dialog.add_entry(
+    checker_dialog.add_header(
         "----- Ellipsis check -----------------------------------------------------------"
     )
 
@@ -1433,11 +1426,10 @@ def ellipsis_check() -> None:
         line_number += 1
 
     if no_suspect_ellipsis_found:
-        checker_dialog.add_entry("")
-        checker_dialog.add_entry("    No suspect ellipsis found.")
+        checker_dialog.add_footer("", "    No suspect ellipsis found.")
 
     # Add line spacer at end of this checker section.
-    checker_dialog.add_entry("")
+    checker_dialog.add_footer("")
 
 
 ######################################################################
@@ -1448,7 +1440,7 @@ def ellipsis_check() -> None:
 def curly_quote_check() -> None:
     """Curly quote check."""
 
-    checker_dialog.add_entry(
+    checker_dialog.add_header(
         "----- Basic (positional) curly-quote check -------------------------------------"
     )
 
@@ -1463,21 +1455,21 @@ def curly_quote_check() -> None:
         if re.search(pattern, line):
             if first_match:
                 first_match = False
-                checker_dialog.add_entry("floating quote (single or double)")
+                checker_dialog.add_header("floating quote (single or double)")
             report_all_occurrences_on_line(pattern, line, line_number)
             no_suspect_curly_quote_found = False
         pattern = r"^[“”\‘\’](?= )"
         if re.search(pattern, line):
             if first_match:
                 first_match = False
-                checker_dialog.add_entry("floating quote (single or double)")
+                checker_dialog.add_header("floating quote (single or double)")
             report_all_occurrences_on_line(pattern, line, line_number)
             no_suspect_curly_quote_found = False
         pattern = r"(?<= )[“”\‘\’]$"
         if re.search(pattern, line):
             if first_match:
                 first_match = False
-                checker_dialog.add_entry("floating quote (single or double)")
+                checker_dialog.add_header("floating quote (single or double)")
             report_all_occurrences_on_line(pattern, line, line_number)
             no_suspect_curly_quote_found = False
 
@@ -1494,32 +1486,31 @@ def curly_quote_check() -> None:
         if re.search(pattern, line):
             if first_match:
                 first_match = False
-                checker_dialog.add_entry("quote direction")
+                checker_dialog.add_header("quote direction")
             report_all_occurrences_on_line(pattern, line, line_number)
             no_suspect_curly_quote_found = False
         pattern = r"(?<=\p{L})[\‘\“]"
         if re.search(pattern, line):
             if first_match:
                 first_match = False
-                checker_dialog.add_entry("quote direction")
+                checker_dialog.add_header("quote direction")
             report_all_occurrences_on_line(pattern, line, line_number)
             no_suspect_curly_quote_found = False
         pattern = r"”(?=[\p{L}])"
         if re.search(pattern, line):
             if first_match:
                 first_match = False
-                checker_dialog.add_entry("quote direction")
+                checker_dialog.add_header("quote direction")
             report_all_occurrences_on_line(pattern, line, line_number)
             no_suspect_curly_quote_found = False
 
         line_number += 1
 
     if no_suspect_curly_quote_found:
-        checker_dialog.add_entry("")
-        checker_dialog.add_entry("    No suspect curly quotes found.")
+        checker_dialog.add_footer("", "    No suspect curly quotes found.")
 
     # Add line spacer at end of this checker section.
-    checker_dialog.add_entry("")
+    checker_dialog.add_footer("")
 
 
 ######################################################################
@@ -1530,35 +1521,33 @@ def curly_quote_check() -> None:
 def quote_type_checks() -> None:
     """Check for mixed straight/curly quotes."""
 
-    checker_dialog.add_entry(
-        "----- Quotes types check -------------------------------------------------------"
+    checker_dialog.add_header(
+        "----- Quotes types check -------------------------------------------------------",
+        "",
     )
-
-    # Add line spacer at start of this checker section.
-    checker_dialog.add_entry("")
 
     # Any straight single/double quotes?
     if ssq > 0 or sdq > 0:
         # Yep, so what about any curly single and double quotes?
         if csq == 0 and cdq == 0:
-            checker_dialog.add_entry(
+            checker_dialog.add_header(
                 "    Only straight quotes found in this file (maybe single and/or double)."
             )
         elif csq > 0 or cdq > 0:
-            checker_dialog.add_entry(
+            checker_dialog.add_header(
                 "    Both straight and curly quotes found in this file (maybe single and/or double)."
             )
     elif (ssq == 0 and sdq == 0) and (csq > 0 or cdq > 0):
-        checker_dialog.add_entry(
+        checker_dialog.add_header(
             "    Only curly quotes found in this file (maybe single and/or double)."
         )
     elif ssq == 0 and sdq == 0 and csq == 0 and cdq == 0:
-        checker_dialog.add_entry(
+        checker_dialog.add_header(
             "    No single or double quotes of any type found in file - that is unusual."
         )
 
     # Add line spacer at end of this checker section.
-    checker_dialog.add_entry("")
+    checker_dialog.add_footer("")
 
 
 ######################################################################
@@ -1569,7 +1558,7 @@ def quote_type_checks() -> None:
 def dash_review() -> None:
     """Hyphen/dashes check."""
 
-    checker_dialog.add_entry(
+    checker_dialog.add_header(
         "----- Hyphen/dashes check (one or more present on line) ------------------------"
     )
 
@@ -1826,8 +1815,8 @@ def dash_review() -> None:
         if first_header:
             first_header = False
         else:
-            checker_dialog.add_entry("")
-        checker_dialog.add_entry("Pairs of '--' (keyboard '-') found")
+            checker_dialog.add_header("")
+        checker_dialog.add_header("Pairs of '--' (keyboard '-') found")
 
         count = 0
         for record in a_h2:
@@ -1842,11 +1831,11 @@ def dash_review() -> None:
                 output_record = "  ...1 more line"
             else:
                 output_record = f"  ...{len(a_h2) - 5} more lines"
-            checker_dialog.add_entry(output_record)
+            checker_dialog.add_footer(output_record)
         if counth2 > 5:
-            checker_dialog.add_entry("")
-            checker_dialog.add_entry(
-                "    [Book seems to use '--' as em-dash so not reporting these further]"
+            checker_dialog.add_footer(
+                "",
+                "    [Book seems to use '--' as em-dash so not reporting these further]",
             )
 
     # Report other consecutive dashes
@@ -1855,8 +1844,8 @@ def dash_review() -> None:
         if first_header:
             first_header = False
         else:
-            checker_dialog.add_entry("")
-        checker_dialog.add_entry(
+            checker_dialog.add_header("")
+        checker_dialog.add_header(
             "Adjacent dashes (expected at least 8 emdash or keyboard '-' as a separator)"
         )
 
@@ -1871,8 +1860,8 @@ def dash_review() -> None:
         if first_header:
             first_header = False
         else:
-            checker_dialog.add_entry("")
-        checker_dialog.add_entry("Hyphen-minus (single keyboard '-')")
+            checker_dialog.add_header("")
+        checker_dialog.add_header("Hyphen-minus (single keyboard '-')")
         for record in a_hm:
             line_number = record[0]
             line = record[1]
@@ -1885,8 +1874,8 @@ def dash_review() -> None:
         if first_header:
             first_header = False
         else:
-            checker_dialog.add_entry("")
-        checker_dialog.add_entry("Hyphen")
+            checker_dialog.add_header("")
+        checker_dialog.add_header("Hyphen")
         for record in a_hy:
             line_number = record[0]
             line = record[1]
@@ -1898,8 +1887,8 @@ def dash_review() -> None:
         if first_header:
             first_header = False
         else:
-            checker_dialog.add_entry("")
-        checker_dialog.add_entry("Non-breaking hyphen")
+            checker_dialog.add_header("")
+        checker_dialog.add_header("Non-breaking hyphen")
         for record in a_nb:
             line_number = record[0]
             line = record[1]
@@ -1911,8 +1900,8 @@ def dash_review() -> None:
         if first_header:
             first_header = False
         else:
-            checker_dialog.add_entry("")
-        checker_dialog.add_entry("Figure dash")
+            checker_dialog.add_header("")
+        checker_dialog.add_header("Figure dash")
         for record in a_fd:
             line_number = record[0]
             line = record[1]
@@ -1924,8 +1913,8 @@ def dash_review() -> None:
         if first_header:
             first_header = False
         else:
-            checker_dialog.add_entry("")
-        checker_dialog.add_entry("En-dash")
+            checker_dialog.add_header("")
+        checker_dialog.add_header("En-dash")
         for record in a_en:
             line_number = record[0]
             line = record[1]
@@ -1937,8 +1926,8 @@ def dash_review() -> None:
         if first_header:
             first_header = False
         else:
-            checker_dialog.add_entry("")
-        checker_dialog.add_entry("Em-dash")
+            checker_dialog.add_header("")
+        checker_dialog.add_header("Em-dash")
         for record in a_em:
             line_number = record[0]
             line = record[1]
@@ -1950,8 +1939,8 @@ def dash_review() -> None:
         if first_header:
             first_header = False
         else:
-            checker_dialog.add_entry("")
-        checker_dialog.add_entry("Unrecognised dash")
+            checker_dialog.add_header("")
+        checker_dialog.add_header("Unrecognised dash")
         for record in a_un:
             line_number = record[0]
             line = record[1]
@@ -1959,11 +1948,10 @@ def dash_review() -> None:
 
     # All book lines scanned.
     if not dash_suspects_found:
-        checker_dialog.add_entry("")
-        checker_dialog.add_entry("    No dash suspects found.")
+        checker_dialog.add_footer("", "    No dash suspects found.")
 
     # Add line spacer at end of this checker section.
-    checker_dialog.add_entry("")
+    checker_dialog.add_footer("")
 
 
 ######################################################################
@@ -1975,7 +1963,7 @@ def scanno_check() -> None:
     """Checks the 'words' on a line against a long list
     of commonly misspelled words."""
 
-    checker_dialog.add_entry(
+    checker_dialog.add_header(
         "----- Scannos check ------------------------------------------------------------"
     )
 
@@ -2029,9 +2017,9 @@ def scanno_check() -> None:
         if first_header:
             first_header = False
         else:
-            checker_dialog.add_entry("")
+            checker_dialog.add_header("")
         # Header is the scanno.
-        checker_dialog.add_entry(scanno)
+        checker_dialog.add_header(scanno)
 
         for tple in tple_list:
             line_number = tple[0]
@@ -2061,11 +2049,11 @@ def scanno_check() -> None:
                 )
 
     if no_scannos_found:
-        checker_dialog.add_entry("")
-        checker_dialog.add_entry("    No scannos found.")
+        checker_dialog.add_footer("")
+        checker_dialog.add_footer("    No scannos found.")
 
     # Add line spacer at end of this checker section.
-    checker_dialog.add_entry("")
+    checker_dialog.add_footer("")
 
 
 ######################################################################
@@ -2507,6 +2495,17 @@ def pptxt(project_dict: ProjectDict) -> None:
     checker_dialog = CheckerDialog.show_dialog(
         "PPtxt Results", rerun_command=lambda: pptxt(project_dict)
     )
+    ToolTip(
+        checker_dialog.text,
+        "\n".join(
+            [
+                "Left click: Select & find issue",
+                "Right click: Remove issue from list",
+                "Shift Right click: Remove all matching issues",
+            ]
+        ),
+        use_pointer_pos=True,
+    )
     checker_dialog.reset()
 
     # Get the whole of the file from the main text widget
@@ -2604,4 +2603,5 @@ def pptxt(project_dict: ProjectDict) -> None:
 
     # Add final divider line to dialog.
 
-    checker_dialog.add_entry(f"{'-' * 80}")
+    checker_dialog.add_footer(f"{'-' * 80}")
+    checker_dialog.display_entries()

--- a/src/guiguts/utilities.py
+++ b/src/guiguts/utilities.py
@@ -286,6 +286,11 @@ def folder_dir_str(lowercase: bool = False) -> str:
     return fd_string.lower() if lowercase else fd_string
 
 
+def cmd_ctrl_string() -> str:
+    """Return "Command" or "Control" depending on platform."""
+    return "Command" if is_mac() else "Control"
+
+
 def force_tcl_wholeword(string: str, regex: bool) -> tuple[str, bool]:
     """Change string to only match whole word(s) by converting to
     a regex (if not already), then prepending and appending Tcl-style

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -324,7 +324,7 @@ class ToolTip(tk.Toplevel):
         ttk.Label(frame, text=msg).grid()
         self.enter_bind = self.widget.bind("<Enter>", self.on_enter, add="+")
         self.leave_bind = self.widget.bind("<Leave>", self.on_leave, add="+")
-        self.press_bind = self.widget.bind("<ButtonPress>", self.on_leave, add="+")
+        self.press_bind = self.widget.bind("<ButtonRelease>", self.on_leave, add="+")
         self.update_idletasks()
         self.width = self.winfo_width()
         self.height = self.winfo_height()


### PR DESCRIPTION
1. Either sort by line.column or by "Alpha/type", which means an alphabetic sort where appropriate, or grouped by type of error.
2. CheckerDialog provides default sort routines, but specific tools can define their own, like Basic Fixup.
3. Checker messages are now distinguished into header, footer or content, with different sections - this is so that sorting knows which ordering to preserve, e.g. a header should come above content, regardless of sort order.
4. Project dictionary is now only saved if a word was actually added - previously it was saved even if word was already there.
5. This makes it possible to change the meaning of "process & remove all" to mean "(process & remove) all", rather than "process & (remove all)".
6. Previously selected message is reselected and displayed when results are re-sorted.
7. Some commonizing of code within checkers.py so that one method now does the work of processing and/or removing, and is called with various arguments to control it.
8. Add tooltips to checker dialogs, and make tooltips vanish on button release, not press, so they do not clash with button presses that actually do something.
9. Also add support for "Shift+Cmd/Ctrl+left button", which means process this line and all matching lines.

Fixes #193 (or at least enough of it for now)