### PR TITLE
Add a Preferences dialog

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ Checkers
 .. automodule:: checkers
  
 File
-=========
+====
     
 .. automodule:: file
 
@@ -73,9 +73,14 @@ Word Frequency
 .. automodule:: word_frequency
 
 PPtxt
-============
+=====
     
 .. automodule:: tools.pptxt
+ 
+Misc. Dialogs
+=============
+    
+.. automodule:: misc_dialogs
  
 Misc. Tools
 ===========

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -472,7 +472,9 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         )
         the_statusbar.add_binding("rowcol", "ButtonRelease-1", self.file.goto_line)
         the_statusbar.add_binding(
-            "rowcol", "Shift-ButtonRelease-1", lambda: preferences.toggle(PrefKey.LINENUMBERS)
+            "rowcol",
+            "Shift-ButtonRelease-1",
+            lambda: preferences.toggle(PrefKey.LINENUMBERS),
         )
 
         the_statusbar.add(
@@ -499,7 +501,9 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             self.show_image,
         )
         the_statusbar.add_binding(
-            "see img", "Shift-ButtonRelease-1", lambda: preferences.toggle(PrefKey.AUTOIMAGE)
+            "see img",
+            "Shift-ButtonRelease-1",
+            lambda: preferences.toggle(PrefKey.AUTOIMAGE),
         )
 
         the_statusbar.add(

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -252,7 +252,7 @@ class MainText(tk.Text):
 
     def toggle_line_numbers(self) -> None:
         """Toggle whether line numbers are shown."""
-        self.show_line_numbers(not self.line_numbers_shown())
+        preferences.set(PrefKey.LINENUMBERS, not preferences.get(PrefKey.LINENUMBERS))
 
     def show_line_numbers(self, show: bool) -> None:
         """Show or hide line numbers.
@@ -260,21 +260,10 @@ class MainText(tk.Text):
         Args:
             show: True to show, False to hide.
         """
-        if self.line_numbers_shown() == show:
-            return
         if show:
             self.linenumbers.grid()
         else:
             self.linenumbers.grid_remove()
-        preferences.set(PrefKey.LINENUMBERS, show)
-
-    def line_numbers_shown(self) -> bool:
-        """Check if line numbers are shown.
-
-        Returns:
-            True if shown, False if not.
-        """
-        return self.linenumbers.winfo_viewable()
 
     def key_bind(
         self, keyevent: str, handler: Callable[[Any], None], bind_all: bool

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -712,22 +712,20 @@ def do_sound_bell() -> None:
 
     Audible uses the default system bell sound.
     Visible flashes the first statusbar button (must be ttk.Button)
-    Preference "Bell" contains "Audible", "Visible", both or neither
     """
-    bell_pref = preferences.get(PrefKey.BELL)
-    if "Audible" in bell_pref:
+    if preferences.get(PrefKey.BELLAUDIBLE):
         root().bell()
-    if "Visible" in bell_pref:
+    if preferences.get(PrefKey.BELLVISUAL):
         bell_button = statusbar().fields["rowcol"]
         # Belt & suspenders: uses the "disabled" state of button in temporary style,
         # but also restores setting in temporary style, and restores default style.
         style = ttk.Style()
-        # Set temporary style's disabled bg to red, inherting
+        # Set temporary style's disabled bg to red
         style.map("W.TButton", foreground=[("disabled", "red")])
         # Save current disabled bg default for buttons
         save_bg = style.lookup("TButton", "background", state=[("disabled")])
         # Save style currently used by button
-        cur_style = statusbar().fields["rowcol"]["style"]
+        cur_style = bell_button["style"]
         # Set button to use temporary style
         bell_button.configure(style="W.TButton")
         # Flash 3 times

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -13,12 +13,10 @@ class PreferencesDialog(ToplevelDialog):
         """Initialize preferences dialog."""
         super().__init__("Settings", resize_y=False)
         self.minsize(250, 10)
-        self.notebook = ttk.Notebook(self.top_frame, takefocus=False)
-        self.notebook.grid(column=0, row=0, sticky="NSEW")
-        self.notebook.enable_traversal()
 
-        # Appearance tab
-        appearance_frame = ttk.Frame(self.notebook, padding=10)
+        # Appearance
+        appearance_frame = ttk.LabelFrame(self.top_frame, text="Appearance", padding=10)
+        appearance_frame.grid(column=0, row=0, sticky="NSEW")
         ttk.Checkbutton(
             appearance_frame,
             text="Display Line Numbers",
@@ -42,11 +40,10 @@ class PreferencesDialog(ToplevelDialog):
             text="Visual",
             variable=PersistentBoolean(PrefKey.BELLVISUAL),
         ).grid(column=2, row=0, sticky="NEW")
-        self.notebook.add(appearance_frame, text="Appearance", underline=0)
 
         # Processing tab
-        processing_frame = ttk.Frame(self.notebook, padding=10)
+        processing_frame = ttk.LabelFrame(self.top_frame, text="Processing", padding=10)
+        processing_frame.grid(column=0, row=1, sticky="NSEW", pady=(10, 0))
         ttk.Label(processing_frame, text="Nothing to see here yet").grid(
             column=0, row=0, sticky="NEW"
         )
-        self.notebook.add(processing_frame, text="Processing", underline=0)

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -1,0 +1,54 @@
+"""Miscellaneous dialogs."""
+
+from tkinter import ttk
+
+from guiguts.preferences import PrefKey, PersistentBoolean
+from guiguts.widgets import ToplevelDialog
+
+
+class PreferencesDialog(ToplevelDialog):
+    """A dialog that displays settings/preferences."""
+
+    def __init__(self) -> None:
+        """Initialize preferences dialog."""
+        super().__init__("Settings", resize_y=False)
+        self.minsize(250, 10)
+        self.notebook = ttk.Notebook(self.top_frame, takefocus=False)
+        self.notebook.grid(column=0, row=0, sticky="NSEW")
+        self.notebook.enable_traversal()
+
+        # Appearance tab
+        appearance_frame = ttk.Frame(self.notebook, padding=10)
+        appearance_frame.grid(column=0, sticky="NSEW")
+        ttk.Checkbutton(
+            appearance_frame,
+            text="Display Line Numbers",
+            variable=PersistentBoolean(PrefKey.LINENUMBERS),
+        ).grid(column=0, row=0, sticky="NEW")
+        ttk.Checkbutton(
+            appearance_frame,
+            text="Automatically show current page image",
+            variable=PersistentBoolean(PrefKey.AUTOIMAGE),
+        ).grid(column=0, row=1, sticky="NEW")
+        bell_frame = ttk.Frame(appearance_frame)
+        bell_frame.grid(column=0, row=2, sticky="NEW")
+        ttk.Label(bell_frame, text="Warning bell: ").grid(column=0, row=0, sticky="NEW")
+        ttk.Checkbutton(
+            bell_frame,
+            text="Audible",
+            variable=PersistentBoolean(PrefKey.BELLAUDIBLE),
+        ).grid(column=1, row=0, sticky="NEW", padx=20)
+        ttk.Checkbutton(
+            bell_frame,
+            text="Visual",
+            variable=PersistentBoolean(PrefKey.BELLVISUAL),
+        ).grid(column=2, row=0, sticky="NEW")
+        self.notebook.add(appearance_frame, text="Appearance", underline=0)
+
+        # Processing tab
+        processing_frame = ttk.Frame(self.notebook, padding=10)
+        processing_frame.grid(column=0, sticky="NSEW")
+        ttk.Label(processing_frame, text="Nothing to see here yet").grid(
+            column=0, row=0, sticky="NEW"
+        )
+        self.notebook.add(processing_frame, text="Processing", underline=0)

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -19,7 +19,6 @@ class PreferencesDialog(ToplevelDialog):
 
         # Appearance tab
         appearance_frame = ttk.Frame(self.notebook, padding=10)
-        appearance_frame.grid(column=0, sticky="NSEW")
         ttk.Checkbutton(
             appearance_frame,
             text="Display Line Numbers",
@@ -47,7 +46,6 @@ class PreferencesDialog(ToplevelDialog):
 
         # Processing tab
         processing_frame = ttk.Frame(self.notebook, padding=10)
-        processing_frame.grid(column=0, sticky="NSEW")
         ttk.Label(processing_frame, text="Nothing to see here yet").grid(
             column=0, row=0, sticky="NEW"
         )

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -18,7 +18,8 @@ class PrefKey(StrEnum):
     """Enum class to store preferences keys."""
 
     AUTOIMAGE = auto()
-    BELL = auto()
+    BELLAUDIBLE = auto()
+    BELLVISUAL = auto()
     IMAGEWINDOW = auto()
     RECENTFILES = auto()
     LINENUMBERS = auto()
@@ -45,9 +46,10 @@ class Preferences:
     """Handle setting/getting/saving/loading/defaulting preferences.
 
     Call `add` to create/define each preference, giving its default value,
-    and optionally a callback function, e.g. if loading a pref requires an
-    initial UI setting. Once UI is ready, call `run_callbacks` to deal with
-    all required side effects.
+    and optionally a callback function, e.g. if loading or setting a pref
+    requires a UI change or other side effect. Once UI is initially ready,
+    call `run_callbacks` to deal with all required side effects from loading
+    the GGprefs file.
 
     Load/Save preferences in temporary file when testing.
 
@@ -55,8 +57,8 @@ class Preferences:
         dict: dictionary of values for prefs.
         defaults: dictionary of values for defaults.
         callbacks: dictionary of callbacks - typically a function to
-          deal with initial side effect of loading the pref, which will be
-          called after all prefs have been loaded and UI is ready. Not called
+          deal with side effect of loading/setting the pref, which will be
+          called after all prefs have been loaded and UI is ready. Also called
           each time pref is changed.
         prefsdir: directory containing user prefs & data files
     """
@@ -96,6 +98,8 @@ class Preferences:
     def set(self, key: PrefKey, value: Any) -> None:
         """Set preference value and save to file if value has changed.
 
+        If key has an associated callback, call it.
+
         Args:
             key: Name of preference.
             value: Value for preference.
@@ -103,6 +107,16 @@ class Preferences:
         if self.get(key) != value:
             self.dict[key] = value
             self.save()
+            if key in self.callbacks:
+                self.callbacks[key](value)
+
+    def toggle(self, key: PrefKey) -> None:
+        """Toggle the value of a boolean preference.
+
+        Args:
+            key: Name of preference.
+        """
+        self.set(key, not self.get(key))
 
     def __del__(self) -> None:
         """Remove any test prefs file when finished."""


### PR DESCRIPTION
1. Menu Edit-->Preferences pops the dialog on Windows/Linux, and the standard application menu Settings entry pops it on a Mac.
2. Currently has 2 tabs (one of which is currently empty)
3. Line numbers, Auto Img, and Bell settings implemented.
4. Existing Preference callback feature utilized and extended to be called whenever preference changes. This means preference can be used to set/query the value, rather than needing a separate variable and/or set/query functions.
5. Should be able to change tabs in the dialog by using Ctrl-tab (maybe Cmd-tab on Macs?) and by using Alt+first letter of tab name (probably not on a Mac).