### PR TITLE
Add Pref for Tear-Off menus

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -319,6 +319,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
                 theme_name_internal_from_user(value)
             ),
         )
+        preferences.set_default(PrefKey.TEAROFF_MENUS, False)
 
         # Check all preferences have a default
         for pref_key in PrefKey:

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -9,7 +9,7 @@ from guiguts.preferences import (
     PersistentInt,
     PersistentString,
 )
-from guiguts.utilities import is_windows
+from guiguts.utilities import is_mac
 from guiguts.widgets import ToplevelDialog, ToolTip
 
 
@@ -43,7 +43,7 @@ class PreferencesDialog(ToplevelDialog):
             variable=PersistentBoolean(PrefKey.TEAROFF_MENUS),
         )
         tearoff_check.grid(column=0, row=2, sticky="NEW", pady=5)
-        if is_windows():
+        if is_mac():
             tearoff_check["state"] = tk.DISABLED
             ToolTip(tearoff_check, "Not available on macOS")
         ttk.Checkbutton(

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -1,5 +1,6 @@
 """Miscellaneous dialogs."""
 
+import tkinter as tk
 from tkinter import ttk
 
 from guiguts.preferences import (
@@ -8,6 +9,7 @@ from guiguts.preferences import (
     PersistentInt,
     PersistentString,
 )
+from guiguts.utilities import is_windows
 from guiguts.widgets import ToplevelDialog, ToolTip
 
 
@@ -35,11 +37,15 @@ class PreferencesDialog(ToplevelDialog):
         ttk.Label(
             appearance_frame, text="(May need to restart program for full effect)"
         ).grid(column=0, row=1, sticky="NSEW")
-        ttk.Checkbutton(
+        tearoff_check = ttk.Checkbutton(
             appearance_frame,
             text="Use Tear-Off Menus (requires restart)",
             variable=PersistentBoolean(PrefKey.TEAROFF_MENUS),
-        ).grid(column=0, row=2, sticky="NEW", pady=5)
+        )
+        tearoff_check.grid(column=0, row=2, sticky="NEW", pady=5)
+        if is_windows():
+            tearoff_check["state"] = tk.DISABLED
+            ToolTip(tearoff_check, "Not available on macOS")
         ttk.Checkbutton(
             appearance_frame,
             text="Display Line Numbers",

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -37,16 +37,21 @@ class PreferencesDialog(ToplevelDialog):
         ).grid(column=0, row=1, sticky="NSEW")
         ttk.Checkbutton(
             appearance_frame,
+            text="Use Tear-Off Menus (requires restart)",
+            variable=PersistentBoolean(PrefKey.TEAROFF_MENUS),
+        ).grid(column=0, row=2, sticky="NEW", pady=5)
+        ttk.Checkbutton(
+            appearance_frame,
             text="Display Line Numbers",
             variable=PersistentBoolean(PrefKey.LINE_NUMBERS),
-        ).grid(column=0, row=2, sticky="NEW", pady=5)
+        ).grid(column=0, row=3, sticky="NEW", pady=5)
         ttk.Checkbutton(
             appearance_frame,
             text="Automatically show current page image",
             variable=PersistentBoolean(PrefKey.AUTO_IMAGE),
-        ).grid(column=0, row=3, sticky="NEW", pady=5)
+        ).grid(column=0, row=4, sticky="NEW", pady=5)
         bell_frame = ttk.Frame(appearance_frame)
-        bell_frame.grid(column=0, row=4, sticky="NEW", pady=(5, 0))
+        bell_frame.grid(column=0, row=5, sticky="NEW", pady=(5, 0))
         ttk.Label(bell_frame, text="Warning bell: ").grid(column=0, row=0, sticky="NEW")
         ttk.Checkbutton(
             bell_frame,

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -53,6 +53,7 @@ class PrefKey(StrEnum):
     WRAP_INDEX_RIGHT_MARGIN = auto()
     PAGESEP_AUTO_TYPE = auto()
     THEME_NAME = auto()
+    TEAROFF_MENUS = auto()
 
 
 class Preferences:

--- a/src/guiguts/root.py
+++ b/src/guiguts/root.py
@@ -27,7 +27,7 @@ class Root(tk.Tk):
 
         super().__init__(**kwargs)
         self.geometry(preferences.get(PrefKey.ROOT_GEOMETRY))
-        self.option_add("*tearOff", False)
+        self.option_add("*tearOff", preferences.get(PrefKey.TEAROFF_MENUS))
         self.rowconfigure(0, weight=1)
         self.columnconfigure(0, weight=1)
         self.after_idle(lambda: grab_focus(self, maintext(), True))


### PR DESCRIPTION
Note that GG2 will need to be restarted after changing this Pref. All the menus would have to be deleted and recreated, which is just not worth the time or code complexity for something that most users will use once (or never).