### PR TITLE
Fix a few tooltips

### DIFF
--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -84,53 +84,53 @@ class PreferencesDialog(ToplevelDialog):
             ToolTip(spinbox, tooltip)
 
         add_label_spinbox(
-            0, "Left Margin:", PrefKey.WRAP_LEFT_MARGIN, "Left margin for normal text."
+            0, "Left Margin:", PrefKey.WRAP_LEFT_MARGIN, "Left margin for normal text"
         )
         add_label_spinbox(
             1,
             "Right Margin:",
             PrefKey.WRAP_RIGHT_MARGIN,
-            "Right margin for normal text.",
+            "Right margin for normal text",
         )
         add_label_spinbox(
             2,
             "Blockquote Indent:",
             PrefKey.WRAP_BLOCKQUOTE_INDENT,
-            "Extra indent for each level of blockquotes.",
+            "Extra indent for each level of blockquotes",
         )
         add_label_spinbox(
             3,
             "Blockquote Right Margin:",
             PrefKey.WRAP_BLOCKQUOTE_RIGHT_MARGIN,
-            "Right margin for blockquotes.",
+            "Right margin for blockquotes",
         )
         add_label_spinbox(
             4,
             "Block Indent:",
             PrefKey.WRAP_BLOCK_INDENT,
-            "Indent for /*, /P, /L blocks.",
+            "Indent for /*, /P, /L blocks",
         )
         add_label_spinbox(
             5,
             "Poetry Indent:",
             PrefKey.WRAP_POETRY_INDENT,
-            "Indent for /P poetry blocks.",
+            "Indent for /P poetry blocks",
         )
         add_label_spinbox(
             6,
             "Index Main Entry Margin:",
             PrefKey.WRAP_INDEX_MAIN_MARGIN,
-            "Indent for main entries in index - sub-entries retain their indent relative to this.",
+            "Indent for main entries in index - sub-entries retain their indent relative to this",
         )
         add_label_spinbox(
             8,
             "Index Wrap Margin:",
             PrefKey.WRAP_INDEX_WRAP_MARGIN,
-            "Left margin for all lines rewrapped in index.",
+            "Left margin for all lines rewrapped in index",
         )
         add_label_spinbox(
             9,
             "Index Right Margin:",
             PrefKey.WRAP_INDEX_RIGHT_MARGIN,
-            "Right margin for index entries.",
+            "Right margin for index entries",
         )

--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -25,6 +25,7 @@ from guiguts.utilities import (
     IndexRowCol,
     sound_bell,
     process_accel,
+    cmd_ctrl_string,
 )
 from guiguts.widgets import ToplevelDialog, Combobox, ToolTip, mouse_bind
 
@@ -384,6 +385,16 @@ class WordFrequencyDialog(ToplevelDialog):
         mouse_bind(self.text, "1", self.goto_word)
         _, event = process_accel("Cmd/Ctrl+1")
         self.text.bind(event, self.search_word)
+        ToolTip(
+            self.text,
+            "\n".join(
+                [
+                    "Left click: Find first match, click again for other matches",
+                    f"{cmd_ctrl_string()}-left click: Find using Search dialog",
+                ]
+            ),
+            use_pointer_pos=True,
+        )
 
         self.previous_word = ""
 


### PR DESCRIPTION
1. Missing tooltip in word frequency dialog word list.
2. Remove periods from Prefs dialog spinboxes.