### PR TITLE
Add rewrap functionailty

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -285,6 +285,15 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         preferences.set_default(
             PrefKey.JEEBIES_PARANOIA_LEVEL, JeebiesParanoiaLevel.NORMAL
         )
+        preferences.set_default(PrefKey.WRAP_LEFT_MARGIN, 0)
+        preferences.set_default(PrefKey.WRAP_RIGHT_MARGIN, 72)
+        preferences.set_default(PrefKey.WRAP_BLOCKQUOTE_INDENT, 2)
+        preferences.set_default(PrefKey.WRAP_BLOCKQUOTE_RIGHT_MARGIN, 72)
+        preferences.set_default(PrefKey.WRAP_BLOCK_INDENT, 2)
+        preferences.set_default(PrefKey.WRAP_POETRY_INDENT, 4)
+        preferences.set_default(PrefKey.WRAP_INDEX_MAIN_MARGIN, 2)
+        preferences.set_default(PrefKey.WRAP_INDEX_WRAP_MARGIN, 8)
+        preferences.set_default(PrefKey.WRAP_INDEX_RIGHT_MARGIN, 72)
 
         # Check all preferences have a default
         for pref_key in PrefKey:
@@ -418,17 +427,20 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
 
     def init_tools_menu(self) -> None:
         """Create the Tools menu."""
-        menu_edit = Menu(menubar(), "~Tools")
-        menu_edit.add_button("Basic Fi~xup", basic_fixup_check)
-        menu_edit.add_button("~Word Frequency", word_frequency)
-        menu_edit.add_button(
+        menu_tools = Menu(menubar(), "~Tools")
+        menu_tools.add_button("Basic Fi~xup", basic_fixup_check)
+        menu_tools.add_button("~Word Frequency", word_frequency)
+        menu_tools.add_button(
             "~Spelling Check",
             lambda: spell_check(
                 self.file.project_dict, self.file.add_good_word_to_project_dictionary
             ),
         )
-        menu_edit.add_button("PP~txt", lambda: pptxt(self.file.project_dict))
-        menu_edit.add_button("~Jeebies", jeebies_check)
+        menu_tools.add_button("PP~txt", lambda: pptxt(self.file.project_dict))
+        menu_tools.add_button("~Jeebies", jeebies_check)
+        menu_tools.add_separator()
+        menu_tools.add_button("~Rewrap All", self.file.rewrap_all)
+        menu_tools.add_button("R~ewrap Selection", self.file.rewrap_selection)
 
     def init_view_menu(self) -> None:
         """Create the View menu."""

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1277,6 +1277,12 @@ class MainText(tk.Text):
 
         # Output any last paragraph
         if paragraph:
+            # If paragraph runs right to end of file, ensure it has a terminating newline
+            if (
+                IndexRowCol(maintext().index(f"{line_start} +1l")).row
+                == maintext().end().row
+            ):
+                maintext().insert(tk.END, "\n")
             self.wrap_paragraph(
                 paragraph_start,
                 f"{line_start} +1l",

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1345,10 +1345,9 @@ class MainText(tk.Text):
         while self.compare(line_start, "<", end_index):
             next_start = self.index(f"{line_start} +1l")
             left_limit, right_limit = self.wrap_get_block_limits(line_start, next_start)
-            indent = (
-                int((right_margin - left_margin - (right_limit - left_limit)) / 2)
-                - left_limit
-            )
+            # Indent required is the difference between half the margin range and
+            # half the block width, i.e. move the block center to the margin center.
+            indent = int((right_margin + left_margin - (right_limit + left_limit)) / 2)
             self.wrap_reindent_block(line_start, next_start, indent)
             line_start = next_start
 

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1205,12 +1205,15 @@ class MainText(tk.Text):
 
                     # Handle complete center block
                     elif block_type == "c":
-                        self.wrap_center_block(
-                            line_start,
-                            close_index,
-                            block_params_list[-1].left,
-                            block_params_list[-1].right,
+                        default_center = int(
+                            (block_params_list[-1].left + block_params_list[-1].right)
+                            / 2
                         )
+                        center_point = self.wrap_interpret_single_margin(
+                            match[2],
+                            default_center,
+                        )
+                        self.wrap_center_block(line_start, close_index, center_point)
 
                     # Handle complete index block
                     elif block_type == "i":
@@ -1330,7 +1333,7 @@ class MainText(tk.Text):
         self.insert(paragraph_start, wrapped + "\n")
 
     def wrap_center_block(
-        self, start_index: str, end_index: str, left_margin: int, right_margin: int
+        self, start_index: str, end_index: str, center_point: int
     ) -> None:
         """Center each line in the block between start_index and end_index
         within the given margins.
@@ -1338,16 +1341,13 @@ class MainText(tk.Text):
         Args:
             start_index: Beginning of first line to center.
             end_index: Beginning of line immediately after text block (the "c/" line).
-            left_margin: Left margin to wrap between.
-            right_margin: Right margin to wrap between.
+            center_point: Column to center on.
         """
         line_start = start_index
         while self.compare(line_start, "<", end_index):
             next_start = self.index(f"{line_start} +1l")
             left_limit, right_limit = self.wrap_get_block_limits(line_start, next_start)
-            # Indent required is the difference between half the margin range and
-            # half the block width, i.e. move the block center to the margin center.
-            indent = int((right_margin + left_margin - (right_limit + left_limit)) / 2)
+            indent = center_point - int((right_limit + left_limit) / 2)
             self.wrap_reindent_block(line_start, next_start, indent)
             line_start = next_start
 

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__package__)
 
 TK_ANCHOR_MARK = "tk::anchor1"
 WRAP_NEXT_LINE_MARK = "WrapParagraphStart"
+INDEX_END_MARK = "IndexEnd"
 INDEX_NEXT_LINE_MARK = "IndexLineStart"
 WRAP_END_MARK = "WrapSectionEnd"
 PAGE_FLAG_TAG = "PageFlag"
@@ -1367,14 +1368,20 @@ class MainText(tk.Text):
 
         Args:
             start_index: Beginning of first line to center.
-            end_index: Beginning of line immediately after text block (the "c/" line).
+            end_index: Beginning of line immediately after text block (the "i/" line).
             left_margin: Left margin that long lines wrap to.
             main_margin: Left margin for main index entries
             right_margin: Right margin to wrap between.
             wrapper: TextWrapper object to perform the wrapping - re-used for efficiency.
         """
+        # Mark end_index in case wrapping below changes line numbering
+        self.set_mark_position(
+            INDEX_END_MARK,
+            IndexRowCol(end_index),
+            tk.RIGHT,
+        )
         line_start = start_index
-        while self.compare(line_start, "<", end_index):
+        while self.compare(line_start, "<", INDEX_END_MARK):
             line_end = self.index(f"{line_start} lineend")
             line = self.get(line_start, line_end).rstrip()
             # Don't include pagemark pins in calculations, since removed after wrapping

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -2,8 +2,12 @@
 
 from tkinter import ttk
 
-from guiguts.preferences import PrefKey, PersistentBoolean
-from guiguts.widgets import ToplevelDialog
+from guiguts.preferences import (
+    PrefKey,
+    PersistentBoolean,
+    PersistentInt,
+)
+from guiguts.widgets import ToplevelDialog, ToolTip
 
 
 class PreferencesDialog(ToplevelDialog):
@@ -41,9 +45,78 @@ class PreferencesDialog(ToplevelDialog):
             variable=PersistentBoolean(PrefKey.BELL_VISUAL),
         ).grid(column=2, row=0, sticky="NEW")
 
-        # Processing tab
-        processing_frame = ttk.LabelFrame(self.top_frame, text="Processing", padding=10)
-        processing_frame.grid(column=0, row=1, sticky="NSEW", pady=(10, 0))
-        ttk.Label(processing_frame, text="Nothing to see here yet").grid(
-            column=0, row=0, sticky="NEW"
+        # Wrapping tab
+        wrapping_frame = ttk.LabelFrame(self.top_frame, text="Wrapping", padding=10)
+        wrapping_frame.grid(column=0, row=1, sticky="NSEW", pady=(10, 0))
+
+        def add_label_spinbox(row: int, label: str, key: PrefKey, tooltip: str) -> None:
+            """Add a label and spinbox to the wrapping frame.
+            Args:
+                label: Text for label.
+                key: Prefs key to use to store preference.
+                tooltip: Text for tooltip.
+            """
+            ttk.Label(wrapping_frame, text=label).grid(
+                column=0, row=row, sticky="NE", pady=2
+            )
+            spinbox = ttk.Spinbox(
+                wrapping_frame,
+                textvariable=PersistentInt(key),
+                from_=0,
+                to=999,
+                width=5,
+            )
+            spinbox.grid(column=1, row=row, sticky="NW", padx=5, pady=2)
+            ToolTip(spinbox, tooltip)
+
+        add_label_spinbox(
+            0, "Left Margin:", PrefKey.WRAP_LEFT_MARGIN, "Left margin for normal text."
+        )
+        add_label_spinbox(
+            1,
+            "Right Margin:",
+            PrefKey.WRAP_RIGHT_MARGIN,
+            "Right margin for normal text.",
+        )
+        add_label_spinbox(
+            2,
+            "Blockquote Indent:",
+            PrefKey.WRAP_BLOCKQUOTE_INDENT,
+            "Extra indent for each level of blockquotes.",
+        )
+        add_label_spinbox(
+            3,
+            "Blockquote Right Margin:",
+            PrefKey.WRAP_BLOCKQUOTE_RIGHT_MARGIN,
+            "Right margin for blockquotes.",
+        )
+        add_label_spinbox(
+            4,
+            "Block Indent:",
+            PrefKey.WRAP_BLOCK_INDENT,
+            "Indent for /*, /P, /L blocks.",
+        )
+        add_label_spinbox(
+            5,
+            "Poetry Indent:",
+            PrefKey.WRAP_POETRY_INDENT,
+            "Indent for /P poetry blocks.",
+        )
+        add_label_spinbox(
+            6,
+            "Index Main Entry Margin:",
+            PrefKey.WRAP_INDEX_MAIN_MARGIN,
+            "Indent for main entries in index - sub-entries retain their indent relative to this.",
+        )
+        add_label_spinbox(
+            8,
+            "Index Wrap Margin:",
+            PrefKey.WRAP_INDEX_WRAP_MARGIN,
+            "Left margin for all lines rewrapped in index.",
+        )
+        add_label_spinbox(
+            9,
+            "Index Right Margin:",
+            PrefKey.WRAP_INDEX_RIGHT_MARGIN,
+            "Right margin for index entries.",
         )

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -42,6 +42,15 @@ class PrefKey(StrEnum):
     ROOT_GEOMETRY = auto()
     DEFAULT_LANGUAGES = auto()
     JEEBIES_PARANOIA_LEVEL = auto()
+    WRAP_LEFT_MARGIN = auto()
+    WRAP_RIGHT_MARGIN = auto()
+    WRAP_BLOCKQUOTE_INDENT = auto()
+    WRAP_BLOCKQUOTE_RIGHT_MARGIN = auto()
+    WRAP_BLOCK_INDENT = auto()
+    WRAP_POETRY_INDENT = auto()
+    WRAP_INDEX_MAIN_MARGIN = auto()
+    WRAP_INDEX_WRAP_MARGIN = auto()
+    WRAP_INDEX_RIGHT_MARGIN = auto()
 
 
 class Preferences:
@@ -213,6 +222,35 @@ class PersistentBoolean(tk.BooleanVar):
         """
         super().__init__(value=preferences.get(prefs_key))
         self.trace_add("write", lambda *_args: preferences.set(prefs_key, self.get()))
+
+
+class PersistentInt(tk.IntVar):
+    """Tk integer variable whose value is stored in user prefs file.
+
+    Note that, like all prefs, the default value must be set in
+    `initialize_preferences`
+    """
+
+    def __init__(self, prefs_key: PrefKey) -> None:
+        """Initialize persistent boolean.
+
+        Args:
+            prefs_key: Preferences key associated with the variable.
+        """
+        super().__init__(value=preferences.get(prefs_key))
+
+        def set_pref(*_args: Any) -> None:
+            """Set the preference if the IntVar holds an int.
+
+            If it's not, e.g. because the entry field it is linked to is empty,
+            or contains non-digits, a tk exception occurs, and we don't set the pref.
+            """
+            try:
+                preferences.set(prefs_key, self.get())
+            except tk.TclError:
+                pass
+
+        self.trace_add("write", set_pref)
 
 
 class PersistentString(tk.StringVar):


### PR DESCRIPTION
Same behavior as Guiguts 1, as documented in the manual: https://www.pgdp.net/wiki/PPTools/Guiguts/Guiguts_Manual/Tools_Menu#Rewrapping

More tolerant regarding blank lines than GG1, e.g. if no blank line before/after markup or between nested markups, it should still work correctly.

Only blockquote markup can have other markup nested inside.

Wrapping margins can be set in the Prefs dialog, or as described in the manual, can be overridden using markup for some types, e.g. `/#[8.4,68]`

At present, rewrapping uses the "greedy" algorithm (via the standard python `textwrap` module), that used to be in GG 1.0.25. The other (Knuth-Plass) algorithm that was in GG 1.0.25 may be added to GG2 at a later date if desired.

FIxes #54