### PR TITLE
Tidy/harmonize menu entries

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -373,7 +373,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             self.file.add_good_and_bad_words,
         )
         proj_menu.add_button(
-            f"Set ~Scan Image {'Folder' if is_windows() else 'Directory'}",
+            f"Set ~Scan Image {'Folder' if is_windows() else 'Directory'}...",
             self.file.choose_image_dir,
         )
         if not is_mac():
@@ -497,26 +497,27 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
     def init_tools_menu(self) -> None:
         """Create the Tools menu."""
         menu_tools = Menu(menubar(), "~Tools")
-        menu_tools.add_button("Basic Fi~xup", basic_fixup_check)
-        menu_tools.add_button("~Word Frequency", word_frequency)
+        menu_tools.add_button("Basic Fi~xup...", basic_fixup_check)
+        menu_tools.add_button("~Word Frequency...", word_frequency)
         menu_tools.add_button(
-            "~Spelling Check",
+            "~Spelling Check...",
             lambda: spell_check(
                 self.file.project_dict, self.file.add_good_word_to_project_dictionary
             ),
         )
-        menu_tools.add_button("PP~txt", lambda: pptxt(self.file.project_dict))
-        menu_tools.add_button("~Jeebies", jeebies_check)
+        menu_tools.add_button("PP~txt...", lambda: pptxt(self.file.project_dict))
+        menu_tools.add_button("~Jeebies...", jeebies_check)
         menu_tools.add_separator()
-        menu_tools.add_button("Fixup ~Page Separators", page_separator_fixup)
+        menu_tools.add_button("Fixup ~Page Separators...", page_separator_fixup)
         menu_tools.add_separator()
         menu_tools.add_button("~Rewrap All", self.file.rewrap_all)
         menu_tools.add_button("R~ewrap Selection", self.file.rewrap_selection)
         menu_tools.add_separator()
-        menu_tools.add_button("Unmatched Bloc~k Markup", unmatched_block_markup)
-        menu_tools.add_button("Unmatched ~DP Markup", unmatched_dp_markup)
-        menu_tools.add_button("Unmatched ~Brackets", unmatched_brackets)
-        menu_tools.add_button("Unmatched Curly ~Quotes", unmatched_curly_quotes)
+        unmatched_menu = Menu(menu_tools, "~Unmatched")
+        unmatched_menu.add_button("Bloc~k Markup...", unmatched_block_markup)
+        unmatched_menu.add_button("~DP Markup...", unmatched_dp_markup)
+        unmatched_menu.add_button("~Brackets...", unmatched_brackets)
+        unmatched_menu.add_button("Curly ~Quotes...", unmatched_curly_quotes)
 
         fraction_menu = Menu(menu_tools, "Convert ~Fractions")
         fraction_menu.add_button(

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -409,25 +409,26 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             "Colu~mn Paste", maintext().columnize_paste, "Cmd/Ctrl+Shift+V"
         )
         menu_edit.add_separator()
-        menu_edit.add_button(
-            "lo~wercase selection",
+        case_menu = Menu(menu_edit, "C~hange Case")
+        case_menu.add_button(
+            "~lowercase selection",
             lambda: maintext().transform_selection(str.lower),
             "",
         )
-        menu_edit.add_button(
+        case_menu.add_button(
             "~Sentence case selection",
             lambda: maintext().transform_selection(
                 maintext().sentence_case_transformer
             ),
             "",
         )
-        menu_edit.add_button(
-            "T~itle Case Selection",
+        case_menu.add_button(
+            "~Title Case Selection",
             lambda: maintext().transform_selection(maintext().title_case_transformer),
             "",
         )
-        menu_edit.add_button(
-            "UPP~ERCASE SELECTION",
+        case_menu.add_button(
+            "~UPPERCASE SELECTION",
             lambda: maintext().transform_selection(str.upper),
             "",
         )


### PR DESCRIPTION
Some menu entries did not have `...` following them. It appears the most common use of this is when a new dialog will appear that the user can interact with to complete the task, and not for just "View xyz" or
"Help About" entries.

Also, put the 4 unmatched markup/bracket/quote
entries into a submenu, to stop the Tools menu becoming too long.