### PR TITLE
Add text file "Unmatched..." checks

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -453,7 +453,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_tools.add_button("~Rewrap All", self.file.rewrap_all)
         menu_tools.add_button("R~ewrap Selection", self.file.rewrap_selection)
         menu_tools.add_separator()
-        menu_tools.add_button("~Unmatched DP Markup", unmatched_markup_dp)
+        menu_tools.add_button("~Unmatched DP Markup", unmatched_dp_markup)
         menu_tools.add_button("Unmatched Bloc~k Markup", unmatched_block_markup)
         menu_tools.add_button("Unmatched ~DP Markup", unmatched_dp_markup)
         menu_tools.add_button("Unmatched ~Brackets", unmatched_brackets)

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -22,7 +22,12 @@ from guiguts.mainwindow import (
     ErrorHandler,
 )
 from guiguts.misc_dialogs import PreferencesDialog
-from guiguts.misc_tools import basic_fixup_check, page_separator_fixup, PageSepAutoType
+from guiguts.misc_tools import (
+    basic_fixup_check,
+    page_separator_fixup,
+    PageSepAutoType,
+    unmatched_markup_dp,
+)
 from guiguts.page_details import PageDetailsDialog
 from guiguts.preferences import preferences, PrefKey
 from guiguts.root import root
@@ -444,6 +449,8 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_tools.add_separator()
         menu_tools.add_button("~Rewrap All", self.file.rewrap_all)
         menu_tools.add_button("R~ewrap Selection", self.file.rewrap_selection)
+        menu_tools.add_separator()
+        menu_tools.add_button("~Unmatched DP Markup", unmatched_markup_dp)
 
     def init_view_menu(self) -> None:
         """Create the View menu."""

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -22,7 +22,7 @@ from guiguts.mainwindow import (
     ErrorHandler,
 )
 from guiguts.misc_dialogs import PreferencesDialog
-from guiguts.misc_tools import basic_fixup_check
+from guiguts.misc_tools import basic_fixup_check, page_separator_fixup, PageSepAutoType
 from guiguts.page_details import PageDetailsDialog
 from guiguts.preferences import preferences, PrefKey
 from guiguts.root import root
@@ -294,6 +294,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         preferences.set_default(PrefKey.WRAP_INDEX_MAIN_MARGIN, 2)
         preferences.set_default(PrefKey.WRAP_INDEX_WRAP_MARGIN, 8)
         preferences.set_default(PrefKey.WRAP_INDEX_RIGHT_MARGIN, 72)
+        preferences.set_default(PrefKey.PAGESEP_AUTO_TYPE, PageSepAutoType.AUTO_FIX)
 
         # Check all preferences have a default
         for pref_key in PrefKey:
@@ -438,6 +439,8 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         )
         menu_tools.add_button("PP~txt", lambda: pptxt(self.file.project_dict))
         menu_tools.add_button("~Jeebies", jeebies_check)
+        menu_tools.add_separator()
+        menu_tools.add_button("Fixup ~Page Separators", page_separator_fixup)
         menu_tools.add_separator()
         menu_tools.add_button("~Rewrap All", self.file.rewrap_all)
         menu_tools.add_button("R~ewrap Selection", self.file.rewrap_selection)

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -26,7 +26,10 @@ from guiguts.misc_tools import (
     basic_fixup_check,
     page_separator_fixup,
     PageSepAutoType,
-    unmatched_markup_dp,
+    unmatched_dp_markup,
+    unmatched_brackets,
+    unmatched_curly_quotes,
+    unmatched_block_markup,
 )
 from guiguts.page_details import PageDetailsDialog
 from guiguts.preferences import preferences, PrefKey
@@ -451,6 +454,10 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_tools.add_button("R~ewrap Selection", self.file.rewrap_selection)
         menu_tools.add_separator()
         menu_tools.add_button("~Unmatched DP Markup", unmatched_markup_dp)
+        menu_tools.add_button("Unmatched Bloc~k Markup", unmatched_block_markup)
+        menu_tools.add_button("Unmatched ~DP Markup", unmatched_dp_markup)
+        menu_tools.add_button("Unmatched ~Brackets", unmatched_brackets)
+        menu_tools.add_button("Unmatched Curly ~Quotes", unmatched_curly_quotes)
 
     def init_view_menu(self) -> None:
         """Create the View menu."""

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -453,7 +453,6 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_tools.add_button("~Rewrap All", self.file.rewrap_all)
         menu_tools.add_button("R~ewrap Selection", self.file.rewrap_selection)
         menu_tools.add_separator()
-        menu_tools.add_button("~Unmatched DP Markup", unmatched_dp_markup)
         menu_tools.add_button("Unmatched Bloc~k Markup", unmatched_block_markup)
         menu_tools.add_button("Unmatched ~DP Markup", unmatched_dp_markup)
         menu_tools.add_button("Unmatched ~Brackets", unmatched_brackets)

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -838,10 +838,10 @@ class MainText(tk.Text):
         self,
         search_string: str,
         start_range: IndexRowCol | IndexRange,
-        nocase: bool,
-        regexp: bool,
-        wholeword: bool,
-        backwards: bool,
+        nocase: bool = False,
+        regexp: bool = False,
+        wholeword: bool = False,
+        backwards: bool = False,
     ) -> Optional[FindMatch]:
         """Find occurrence of string/regex in given range.
 

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1104,7 +1104,6 @@ class MainText(tk.Text):
         # Loop until we reach the end of the whole section we want to rewrap
         while self.compare(WRAP_NEXT_LINE_MARK, "<", WRAP_END_MARK):
             line_start = self.index(WRAP_NEXT_LINE_MARK)
-            start_rowcol = IndexRowCol(line_start)
             self.set_mark_position(
                 WRAP_NEXT_LINE_MARK,
                 IndexRowCol(self.index(f"{line_start} +1l")),
@@ -1178,8 +1177,9 @@ class MainText(tk.Text):
                         )
                     else:
                         tidy_function()
+                        next_line_rowcol = IndexRowCol(self.index(WRAP_NEXT_LINE_MARK))
                         logger.error(
-                            f"No closing markup found to match /{block_type} near line {start_rowcol.row}"
+                            f"No closing markup found to match /{block_type} at line {next_line_rowcol.row-1}"
                         )
                         return
 
@@ -1257,8 +1257,9 @@ class MainText(tk.Text):
                 # End blocks should have been dealt with by the begin block code
                 elif match := re.fullmatch(r"([\$\*xfcrpl]/)", trimmed):
                     tidy_function()
+                    next_line_rowcol = IndexRowCol(self.index(WRAP_NEXT_LINE_MARK))
                     logger.error(
-                        f"{match[1]} markup error near line {start_rowcol.row}"
+                        f"{match[1]} markup error at line {next_line_rowcol.row-1}"
                     )
                     return
                 else:
@@ -1288,8 +1289,9 @@ class MainText(tk.Text):
                         raise IndexError
                 except IndexError:
                     tidy_function()
+                    next_line_rowcol = IndexRowCol(self.index(WRAP_NEXT_LINE_MARK))
                     logger.error(
-                        f"Block quote markup error near line {start_rowcol.row}"
+                        f"Block quote markup error at line {next_line_rowcol.row-1}"
                     )
                     return
             bq_depth += bq_depth_change

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -416,6 +416,17 @@ class MainText(tk.Text):
             focus: Optional, False means focus will not be forced to maintext
         """
         self.mark_set(tk.INSERT, insert_pos.index())
+        # The `see` method can leave the desired line at the top or bottom of window.
+        # So, we "see" lines above and below desired line incrementally up to
+        # half window height each way, ensuring desired line is left in the middle.
+        # If performance turns out to be an issue, consider giving `step` to `range`.
+        # Step should be smaller than half minimum likely window height.
+        start_index = self.index(f"@0,{int(self.cget('borderwidth'))} linestart")
+        end_index = self.index(f"@0,{self.winfo_height()} linestart")
+        n_lines = IndexRowCol(end_index).row - IndexRowCol(start_index).row
+        for inc in range(1, int(n_lines / 2) + 1):
+            self.see(f"{tk.INSERT}-{inc}l")
+            self.see(f"{tk.INSERT}+{inc}l")
         self.see(tk.INSERT)
         if focus:
             self.focus_set()

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__package__)
 
 BLOCK_TYPES = "[$*XxFf]"
 POEM_TYPES = "[Pp]"
-ALL_BLOCKS_REG = f"[{re.escape('#$*FfIiLlPpXxCcRr')}]"
+ALL_BLOCKS_REG = f"[{re.escape('#$*FILPXCR')}]"
 
 
 def tool_save() -> bool:
@@ -591,34 +591,34 @@ def unmatched_brackets() -> None:
     """Check for unmatched brackets."""
 
     def toggle_bracket(bracket_in: str) -> tuple[str, bool]:
-        """Convert open bracket to closed and vice versa.
+        """Get regex that matches open and close bracket.
 
         Args:
             bracket_in: Bracket - must be one of ( [ { ) ] }
 
         Returns:
-            Tuple with opposite bracket, True if bracket_in was close bracket.
+            Tuple with regex, True if bracket_in was close bracket.
         """
         match bracket_in:
             case "(":
-                return ")", False
+                return "[)(]", False
             case ")":
-                return "(", True
+                return "[)(]", True
             case "{":
-                return "}", False
+                return "[}{]", False
             case "}":
-                return "{", True
+                return "[}{]", True
             case "[":
-                return "]", False
+                return "[][]", False
             case "]":
-                return "[", True
+                return "[][]", True
         assert False, f"'{bracket_in}' is not a bracket character"
 
     unmatched_markup_check(
         "Unmatched Brackets",
         rerun_command=unmatched_brackets,
         match_reg="[][}{)(]",
-        toggle_func=toggle_bracket,
+        match_pair_func=toggle_bracket,
     )
 
 
@@ -626,44 +626,44 @@ def unmatched_curly_quotes() -> None:
     """Check for unmatched curly quotes."""
 
     def toggle_quote(quote_in: str) -> tuple[str, bool]:
-        """Convert open quote to closed and vice versa.
+        """Get regex that matches open and close quote.
 
         Args:
             quote_in: Quote - must be one of ‘ ’ “ ”
 
         Returns:
-            Tuple with opposite bracket, True if bracket_in was close bracket.
+            Tuple with regex, True if bracket_in was close bracket.
         """
         match quote_in:
             case "‘":
-                return "’", False
+                return "[‘’]", False
             case "’":
-                return "‘", True
+                return "[‘’]", True
             case "“":
-                return "”", False
+                return "[“”]", False
             case "”":
-                return "“", True
+                return "[“”]", True
         assert False, f"'{quote_in}' is not a curly quote"
 
     unmatched_markup_check(
         "Unmatched Curly Quotes",
         rerun_command=unmatched_curly_quotes,
         match_reg="[‘’“”]",
-        toggle_func=toggle_quote,
+        match_pair_func=toggle_quote,
     )
 
 
 def unmatched_dp_markup() -> None:
     """Check for unmatched DP markup."""
 
-    def toggle_dp_markup(markup_in: str) -> tuple[str, bool]:
-        """Convert open DP markup to closed and vice versa.
+    def matched_pair_dp_markup(markup_in: str) -> tuple[str, bool]:
+        """Get regex that matches open and close DP markup.
 
         Args:
             markup_in: Markup string - must be "<i>", "</b>", "<sc>", etc.
 
         Returns:
-            Tuple with opposite markup to markup_in, True if markup_in was close markup.
+            Tuple with regex, True if markup_in was close markup.
         """
         if markup_in[1] == "/":
             return markup_in[:1] + markup_in[2:], True
@@ -673,7 +673,7 @@ def unmatched_dp_markup() -> None:
         "Unmatched DP markup",
         rerun_command=unmatched_dp_markup,
         match_reg="<[a-z]+>|</[a-z]+>",
-        toggle_func=toggle_dp_markup,
+        match_pair_func=matched_pair_dp_markup,
         ignore_reg="<tb>",
     )
 
@@ -681,24 +681,25 @@ def unmatched_dp_markup() -> None:
 def unmatched_block_markup() -> None:
     """Check for unmatched block markup."""
 
-    def toggle_block_markup(markup_in: str) -> tuple[str, bool]:
-        """Convert open block markup to closed and vice versa.
+    def match_pair_block_markup(markup_in: str) -> tuple[str, bool]:
+        """Get regex that matches open and close block markup.
 
         Args:
             markup_in: Markup string - must be "/#", "/*", "C/", etc.
 
         Returns:
-            Tuple with opposite markup to markup_in, True if markup_in was close markup.
+            Tuple with regex, True if markup_in was close markup.
         """
-        if markup_in[1] == "/":
-            return "/" + markup_in[0], True
-        return markup_in[1] + "/", False
+        close = markup_in[1] == "/"
+        block_type = markup_in[0] if close else markup_in[1]
+        block_type = re.escape(block_type)
+        return f"^(/{block_type}|{block_type}/)", close
 
     unmatched_markup_check(
-        "Unmatched DP markup",
+        "Unmatched Block markup",
         rerun_command=unmatched_block_markup,
         match_reg=f"^(/{ALL_BLOCKS_REG}|{ALL_BLOCKS_REG}/)",
-        toggle_func=toggle_block_markup,
+        match_pair_func=match_pair_block_markup,
         nest_reg="/#|#/",
     )
 
@@ -707,7 +708,7 @@ def unmatched_markup_check(
     title: str,
     rerun_command: Callable[[], None],
     match_reg: str,
-    toggle_func: Callable[[str], tuple[str, bool]],
+    match_pair_func: Callable[[str], tuple[str, bool]],
     nest_reg: Optional[str] = None,
     ignore_reg: Optional[str] = None,
 ) -> None:
@@ -735,21 +736,27 @@ def unmatched_markup_check(
 
     search_range = IndexRange(maintext().start(), maintext().end())
     # Find each piece of markup that matches the regex
-    while match := maintext().find_match(match_reg, search_range, regexp=True):
+    while match := maintext().find_match(
+        match_reg, search_range, regexp=True, nocase=True
+    ):
         match_index = match.rowcol.index()
         after_match = maintext().index(f"{match_index}+{match.count}c")
         search_range = IndexRange(after_match, maintext().end())
         match_str = maintext().get_match_text(match)
         # Ignore if it matches the ignore regex
-        if ignore_reg and re.fullmatch(ignore_reg, match_str):
+        if ignore_reg and re.fullmatch(ignore_reg, match_str, flags=re.IGNORECASE):
             continue
-        # Get the pair to the match (e.g. </i> for <i>)
-        pair_str, reverse = toggle_func(match_str)
+        # Get a regex that will find the match and the pair( e.g. "(<i>|</i>)")
+        match_pair_reg, reverse = match_pair_func(match_str)
         # Is this markup permitted to nest?
-        nestable = bool(nest_reg and re.fullmatch(nest_reg, match_str))
+        nestable = bool(
+            nest_reg and re.fullmatch(nest_reg, match_str, flags=re.IGNORECASE)
+        )
         prefix = "Unmatched "
         # Search for the matching pair to this markup
-        if not find_match_pair(match_index, match_str, pair_str, reverse, nestable):
+        if not find_match_pair(
+            match_index, match_str, match_pair_reg, reverse, nestable
+        ):
             checker_dialog.add_entry(
                 f"{prefix}{match_str}",
                 IndexRange(match_index, after_match),
@@ -760,7 +767,7 @@ def unmatched_markup_check(
 
 
 def find_match_pair(
-    match_index: str, match_str: str, pair_str: str, reverse: bool, nestable: bool
+    match_index: str, match_str: str, match_pair_reg: str, reverse: bool, nestable: bool
 ) -> str:
     """Find the pair to the given match.
 
@@ -772,7 +779,6 @@ def find_match_pair(
         nestable: True if markup is allowed to nest.
     """
     found = ""
-    regex = f"{re.escape(match_str)}|{re.escape(pair_str)}"
     match_len = len(match_str)
     depth = 1
     start = match_index if reverse else maintext().index(f"{match_index}+{match_len}c")
@@ -782,13 +788,19 @@ def find_match_pair(
     while depth > 0:
         # Search for the given markup and its pair in order to spot nesting
         match = maintext().find_match(
-            regex, IndexRange(start, end), regexp=True, backwards=reverse
+            match_pair_reg,
+            IndexRange(start, end),
+            regexp=True,
+            backwards=reverse,
+            nocase=True,
         )
         if match is None:
             found = ""
             break
 
-        depth += 1 if maintext().get_match_text(match) == match_str else -1
+        depth += (
+            1 if maintext().get_match_text(match).lower() == match_str.lower() else -1
+        )
         # Check it's not nested when nesting isn't allowed
         if depth > 1 and not nestable:
             found = ""

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -693,7 +693,7 @@ def unmatched_block_markup() -> None:
         close = markup_in[1] == "/"
         block_type = markup_in[0] if close else markup_in[1]
         block_type = re.escape(block_type)
-        return f"^(/{block_type}|{block_type}/)", close
+        return rf"^(/{block_type}(\[\d+)?(\.\d+)?(,\d+)?]?|{block_type}/)$", close
 
     unmatched_markup_check(
         "Unmatched Block markup",

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__package__)
 
 BLOCK_TYPES = "[$*XxFf]"
 POEM_TYPES = "[Pp]"
+ALL_BLOCKS_REG = f"[{re.escape('#$*FfIiLlPpXxCcRr')}]"
 
 
 def tool_save() -> bool:
@@ -586,7 +587,73 @@ def page_separator_fixup() -> None:
     dlg.view()
 
 
-def unmatched_markup_dp() -> None:
+def unmatched_brackets() -> None:
+    """Check for unmatched brackets."""
+
+    def toggle_bracket(bracket_in: str) -> tuple[str, bool]:
+        """Convert open bracket to closed and vice versa.
+
+        Args:
+            bracket_in: Bracket - must be one of ( [ { ) ] }
+
+        Returns:
+            Tuple with opposite bracket, True if bracket_in was close bracket.
+        """
+        match bracket_in:
+            case "(":
+                return ")", False
+            case ")":
+                return "(", True
+            case "{":
+                return "}", False
+            case "}":
+                return "{", True
+            case "[":
+                return "]", False
+            case "]":
+                return "[", True
+        assert False, f"'{bracket_in}' is not a bracket character"
+
+    unmatched_markup_check(
+        "Unmatched Brackets",
+        rerun_command=unmatched_brackets,
+        match_reg="[][}{)(]",
+        toggle_func=toggle_bracket,
+    )
+
+
+def unmatched_curly_quotes() -> None:
+    """Check for unmatched curly quotes."""
+
+    def toggle_quote(quote_in: str) -> tuple[str, bool]:
+        """Convert open quote to closed and vice versa.
+
+        Args:
+            quote_in: Quote - must be one of ‘ ’ “ ”
+
+        Returns:
+            Tuple with opposite bracket, True if bracket_in was close bracket.
+        """
+        match quote_in:
+            case "‘":
+                return "’", False
+            case "’":
+                return "‘", True
+            case "“":
+                return "”", False
+            case "”":
+                return "“", True
+        assert False, f"'{quote_in}' is not a curly quote"
+
+    unmatched_markup_check(
+        "Unmatched Curly Quotes",
+        rerun_command=unmatched_curly_quotes,
+        match_reg="[‘’“”]",
+        toggle_func=toggle_quote,
+    )
+
+
+def unmatched_dp_markup() -> None:
     """Check for unmatched DP markup."""
 
     def toggle_dp_markup(markup_in: str) -> tuple[str, bool]:
@@ -604,10 +671,35 @@ def unmatched_markup_dp() -> None:
 
     unmatched_markup_check(
         "Unmatched DP markup",
-        rerun_command=unmatched_markup_dp,
+        rerun_command=unmatched_dp_markup,
         match_reg="<[a-z]+>|</[a-z]+>",
         toggle_func=toggle_dp_markup,
         ignore_reg="<tb>",
+    )
+
+
+def unmatched_block_markup() -> None:
+    """Check for unmatched block markup."""
+
+    def toggle_block_markup(markup_in: str) -> tuple[str, bool]:
+        """Convert open block markup to closed and vice versa.
+
+        Args:
+            markup_in: Markup string - must be "/#", "/*", "C/", etc.
+
+        Returns:
+            Tuple with opposite markup to markup_in, True if markup_in was close markup.
+        """
+        if markup_in[1] == "/":
+            return "/" + markup_in[0], True
+        return markup_in[1] + "/", False
+
+    unmatched_markup_check(
+        "Unmatched DP markup",
+        rerun_command=unmatched_block_markup,
+        match_reg=f"^(/{ALL_BLOCKS_REG}|{ALL_BLOCKS_REG}/)",
+        toggle_func=toggle_block_markup,
+        nest_reg="/#|#/",
     )
 
 
@@ -655,7 +747,7 @@ def unmatched_markup_check(
         pair_str, reverse = toggle_func(match_str)
         # Is this markup permitted to nest?
         nestable = bool(nest_reg and re.fullmatch(nest_reg, match_str))
-        prefix = "Unmatched markup: "
+        prefix = "Unmatched "
         # Search for the matching pair to this markup
         if not find_match_pair(match_index, match_str, pair_str, reverse, nestable):
             checker_dialog.add_entry(

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -666,8 +666,8 @@ def unmatched_dp_markup() -> None:
             Tuple with regex, True if markup_in was close markup.
         """
         if markup_in[1] == "/":
-            return markup_in[:1] + markup_in[2:], True
-        return markup_in[:1] + "/" + markup_in[1:], False
+            return f"(<{markup_in[2:-1]}>|{markup_in})", True
+        return f"({markup_in}|</{markup_in[1:-1]}>)", False
 
     unmatched_markup_check(
         "Unmatched DP markup",

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -1,15 +1,19 @@
 """Miscellaneous tools."""
 
+from enum import StrEnum, auto
 import logging
-from tkinter import messagebox
+import tkinter as tk
+from tkinter import ttk, messagebox
+from typing import Optional
 
 import regex as re
 
 from guiguts.checkers import CheckerDialog, CheckerEntry
 from guiguts.file import the_file
 from guiguts.maintext import maintext
-from guiguts.utilities import IndexRowCol, IndexRange, cmd_ctrl_string
-from guiguts.widgets import ToolTip
+from guiguts.preferences import PrefKey, PersistentString, preferences
+from guiguts.utilities import IndexRowCol, IndexRange, cmd_ctrl_string, is_mac
+from guiguts.widgets import ToolTip, ToplevelDialog
 
 logger = logging.getLogger(__package__)
 
@@ -187,3 +191,396 @@ def basic_fixup_check() -> None:
                     match.end(group) + prefix_len,
                 )
     checker_dialog.display_entries()
+
+
+class PageSepAutoType(StrEnum):
+    """Enum class to store Page Separator sort types."""
+
+    NO_AUTO = auto()
+    AUTO_ADVANCE = auto()
+    AUTO_FIX = auto()
+
+
+class PageSeparatorDialog(ToplevelDialog):
+    """Dialog for fixing page separators."""
+
+    SEPARATOR_REGEX = r"^-----File: .+"
+    BTN_WIDTH = 16
+
+    def __init__(self) -> None:
+        """Initialize messagelog dialog."""
+        super().__init__("Page Separator Fixup", resize_x=False, resize_y=False)
+        for col in range(0, 3):
+            self.top_frame.columnconfigure(col, pad=2, weight=1)
+
+        btn_frame = ttk.Frame(
+            self.top_frame, borderwidth=1, relief=tk.GROOVE, padding=5
+        )
+        btn_frame.grid(column=0, row=0, columnspan=3, sticky="NSEW")
+
+        for row in range(0, 3):
+            btn_frame.rowconfigure(row, pad=2)
+        for col in range(0, 3):
+            btn_frame.columnconfigure(col, pad=2, weight=1)
+        join_button = ttk.Button(
+            btn_frame,
+            text="Join",
+            underline=0,
+            command=lambda: self.join(False),
+            width=self.BTN_WIDTH,
+        )
+        join_button.grid(column=0, row=0, sticky="NSEW")
+        self.key_bind("j", join_button.invoke)
+
+        keep_button = ttk.Button(
+            btn_frame,
+            text="Join, Keep Hyphen",
+            underline=6,
+            command=lambda: self.join(True),
+            width=self.BTN_WIDTH,
+        )
+        keep_button.grid(column=1, row=0, sticky="NSEW")
+        self.key_bind("k", keep_button.invoke)
+
+        delete_button = ttk.Button(
+            btn_frame,
+            text="Delete",
+            underline=0,
+            command=self.delete,
+            width=self.BTN_WIDTH,
+        )
+        delete_button.grid(column=2, row=0, sticky="NSEW")
+        self.key_bind("d", delete_button.invoke)
+
+        blank_button = ttk.Button(
+            btn_frame,
+            text="Blank (1 line)",
+            underline=0,
+            command=lambda: self.blank(1),
+            width=self.BTN_WIDTH,
+        )
+        blank_button.grid(column=0, row=1, sticky="NSEW")
+        self.key_bind("b", blank_button.invoke)
+        self.key_bind("Key-1", blank_button.invoke)
+
+        section_button = ttk.Button(
+            btn_frame,
+            underline=0,
+            text="Section (2 lines)",
+            command=lambda: self.blank(2),
+            width=self.BTN_WIDTH,
+        )
+        section_button.grid(column=1, row=1, sticky="NSEW")
+        self.key_bind("s", section_button.invoke)
+        self.key_bind("Key-2", section_button.invoke)
+
+        chapter_button = ttk.Button(
+            btn_frame,
+            underline=0,
+            text="Chapter (4 lines)",
+            command=lambda: self.blank(4),
+            width=self.BTN_WIDTH,
+        )
+        chapter_button.grid(column=2, row=1, sticky="NSEW")
+        self.key_bind("c", chapter_button.invoke)
+        self.key_bind("Key-4", chapter_button.invoke)
+
+        self.auto_type = PersistentString(PrefKey.PAGESEP_AUTO_TYPE)
+        ttk.Radiobutton(
+            self.top_frame,
+            text="No Auto",
+            command=self.refresh,
+            variable=self.auto_type,
+            value=PageSepAutoType.NO_AUTO,
+            takefocus=False,
+        ).grid(column=0, row=1, sticky="NSEW", padx=(20, 2), pady=2)
+        ttk.Radiobutton(
+            self.top_frame,
+            text="Auto Advance",
+            command=self.refresh,
+            variable=self.auto_type,
+            value=PageSepAutoType.AUTO_ADVANCE,
+            takefocus=False,
+        ).grid(column=1, row=1, sticky="NSEW", padx=2, pady=2)
+        ttk.Radiobutton(
+            self.top_frame,
+            text="Auto Fix",
+            command=self.refresh,
+            variable=self.auto_type,
+            value=PageSepAutoType.AUTO_FIX,
+            takefocus=False,
+        ).grid(column=2, row=1, sticky="NSEW", padx=2, pady=2)
+
+        end_frame = ttk.Frame(
+            self.top_frame, borderwidth=1, relief=tk.GROOVE, padding=5
+        )
+        end_frame.grid(column=0, row=2, columnspan=3, sticky="NSEW")
+        for col in range(0, 3):
+            end_frame.columnconfigure(col, pad=2, weight=1)
+
+        undo_button = ttk.Button(
+            end_frame,
+            text="Undo",
+            command=self.undo,
+            underline=0,
+            width=self.BTN_WIDTH,
+        )
+        undo_button.grid(column=0, row=0, sticky="NSEW")
+        self.key_bind("u", undo_button.invoke)
+        self.key_bind("Cmd/Ctrl+Z", undo_button.invoke)
+
+        redo_button = ttk.Button(
+            end_frame,
+            text="Redo",
+            command=self.redo,
+            underline=1,
+            width=self.BTN_WIDTH,
+        )
+        redo_button.grid(column=1, row=0, sticky="NSEW")
+        self.key_bind("e", redo_button.invoke)
+        self.key_bind("Cmd+Shift+Z" if is_mac() else "Ctrl+Y", redo_button.invoke)
+
+        refresh_button = ttk.Button(
+            end_frame,
+            text="Refresh",
+            command=self.refresh,
+            underline=0,
+            width=self.BTN_WIDTH,
+        )
+        refresh_button.grid(column=2, row=0, sticky="NSEW")
+        self.key_bind("r", refresh_button.invoke)
+
+    def do_join(self, keep_hyphen: bool) -> None:
+        """Join 2 lines if hyphenated, otherwise just remove separator line.
+
+        Args:
+            keep_hyphen: True to keep hyphen when lines are joined.
+        """
+        if (sep_range := self.find()) is None:
+            return
+
+        self.fix_pagebreak_markup(sep_range)
+        maintext().delete(sep_range.start.index(), sep_range.end.index())
+        prev_eol = f"{sep_range.start.index()} -1l lineend"
+        maybe_hyphen = maintext().get(f"{prev_eol}-1c", prev_eol)
+        # If "*" at end of line, check previous character for "-"
+        if maybe_hyphen == "*":
+            prev_eol = f"{prev_eol} -1c"
+            maybe_hyphen = maintext().get(f"{prev_eol}-1c", prev_eol)
+        # Check for emdash (double-hyphen)
+        maybe_second_hyphen = ""
+        if maybe_hyphen == "-":
+            maybe_second_hyphen = maintext().get(f"{prev_eol}-2c", f"{prev_eol} -1c")
+        # Adjust effective end of line position depending if hyphen is being kept
+        # (always keep emdash)
+        if not keep_hyphen and maybe_hyphen == "-" and maybe_second_hyphen != "-":
+            prev_eol = f"{prev_eol} -1c"
+        # If emdash at start of second page, also want to join,
+        # even if no hyphen at end of first page.
+        next_bol = f"{sep_range.start.index()} linestart"
+        # Omit any "*" at beginning of next line
+        if maintext().get(next_bol, f"{next_bol}+1c") == "*":
+            next_bol = f"{next_bol}+1c"
+        maybe_page2_emdash = maintext().get(next_bol, f"{next_bol}+2c")
+
+        # If word is hyphenated or emdash, join previous end of line to next beg of line
+        if maybe_hyphen == "-" or maybe_page2_emdash == "--":
+            # Replace space with newline after second half of word
+            if space_pos := maintext().search(" ", next_bol, f"{next_bol} lineend"):
+                maintext().replace(space_pos, f"{space_pos}+1c", "\n")
+            # Delete hyphen, asterisks & newline to join the word
+            maintext().delete(prev_eol, next_bol)
+        maintext().set_insert_index(sep_range.start, focus=False)
+
+    def do_delete(self) -> None:
+        """Just remove separator line."""
+        if (sep_range := self.find()) is None:
+            return
+        maintext().delete(sep_range.start.index(), sep_range.end.index())
+        maintext().set_insert_index(sep_range.start, focus=False)
+
+    def do_blank(self, num_lines: int) -> None:
+        """Replace separator & adjacent blank lines with given number of blank lines.
+
+        Args:
+            num_lines: How many blank lines to use.
+        """
+        if (sep_range := self.find()) is None:
+            return
+        # Find previous end and next start of non-whitespace, to replace with given number of blank lines
+        end_prev = maintext().search(
+            r"\S",
+            sep_range.start.index(),
+            "1.0",
+            backwards=True,
+            regexp=True,
+        )
+        end_prev = f"{end_prev}+1l linestart" if end_prev else "1.0"
+        beg_next = maintext().search(r"\S", sep_range.end.index(), tk.END, regexp=True)
+        beg_next = f"{beg_next} linestart" if beg_next else tk.END
+        maintext().replace(end_prev, beg_next, num_lines * "\n")
+        maintext().set_insert_index(sep_range.start, focus=False)
+
+    def refresh(self) -> None:
+        """Refresh to show the first available page separator."""
+        self.undo_block_begin()
+        self.do_auto()
+        self.view()
+        self.undo_block_end()
+
+    def join(self, keep_hyphen: bool) -> None:
+        """Handle click on Join buttons.
+
+        Args:
+            keep_hyphen: True to keep hyphen when lines are joined.
+        """
+        self.undo_block_begin()
+        self.do_join(keep_hyphen)
+        self.do_auto()
+        self.undo_block_end()
+
+    def delete(self) -> None:
+        """Handle click on Delete button."""
+        self.undo_block_begin()
+        self.do_delete()
+        self.do_auto()
+        self.undo_block_end()
+
+    def blank(self, num_lines: int) -> None:
+        """Handle click on Blank buttons.
+
+        Args:
+            num_lines: How many blank lines to use.
+        """
+        self.undo_block_begin()
+        self.do_blank(num_lines)
+        self.do_auto()
+        self.undo_block_end()
+
+    def undo(self) -> None:
+        """Handle click on Undo button, by undoing latest changes and re-viewing
+        the first available page separator."""
+        maintext().event_generate("<<Undo>>")
+        self.view()
+
+    def redo(self) -> None:
+        """Handle click on Redo button, by re-doing latest undo and re-viewing
+        the first available page separator."""
+        maintext().event_generate("<<Redo>>")
+        self.view()
+
+    def view(self) -> None:
+        """Show the first available separator line to be processed."""
+        if (sep_range := self.find()) is None:
+            return
+        maintext().do_select(sep_range)
+        maintext().set_insert_index(sep_range.start, focus=False)
+
+    def find(self) -> Optional[IndexRange]:
+        """Find the first available separator line.
+
+        Returns:
+            IndexRange containing start & end of separator, or None.
+        """
+        match = maintext().find_match(
+            PageSeparatorDialog.SEPARATOR_REGEX,
+            IndexRange(maintext().start(), maintext().end()),
+            nocase=False,
+            regexp=True,
+            wholeword=False,
+            backwards=False,
+        )
+        if match is None:
+            return None
+        end_rowcol = IndexRowCol(match.rowcol.row + 1, match.rowcol.col)
+        return IndexRange(match.rowcol, end_rowcol)
+
+    def fix_pagebreak_markup(self, sep_range: IndexRange) -> None:
+        """Remove inline close markup, e.g. italics, immediately before page break
+        if same markup is reopened immediately afterwards.
+
+        Args:
+            sep_range: Range of page separator line.
+        """
+        markup_prev = maintext().get(
+            f"{sep_range.start.index()}-1l lineend -6c",
+            f"{sep_range.start.index()}-1l lineend",
+        )
+        markup_next = maintext().get(
+            f"{sep_range.end.index()}",
+            f"{sep_range.end.index()} +4c",
+        )
+        if match := re.search(r"</(i|b|f|g|sc)>([,;*]?)$", markup_prev):
+            markup_type = match[1]
+            len_markup = len(markup_type)
+            len_punc = len(match[2])
+            if re.search(rf"^<{markup_type}>", markup_next):
+                maintext().delete(
+                    f"{sep_range.end.index()}",
+                    f"{sep_range.end.index()} +{len_markup+2}c",
+                )
+                maintext().delete(
+                    f"{sep_range.start.index()}-1l lineend -{len_markup+len_punc+3}c",
+                    f"{sep_range.start.index()}-1l lineend -{len_punc}c",
+                )
+
+    def do_auto(self) -> None:
+        """Do auto page separator fixing if allowed by settings."""
+        if preferences.get(PrefKey.PAGESEP_AUTO_TYPE) == PageSepAutoType.NO_AUTO:
+            return
+        if preferences.get(PrefKey.PAGESEP_AUTO_TYPE) == PageSepAutoType.AUTO_ADVANCE:
+            self.view()
+            return
+
+        # Auto-fix: Loop through page separators, fixing them if possible
+        while sep_range := self.find():
+            # Fix markup across page break, even though the join function would fix it later,
+            # because otherwise it would interfere with check for automated joining below.
+            self.fix_pagebreak_markup(sep_range)
+            line_prev = maintext().get(
+                f"{sep_range.start.index()}-1l lineend -10c",
+                f"{sep_range.start.index()}-1l lineend",
+            )
+            line_next = maintext().get(
+                f"{sep_range.end.index()}",
+                f"{sep_range.end.index()}+10c",
+            )
+            if line_next.startswith(4 * "\n"):
+                self.do_blank(4)
+            elif line_next.startswith(2 * "\n"):
+                self.do_blank(2)
+            elif line_next.startswith(1 * "\n"):
+                self.do_blank(1)
+            elif line_next.startswith("-----File:"):
+                self.do_delete()
+            elif not (
+                re.search(r"^\*?-(?!-)", line_next)
+                or re.search(r"(?<!-)-\*?$", line_prev)
+            ):
+                # No hyphen before/after page break, so OK to join
+                self.do_join(False)
+            else:
+                break
+        self.view()
+
+    def undo_block_begin(self) -> None:
+        """Begin a block of changes that will be undone with one undo operation.
+
+        Will be replaced with a method in MainText.
+        """
+        maintext().config(autoseparators=False)
+        maintext().edit_separator()
+
+    def undo_block_end(self) -> None:
+        """End a block of changes that will be undone with one undo operation.
+
+        Will be replaced with a method in MainText.
+        """
+        maintext().edit_separator()
+        maintext().config(autoseparators=True)
+
+
+def page_separator_fixup() -> None:
+    """Fix and remove page separator lines."""
+    dlg = PageSeparatorDialog.show_dialog()
+    dlg.view()

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -51,6 +51,7 @@ class PrefKey(StrEnum):
     WRAP_INDEX_MAIN_MARGIN = auto()
     WRAP_INDEX_WRAP_MARGIN = auto()
     WRAP_INDEX_RIGHT_MARGIN = auto()
+    PAGESEP_AUTO_TYPE = auto()
 
 
 class Preferences:

--- a/src/guiguts/utilities.py
+++ b/src/guiguts/utilities.py
@@ -180,7 +180,7 @@ class IndexRange:
         if isinstance(end, str):
             self.end = IndexRowCol(end)
         else:
-            assert isinstance(start, IndexRowCol)
+            assert isinstance(end, IndexRowCol)
             self.end = end
 
     def __eq__(self, other: object) -> bool:

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -118,6 +118,20 @@ class ToplevelDialog(tk.Toplevel):
             tooltip - the ToolTip widget to register"""
         self.tooltip_list.append(tooltip)
 
+    def key_bind(self, accel: str, handler: Callable[[], None]) -> None:
+        """Convert given accelerator string to a key-event string and bind both
+        the upper & lower case versions to the given handler.
+
+        Args:
+            accel: Accelerator string, e.g. "Cmd/Ctrl+Z", to trigger call to ``handler``.
+            handler: Callback function to be bound to ``accel``.
+        """
+        _, key_event = process_accel(accel)
+        lk = re.sub("[A-Z]>?$", lambda m: m.group(0).lower(), key_event)
+        self.bind(lk, lambda _: handler())
+        uk = re.sub("[a-z]>?$", lambda m: m.group(0).upper(), key_event)
+        self.bind(uk, lambda _: handler())
+
     def tidy_up(self, event: tk.Event) -> None:
         """Tidy up when the dialog is destroyed.
 


### PR DESCRIPTION
1. Unmatched block markup (copes with `/#` being nestable but other types not nestable). 
2. Unmatched brackets (not nestable)
3. Unmatched curly quotes (not nestable)
4. Unmatched DP markup (not nestable)
5. "Nestable" above means that it will permit `/#` to follow `/#` without an intervening `#/`, for example. But it complains about `[` followed by `[` without intervening `]`. It would be possible to change which are nestable and which are not, but this matches GG1 behavior.
6. First enhancement compared to GG1: you can use upper/lower case indiscriminately for block markup  - in GG1, if you use upper case to open, e.g. `/C`, you must use upper case to close.
7. Second enhancement is that it checks that the matching block markup is at the start of a line. In GG1, if you open with `/C`, then close with `     /C` it will not complain.
8. Also, you can sort errors either by row & column, or by type (e.g. all `/c` errors will precede all `/r` errors). I could change the type sorting if my arm were twisted enough. At the moment, it will list all unmatched open markup before all unmatched close, then within those two groups, it is sorted alphabetically by the type of markup. As I say, that could be changed quite easily, but I think it's OK as it is really - I'll leave it to the intrepid testers to decide if they think it's worth it.
9. Menu entries are all in the Tools menu.