### PR TITLE
Add badly formed markup check for block markup

### DIFF
--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -713,6 +713,9 @@ def unmatched_block_markup() -> None:
             after_match = maintext().index(f"{match_index}+{match.count}c")
             search_range = IndexRange(after_match, maintext().end())
             match_str = maintext().get_match_text(match)
+            # Don't report if open markup preceded by "<", e.g. "</i>"
+            if match_str[0] == "/" and maintext().get(f"{match_index}-1c") == "<":
+                continue
             # Now check if markup is malformed - get whole line and check against regex
             line = maintext().get(f"{match_index} linestart", f"{match_index} lineend")
             try:


### PR DESCRIPTION
Badly formed markup can easily give false "unmatched markup" errors, so add a check for bad markup to the Unmatched Block Markup check.

Also, improve "Alpha/Type" sorting in this dialog. It now lists all Bad Markup first (since likely to be the problem), then all Unmatched Markup). Within those categories, it is sorted by the type of markup, e.g. blockquote, poetry, index, etc., and within those subcategories, "open" markup comes first, then close markup, and finally, if all those are equal, e.g. two "#/" markups, they are ordered by their location in the file.