### PR TITLE
Hebe fix bug

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -739,6 +739,7 @@ class MainText(tk.Text):
         minrow = max(minrow, toprow)
         maxrow = max(anchor_rowcol.row, cur_rowcol.row)
         maxlen = -1
+        y_maxlen = -1
         for row in range(minrow, maxrow + 1):
             geometry = self.bbox(f"{row}.0")
             if geometry is None:

--- a/src/guiguts/tools/jeebies.py
+++ b/src/guiguts/tools/jeebies.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__package__)
 
 DEFAULT_DICTIONARY_DIR = importlib.resources.files(dictionaries)
 DISCRIMINATOR_LEVEL = 1.0
+HB_TOGGLE = {"h": "b", "H": "B", "b": "h", "B": "H"}
 
 _the_jeebies_checker = None  # pylint: disable=invalid-name
 
@@ -680,7 +681,7 @@ class JeebiesChecker:
         end_mark = CheckerDialog.mark_from_rowcol(checker_entry.text_range.end)
         match_text = maintext().get(start_mark, end_mark)
         # Toggle match text
-        replacement_text = "he" if match_text == "be" else "be"
+        replacement_text = HB_TOGGLE[match_text[0]] + match_text[1]
         maintext().replace(start_mark, end_mark, replacement_text)
 
 

--- a/src/guiguts/tools/jeebies.py
+++ b/src/guiguts/tools/jeebies.py
@@ -294,7 +294,7 @@ class JeebiesChecker:
     ) -> int:
         """Look for suspect "word be/he" or "be/he word" phrases in paragraphs."""
 
-        def do_finditer_and_report() -> int:
+        def do_finditer_and_report(regx: str, para_lc: str) -> int:
             """Helper function for abstraction of repeated code."""
 
             count_of_suspects = 0
@@ -329,7 +329,8 @@ class JeebiesChecker:
                     behe_form = re.sub(s_hebe, s_behe, hebe_form)
                     behe_count = self.find_in_dictionary(behe_form)
                 else:
-                    pass  # Shouldn't reach here.
+                    # Shouldn't reach here.
+                    hebe_count = behe_count = hebe_start = 0
 
                 # At this point we have the two versions of the phrase. The variables
                 # hebe_count and behe_count are integer frequencies of occurrence of
@@ -441,7 +442,7 @@ class JeebiesChecker:
             para_lc = re.sub(qs_hebe, ss_hebe, para_lc)
             # Look for type 1, 2-form hebe phrases in the edited paragraph string.
             regx = rf"(?<=^|\p{{P}}|\p{{P}} ){hebe} [a-z]+"
-            suspects_count += do_finditer_and_report()
+            suspects_count += do_finditer_and_report(regx, para_lc)
 
         elif order == "second":
             # Looking for hebe as second word of 2-word punctuation delimited phrase.
@@ -449,7 +450,7 @@ class JeebiesChecker:
             para_lc = paragraph_text.lower()
 
             regx = rf"[a-z]+ {hebe}(?=\p{{P}}|$)"
-            suspects_count += do_finditer_and_report()
+            suspects_count += do_finditer_and_report(regx, para_lc)
 
         else:
             # Should never get here. Variable 'order' value either 'first' or 'second'.
@@ -470,7 +471,7 @@ class JeebiesChecker:
     ) -> int:
         """Look for suspect "w1 be w2" or "w1 he w2" phrases in paragraphs."""
 
-        def make_dialog_line() -> None:
+        def make_dialog_line(info: str, checker_dialog: CheckerDialog) -> None:
             """Helper function for abstraction of repeated code."""
 
             # We have the start position in the paragraph string of a suspect hebe.
@@ -534,7 +535,7 @@ class JeebiesChecker:
 
                 # Query this 3-form phrase in the report.
 
-                make_dialog_line()
+                make_dialog_line(info, checker_dialog)
 
             elif check_level == "normal" and hebe_count == 0 and behe_count == 0:
                 # Neither 'he' nor 'be' versions of our 3-form phrase are in the
@@ -560,7 +561,7 @@ class JeebiesChecker:
 
                 # Query this 3-form phrase in the report.
 
-                make_dialog_line()
+                make_dialog_line(info, checker_dialog)
 
             elif check_level == "paranoid" and hebe_count == 0 and behe_count == 0:
                 # Neither 'he' nor 'be' versions of our 3-form phrase are in the
@@ -570,7 +571,7 @@ class JeebiesChecker:
 
                 # Query this 3-form phrase in the report.
 
-                make_dialog_line()
+                make_dialog_line(info, checker_dialog)
 
         return suspects_count
 


### PR DESCRIPTION
The he/be fixing code (via Ctrl-click) only worked for lowercase he/be.
Only "be" was converted to "he". Any other he/be word ("Be", "HE", "bE", etc.) was converted to lowercase "be".

Also (since most, but not all, in jeebies code) silence warnings from latest version of pylint, mostly by passing arguments into nested helper functions, rather than relying on access to variables defined in the outer function. It does make the functions clearer too, IMO.