### PR TITLE
Downgrade invalid PrefKey message

### DIFF
--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -165,7 +165,7 @@ class Preferences:
                 try:
                     self.dict[PrefKey(key)] = value
                 except ValueError:
-                    assert False, f"'{key}' is not a valid PrefKey"
+                    logger.warning(f"'{key}' is not a valid PrefKey - ignored")
 
     def run_callbacks(self) -> None:
         """Run all defined callbacks, passing value as argument.


### PR DESCRIPTION
An assertion is too annoying for developers and testers, because if you run a "later" release, it saves a new PrefKey in the Prefs file. Then when you run an "earlier" version, it reports that the new PrefKey it loads from the Prefs file is invalid.

Downgrade it to a warning, which will appear in the terminal, since it happens before the GUI has been initialized.