### PR TITLE
Tidy up when dialog is destroyed

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -295,6 +295,7 @@ class CheckerDialog(ToplevelDialog):
 
     def reset(self) -> None:
         """Reset dialog and associated structures & marks."""
+        super().reset()
         self.entries: list[CheckerEntry] = []
         self.count_linked_entries = 0
         self.section_count = 0

--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -391,6 +391,7 @@ class WordFrequencyDialog(ToplevelDialog):
 
     def reset(self) -> None:
         """Reset dialog."""
+        super().reset()
         self.entries: list[WordFrequencyEntry] = []
         if not self.winfo_exists():
             return


### PR DESCRIPTION
For now, just tooltips need to be deleted when a dialog is destroyed, because the tooltips are Toplevel widgets in their own right, so are not automatically destroyed when the widget they belong to is destroyed.

Register each tooltip of a child of a TopLevelDialog, and when that dialog is destroyed, destroy the tooltips.