### PR TITLE
Read ISO-8859-1 files from DP correctly

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -345,10 +345,14 @@ class MainText(tk.Text):
         Args:
             fname: Name of file to load text from.
         """
-        with open(fname, "r", encoding="utf-8") as fh:
-            self.delete("1.0", tk.END)
-            self.insert(tk.END, fh.read())
-            self.set_modified(False)
+        self.delete("1.0", tk.END)
+        try:
+            with open(fname, "r", encoding="utf-8") as fh:
+                self.insert(tk.END, fh.read())
+        except UnicodeDecodeError:
+            with open(fname, "r", encoding="iso-8859-1") as fh:
+                self.insert(tk.END, fh.read())
+        self.set_modified(False)
         self.edit_reset()
 
     def do_close(self) -> None:

--- a/src/guiguts/utilities.py
+++ b/src/guiguts/utilities.py
@@ -86,11 +86,16 @@ def load_wordfile_into_dict(path: TraversablePath, target_dict: dict) -> bool:
         True if file opened successfully, False if file not found.
     """
     try:
-        with path.open("r", encoding="utf-8") as fp:
-            for line in fp:
-                word = line.strip()
-                if word:
-                    target_dict[word] = True
+        try:
+            with path.open("r", encoding="utf-8") as fp:
+                data = fp.read()
+        except UnicodeDecodeError:
+            with path.open("r", encoding="iso-8859-1") as fp:
+                data = fp.read()
+        for line in data.split("\n"):
+            word = line.strip()
+            if word:
+                target_dict[word] = True
         return True
     except FileNotFoundError:
         return False


### PR DESCRIPTION
Some text files and good/bad words files may still be ISO-8859-1 rather than UTF-8. Try to read them as UTF-8, and if they fail, read them as ISO-8859-1.