### PR TITLE
Improve column selection

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -557,12 +557,15 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
 
         the_statusbar.add(
             "selection",
-            tooltip="Click: Restore previous selection",
+            tooltip="Click: Restore previous selection\nShift Click: Toggle column/regular selection",
             update=selection_str,
             width=16,
         )
         the_statusbar.add_binding(
             "selection", "ButtonRelease-1", maintext().restore_selection_ranges
+        )
+        the_statusbar.add_binding(
+            "selection", "Shift-ButtonRelease-1", maintext().toggle_selection_type
         )
 
         the_statusbar.add(

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -182,6 +182,10 @@ class MainText(tk.Text):
         self.bind_event(f"<{modifier}-B1-Motion>", self.column_select_motion)
         self.bind_event(f"<{modifier}-ButtonRelease-1>", self.column_select_release)
         self.bind_event("<KeyRelease-Alt_L>", lambda _event: self.column_select_stop())
+        # Make use of built-in Shift click functionality to extend selections,
+        # but adapt for column select with Option/Alt key
+        self.bind_event(f"<Shift-{modifier}-ButtonPress-1>", self.column_select_release)
+        self.bind_event(f"<Shift-{modifier}-ButtonRelease-1>", lambda _event: "break")
         self.column_selecting = False
 
         # Add common Mac key bindings for beginning/end of file
@@ -447,6 +451,14 @@ class MainText(tk.Text):
         for line_num in range(1, self.end().row):
             line = maintext().get(f"{line_num}.0", f"{line_num}.0 lineend")
             yield line, line_num
+
+    def toggle_selection_type(self) -> None:
+        """Switch regular selection to column selection or vice versa."""
+        sel_ranges = self.selected_ranges()
+        if len(sel_ranges) > 1:
+            self.do_select(IndexRange(sel_ranges[0].start, sel_ranges[-1].end))
+        else:
+            self.columnize_selection()
 
     def columnize_copy(self) -> None:
         """Columnize the current selection and copy it."""


### PR DESCRIPTION
1. Allow user to Shift-click with Option/Alt key pressed to make a column selection. So, user can click at start, then Shift-click to make a regular selection. Or, click at start, then Shift-Alt-Click (use Option instead of Alt on Macs) at end to make a column selection. Multiple Shift-Alt-Clicking may not do what you expect due to ambiguity over the start/end points of the selection - you have been warned!
2. User can Shift click the Selection label in the status bar to switch selection from a regular selection to a column selection.

Fixes #239