### PR TITLE
Implement Page Separator Fixup

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -22,7 +22,7 @@ from guiguts.mainwindow import (
     ErrorHandler,
 )
 from guiguts.misc_dialogs import PreferencesDialog
-from guiguts.misc_tools import basic_fixup_check
+from guiguts.misc_tools import basic_fixup_check, page_separator_fixup, PageSepAutoType
 from guiguts.page_details import PageDetailsDialog
 from guiguts.preferences import preferences, PrefKey
 from guiguts.root import root
@@ -294,6 +294,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         preferences.set_default(PrefKey.WRAP_INDEX_MAIN_MARGIN, 2)
         preferences.set_default(PrefKey.WRAP_INDEX_WRAP_MARGIN, 8)
         preferences.set_default(PrefKey.WRAP_INDEX_RIGHT_MARGIN, 72)
+        preferences.set_default(PrefKey.PAGESEP_AUTO_TYPE, PageSepAutoType.AUTO_FIX)
 
         # Check all preferences have a default
         for pref_key in PrefKey:
@@ -438,6 +439,8 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         )
         menu_tools.add_button("PP~txt", lambda: pptxt(self.file.project_dict))
         menu_tools.add_button("~Jeebies", jeebies_check)
+        menu_tools.add_separator()
+        menu_tools.add_button("Fixup ~Page Separators", page_separator_fixup)
         menu_tools.add_separator()
         menu_tools.add_button("~Rewrap All", self.file.rewrap_all)
         menu_tools.add_button("R~ewrap Selection", self.file.rewrap_selection)

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -359,6 +359,7 @@ class PageSeparatorDialog(ToplevelDialog):
         if (sep_range := self.find()) is None:
             return
 
+        self.fix_pagebreak_markup(sep_range)
         maintext().delete(sep_range.start.index(), sep_range.end.index())
         prev_eol = f"{sep_range.start.index()} -1l lineend"
         maybe_hyphen = maintext().get(f"{prev_eol}-1c", prev_eol)
@@ -525,6 +526,8 @@ class PageSeparatorDialog(ToplevelDialog):
 
         # Auto-fix: Loop through page separators, fixing them if possible
         while sep_range := self.find():
+            # Fix markup across page break, even though the join function would fix it later,
+            # because otherwise it would interfere with check for automated joining below.
             self.fix_pagebreak_markup(sep_range)
             line_prev = maintext().get(
                 f"{sep_range.start.index()}-1l lineend -10c",

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -51,6 +51,7 @@ class PrefKey(StrEnum):
     WRAP_INDEX_MAIN_MARGIN = auto()
     WRAP_INDEX_WRAP_MARGIN = auto()
     WRAP_INDEX_RIGHT_MARGIN = auto()
+    PAGESEP_AUTO_TYPE = auto()
 
 
 class Preferences:

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -118,6 +118,20 @@ class ToplevelDialog(tk.Toplevel):
             tooltip - the ToolTip widget to register"""
         self.tooltip_list.append(tooltip)
 
+    def key_bind(self, accel: str, handler: Callable[[], None]) -> None:
+        """Convert given accelerator string to a key-event string and bind both
+        the upper & lower case versions to the given handler.
+
+        Args:
+            accel: Accelerator string, e.g. "Cmd/Ctrl+Z", to trigger call to ``handler``.
+            handler: Callback function to be bound to ``accel``.
+        """
+        _, key_event = process_accel(accel)
+        lk = re.sub("[A-Z]>?$", lambda m: m.group(0).lower(), key_event)
+        self.bind(lk, lambda _: handler())
+        uk = re.sub("[a-z]>?$", lambda m: m.group(0).upper(), key_event)
+        self.bind(uk, lambda _: handler())
+
     def tidy_up(self, event: tk.Event) -> None:
         """Tidy up when the dialog is destroyed.
 


### PR DESCRIPTION
1. Menu entry added to Tools menu.
2. Behavior generally similar to GG1
3. "Auto Fix" option is like "99% Auto" in GG1, but a more conservative when there are hyphens or hyphen-asterisks before/after the page separator. These need a human eye.
4. Reason for Undo/Redo buttons is that these need to normal undo/redo but then to re-view the first page separator that needs fixing, which a simple Undo/Redo can't do.
5. The "undo block" methods will be replaced by more general MainText methods at a later date. The idea is that a single "undo/redo" will undo/redo all the changes made by the last mouse click.
6. Various key bindings have been set up, to mostly match or augment those in GG1. In Windows, at least, the buttons have and underline under the character that will work as a shortcut when focus is on the dialog (where it remains during the process). No need for Cmd or Ctrl, just the letter, e.g. "j" for "Join". Some have an additional shortcut, e.g. the Blank, Section, Chapter ones also allow you to press the key for the number of blank lines i.e. 1, 2 or 4. Also, the normal undo & redo shortcuts (like Ctrl+Z) work as shortcuts to the Undo/Redo buttons in addition to "u" and "e".
7. The "Auto" setting is stored in the prefs file. Note that with "Auto Fix", it doesn't start fixing as soon as the dialog is popped, because users found that disconcerting when GG1 did it. So, just like GG1, you need to do something in the dialog, typically click Refresh or the "Auto Fix" radio button, but it could be one of the manual fix buttons, like Delete, which it will first do, then continue automatically.