### PR TITLE
Ensure document has a filename before running tool

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -11,7 +11,7 @@ import unicodedata
 import webbrowser
 
 from guiguts.checkers import CheckerSortType
-from guiguts.file import File, NUM_RECENT_FILES
+from guiguts.file import File, the_file, NUM_RECENT_FILES
 from guiguts.maintext import maintext
 from guiguts.mainwindow import (
     MainWindow,
@@ -55,6 +55,7 @@ class Guiguts:
         self.initialize_preferences()
 
         self.file = File(self.filename_changed, self.languages_changed)
+        the_file(self.file)
 
         self.mainwindow = MainWindow()
         self.update_title()

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -21,7 +21,7 @@ from guiguts.page_details import (
 from guiguts.preferences import preferences, PrefKey
 from guiguts.project_dict import ProjectDict, GOOD_WORDS_FILENAME, BAD_WORDS_FILENAME
 from guiguts.root import root
-from guiguts.spell import spell_check_clear_dictionary
+
 from guiguts.utilities import (
     load_dict_from_json,
     IndexRowCol,
@@ -129,8 +129,6 @@ class File:
         preferences.set(PrefKey.DEFAULTLANGUAGES, value)
         # Inform maintext, so text manipulation algorithms there can check languages
         maintext().set_languages(value)
-        # Clear any existing spell checker dictionary
-        spell_check_clear_dictionary()
 
     def reset(self) -> None:
         """Reset file internals to defaults, e.g. filename, page markers, etc.
@@ -775,3 +773,18 @@ def bin_name(basename: str) -> str:
         Name of associated bin file.
     """
     return basename + BINFILE_SUFFIX
+
+
+# For convenient access, store the single File instance here,
+# with a function to set/query it.
+_the_file = None  # pylint: disable=invalid-name
+
+
+def the_file(file: Optional[File] = None) -> File:
+    """Store and return the single File widget"""
+    global _the_file
+    if file is not None:
+        assert _the_file is None
+        _the_file = file
+    assert _the_file is not None
+    return _the_file

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -1,9 +1,12 @@
 """Miscellaneous tools."""
 
 import logging
+from tkinter import messagebox
+
 import regex as re
 
 from guiguts.checkers import CheckerDialog, CheckerEntry
+from guiguts.file import the_file
 from guiguts.maintext import maintext
 from guiguts.utilities import IndexRowCol, IndexRange, cmd_ctrl_string
 from guiguts.widgets import ToolTip
@@ -12,6 +15,25 @@ logger = logging.getLogger(__package__)
 
 BLOCK_TYPES = "[$*XxFf]"
 POEM_TYPES = "[Pp]"
+
+
+def tool_save() -> bool:
+    """File must be saved before running tool, so check if it has been,
+    and if not, check if user wants to save, or cancel the tool run.
+
+    Returns:
+        True if OK to continue with intended operation.
+    """
+    if the_file().filename:
+        return True
+
+    save = messagebox.askokcancel(
+        title="Save document",
+        message="Document must be saved before running tool",
+        icon=messagebox.INFO,
+    )
+    # User could cancel from messagebox or save-as dialog
+    return save and bool(the_file().save_file())
 
 
 def process_fixup(checker_entry: CheckerEntry) -> None:
@@ -65,6 +87,9 @@ def sort_key_type(
 
 def basic_fixup_check() -> None:
     """Check the currently loaded file for basic fixup errors."""
+
+    if not tool_save():
+        return
 
     checker_dialog = CheckerDialog.show_dialog(
         "Basic Fixup Check Results",

--- a/src/guiguts/tools/jeebies.py
+++ b/src/guiguts/tools/jeebies.py
@@ -11,6 +11,7 @@ import regex as re
 from guiguts.checkers import CheckerDialog
 from guiguts.data import dictionaries
 from guiguts.maintext import maintext
+from guiguts.misc_tools import tool_save
 from guiguts.preferences import (
     PersistentString,
     PrefKey,
@@ -670,6 +671,9 @@ class JeebiesChecker:
 def jeebies_check() -> None:
     """Check for jeebies in the currently loaded file."""
     global _the_jeebies_checker
+
+    if not tool_save():
+        return
 
     if _the_jeebies_checker is None:
         try:

--- a/src/guiguts/tools/pptxt.py
+++ b/src/guiguts/tools/pptxt.py
@@ -6,6 +6,7 @@ import regex as re
 from guiguts.checkers import CheckerDialog
 from guiguts.file import ProjectDict
 from guiguts.maintext import maintext
+from guiguts.misc_tools import tool_save
 from guiguts.utilities import IndexRowCol, IndexRange
 from guiguts.widgets import ToolTip
 
@@ -2488,6 +2489,9 @@ def pptxt(project_dict: ProjectDict) -> None:
     global hyphenated_words_dictionary
     global found_long_doctype_declaration
     global ssq, sdq, csq, cdq
+
+    if not tool_save():
+        return
 
     found_long_doctype_declaration = False
 

--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -10,6 +10,7 @@ import regex as re
 from guiguts.file import PAGE_SEPARATOR_REGEX
 from guiguts.maintext import maintext
 from guiguts.mainwindow import ScrolledReadOnlyText
+from guiguts.misc_tools import tool_save
 from guiguts.preferences import (
     preferences,
     PersistentBoolean,
@@ -587,6 +588,9 @@ class WordFrequencyDialog(ToplevelDialog):
 def word_frequency() -> None:
     """Do word frequency analysis on file."""
     global _the_word_lists
+
+    if not tool_save():
+        return
 
     _the_word_lists = WFWordLists()
 


### PR DESCRIPTION
1. If tool is run on a document that has never been saved, then it does not have a "project folder" in which to put files like the project dictionary. So, check file has a filename before running the tool.
2. This required something I've been avoiding for a while - making the single File object accessible from all the higher level routines. Function `the_file` now returns the single File object (similar to how `maintext` works).
3. Unfortunately file.py imported spell.py in order to reset the current spelling dictionary, which was the wrong way round, in that the file shouldn't know about the spell check tool, but came about because of my previous reluctance to do point 2 above.
4. Now point 2 has been done, the spell checker keeps a record of which languages it has loaded, and resets if it is asked to spell check a file with different languages.
5. The structure makes more sense now (at least to me) - there are just a few objects that are essentially singletons that it is a pain to pass around everywhere, so having a function that returns them seems like the least bad option.