### PR TITLE
Simplify status bar clicking

### DIFF
--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -23,17 +23,16 @@ from guiguts.project_dict import ProjectDict, GOOD_WORDS_FILENAME, BAD_WORDS_FIL
 from guiguts.root import root
 from guiguts.spell import spell_check_clear_dictionary
 from guiguts.utilities import (
-    is_windows,
     load_dict_from_json,
     IndexRowCol,
     IndexRange,
     sound_bell,
+    folder_dir_str,
 )
 from guiguts.widgets import grab_focus, ToplevelDialog
 
 logger = logging.getLogger(__package__)
 
-FOLDER_DIR = "folder" if is_windows() else "directory"
 NUM_RECENT_FILES = 9
 PAGEMARK_PREFIX = "Pg"
 BINFILE_SUFFIX = ".json"
@@ -514,7 +513,7 @@ class File:
     def choose_image_dir(self) -> None:
         """Allow user to select directory containing png image files"""
         self.image_dir = filedialog.askdirectory(
-            mustexist=True, title="Select " + FOLDER_DIR + " containing scans"
+            mustexist=True, title=f"Select {folder_dir_str(True)} containing scans"
         )
 
     def get_current_page_label(self) -> str:

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -22,6 +22,7 @@ class PrefKey(StrEnum):
     IMAGEWINDOW = auto()
     RECENTFILES = auto()
     LINENUMBERS = auto()
+    ORDINALNAMES = auto()
     SEARCHHISTORY = auto()
     REPLACEHISTORY = auto()
     SEARCHDIALOGREVERSE = auto()

--- a/src/guiguts/utilities.py
+++ b/src/guiguts/utilities.py
@@ -276,6 +276,16 @@ def process_accel(accel: str) -> tuple[str, str]:
     return (accel, f"<{keyevent}>")
 
 
+def folder_dir_str(lowercase: bool = False) -> str:
+    """Return "Folder" or "Directory" depending on platform.
+
+    Args:
+        lowercase: If True, return lowercase version.
+    """
+    fd_string = "Folder" if is_windows() else "Directory"
+    return fd_string.lower() if lowercase else fd_string
+
+
 def force_tcl_wholeword(string: str, regex: bool) -> tuple[str, bool]:
     """Change string to only match whole word(s) by converting to
     a regex (if not already), then prepending and appending Tcl-style


### PR DESCRIPTION
1. Avoid using right button. Use left button for main feature, and Shift-left for additional feature if needed.
2. Move "Choose image scans dir" to File-->Project menu, so no longer available by clicking status bar. It is popped automatically anyway, if the user tries to look at a scan before it is set up. GG1 has a File-->Project menu button for it too.
3. Add Shift-click to the ordinal button to toggle the display of the character name. Some users find the changing length of the button distracting, and it would take up too much space to make it long enough to fit the longest common character names. Setting is stored in GGprefs file.

Fixes #210