### PR TITLE
Position "seen" line better in window

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -416,6 +416,17 @@ class MainText(tk.Text):
             focus: Optional, False means focus will not be forced to maintext
         """
         self.mark_set(tk.INSERT, insert_pos.index())
+        # The `see` method can leave the desired line at the top or bottom of window.
+        # So, we "see" lines above and below desired line incrementally up to
+        # half window height each way, ensuring desired line is left in the middle.
+        # If performance turns out to be an issue, consider giving `step` to `range`.
+        # Step should be smaller than half minimum likely window height.
+        start_index = self.index(f"@0,{int(self.cget('borderwidth'))} linestart")
+        end_index = self.index(f"@0,{self.winfo_height()} linestart")
+        n_lines = IndexRowCol(end_index).row - IndexRowCol(start_index).row
+        for inc in range(1, int(n_lines / 2) + 1):
+            self.see(f"{tk.INSERT}-{inc}l")
+            self.see(f"{tk.INSERT}+{inc}l")
         self.see(tk.INSERT)
         if focus:
             self.focus_set()


### PR DESCRIPTION
Operations like Search make the found line visible. However the built-in routine that does this only make it visible, not central, so it may be the first or last line in the window, meaning user has no context lines around it.

Fixed by repeatedly seeing lines ever further from the desired line up to half the window height, which leaves the desired line in the middle of the window.

Fixes #244 