### PR TITLE
Add first part of Footnote Fixup

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,6 +71,11 @@ Word Frequency
 ==============
     
 .. automodule:: word_frequency
+ 
+Footnotes
+==============
+    
+.. automodule:: footnotes
 
 PPtxt
 =====

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -14,6 +14,7 @@ import webbrowser
 from guiguts.checkers import CheckerSortType
 from guiguts.data import themes
 from guiguts.file import File, the_file, NUM_RECENT_FILES
+from guiguts.footnotes import footnote_check
 from guiguts.maintext import maintext
 from guiguts.mainwindow import (
     MainWindow,
@@ -510,6 +511,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_tools.add_button("~Jeebies...", jeebies_check)
         menu_tools.add_separator()
         menu_tools.add_button("Fixup ~Page Separators...", page_separator_fixup)
+        menu_tools.add_button("Fixup ~Footnotes...", footnote_check)
         menu_tools.add_separator()
         menu_tools.add_button("~Rewrap All", self.file.rewrap_all)
         menu_tools.add_button("R~ewrap Selection", self.file.rewrap_selection)

--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -1,0 +1,235 @@
+"""Footnote checking, fixing and tidying functionality"""
+
+import logging
+from tkinter import ttk
+from typing import Optional
+import regex as re
+
+from guiguts.checkers import CheckerDialog, CheckerEntry
+from guiguts.maintext import maintext
+from guiguts.misc_tools import tool_save
+from guiguts.utilities import (
+    IndexRowCol,
+    IndexRange,
+)
+from guiguts.widgets import ToolTip
+
+logger = logging.getLogger(__package__)
+
+_the_footnote_checker: Optional[
+    "FootnoteChecker"
+] = None  # pylint: disable=invalid-name
+
+
+class AnchorRecord:
+    """Record of anchor in file."""
+
+    def __init__(
+        self,
+        fn: str,
+        start: IndexRowCol,
+        end: IndexRowCol,
+        hilite_start: int,
+        hilite_end: int,
+    ) -> None:
+        self.anchor = fn
+        self.start = start
+        self.end = end
+        self.hilite_start = hilite_start
+        self.hilite_end = hilite_end
+
+
+class FootnoteRecord:
+    """Record of footnote in file."""
+
+    def __init__(
+        self,
+        fn: str,
+        start: IndexRowCol,
+        end: IndexRowCol,
+        hilite_start: int,
+        hilite_end: int,
+    ) -> None:
+        self.footnote = fn
+        self.start = start
+        self.end = end
+        self.hilite_start = hilite_start
+        self.hilite_end = hilite_end
+
+
+class FootnoteChecker:
+    """Find, check & record footnotes."""
+
+    def __init__(self) -> None:
+        """Initialize footnote checker."""
+        self.fn_records: list[FootnoteRecord] = []
+        self.an_records: list[AnchorRecord] = []
+
+    def reset(self) -> None:
+        """Reset FootnoteChecker."""
+        self.fn_records = []
+        self.an_records = []
+
+    def get_fn_records(self) -> list[FootnoteRecord]:
+        """Return the list of footnote records."""
+        return self.fn_records
+
+    def get_an_records(self) -> list[AnchorRecord]:
+        """Return the list of anchor records."""
+        return self.an_records
+
+    def run_check(self) -> None:
+        """Run the initial footnote check."""
+        self.reset()
+        search_range = IndexRange(maintext().start(), maintext().end())
+        match_regex = r"\[ *footnote"
+        # Loop, finding all footnotes (i.e. beginning with "[Footnote") allowing
+        # some flexibility of spacing & case
+        while beg_match := maintext().find_match(
+            match_regex, search_range, regexp=True, nocase=True
+        ):
+            start = beg_match.rowcol
+            # Find colon position, or use end of the word "Footnote"
+            colon_match = maintext().find_match(
+                ":", IndexRange(start, maintext().rowcol(f"{start.row}.end"))
+            )
+            if colon_match is None:
+                colon_pos = maintext().rowcol(
+                    f"{start.index()}+{beg_match.count+1}c wordend"
+                )
+            else:
+                colon_pos = colon_match.rowcol
+            end_point = colon_pos
+            # Find closing square bracket - allow open/close bracket within footnote
+            end_match = None
+            nested = False
+            while True:
+                end_match = maintext().find_match(
+                    "[][]", IndexRange(end_point, maintext().end()), regexp=True
+                )
+                if end_match is None:
+                    break
+                end_point = maintext().rowcol(f"{end_match.rowcol.index()}+1c")
+                if maintext().get_match_text(end_match) == "]":
+                    if not nested:
+                        break  # Found the one we want
+                    nested = False  # Closing nesting
+                else:
+                    if nested:
+                        end_match = None  # Not attempting to handle double nesting
+                        break
+                    nested = True  # Opening nesting
+
+            # If closing [ not found, use end of line
+            if end_match is None:
+                end_point = maintext().rowcol(f"{start.row}.end")
+
+            # Get label of footnote, e.g. "[Footnote 4:..." has label "4"
+            fn_line = maintext().get(start.index(), f"{start.row}.end")
+            fn_label = fn_line[
+                beg_match.count - beg_match.rowcol.col : colon_pos.col
+            ].strip()
+
+            # Find previous occurrence of matching anchor, e.g. "[4]"
+            # but not where used in context of block markup, e.g. "/#[4]"
+            start_point = start
+            while True:
+                anchor_match = maintext().find_match(
+                    f"[{fn_label}]",
+                    IndexRange(start_point, maintext().start()),
+                    backwards=True,
+                )
+                if anchor_match is None:
+                    break
+                anchor_context = maintext().get(
+                    f"{anchor_match.rowcol.index()}-2c", anchor_match.rowcol.index()
+                )
+                if not re.fullmatch("/[#$*FILPXCR]", anchor_context):
+                    break
+                start_point = anchor_match.rowcol
+
+            fnr = FootnoteRecord(
+                fn_line, start, end_point, start.col + 1, colon_pos.col
+            )
+            self.fn_records.append(fnr)
+
+            if anchor_match is not None:
+                an_line = maintext().get(
+                    f"{anchor_match.rowcol.row}.0", f"{anchor_match.rowcol.row}.end"
+                )
+                anr = AnchorRecord(
+                    an_line,
+                    anchor_match.rowcol,
+                    maintext().rowcol(
+                        f"{anchor_match.rowcol.index()}+{anchor_match.count}c",
+                    ),
+                    anchor_match.rowcol.col,
+                    anchor_match.rowcol.col + anchor_match.count,
+                )
+                self.an_records.append(anr)
+
+            search_range = IndexRange(end_point, maintext().end())
+
+
+def sort_key_type(
+    entry: CheckerEntry,
+) -> tuple[int, int, int]:
+    """Sort key function to sort Footnote entries by type (footnote/anchor), then rowcol.
+
+    Types are distinguished lazily - anchors have a short highlit text, "[1]"
+    """
+    assert entry.text_range is not None
+    assert entry.hilite_start is not None
+    assert entry.hilite_end is not None
+    return (
+        entry.hilite_end - entry.hilite_start,
+        entry.text_range.start.row,
+        entry.text_range.start.col,
+    )
+
+
+def footnote_check() -> None:
+    """Check footnotes in the currently loaded file."""
+    global _the_footnote_checker
+
+    if not tool_save():
+        return
+
+    if _the_footnote_checker is None:
+        _the_footnote_checker = FootnoteChecker()
+
+    checker_dialog = CheckerDialog.show_dialog(
+        "Footnote Check Results",
+        rerun_command=footnote_check,
+        sort_key_alpha=sort_key_type,
+    )
+    ToolTip(
+        checker_dialog.text,
+        "\n".join(
+            [
+                "Left click: Select & find footnote",
+            ]
+        ),
+        use_pointer_pos=True,
+    )
+    frame = ttk.Frame(checker_dialog.header_frame)
+    frame.grid(column=0, row=1, columnspan=2, sticky="NSEW")
+
+    checker_dialog.reset()
+
+    _the_footnote_checker.run_check()
+    for fn_record in _the_footnote_checker.get_fn_records():
+        checker_dialog.add_entry(
+            fn_record.footnote,
+            IndexRange(fn_record.start, fn_record.end),
+            fn_record.hilite_start,
+            fn_record.hilite_end,
+        )
+    for an_record in _the_footnote_checker.get_an_records():
+        checker_dialog.add_entry(
+            an_record.anchor,
+            IndexRange(an_record.start, an_record.end),
+            an_record.hilite_start,
+            an_record.hilite_end,
+        )
+    checker_dialog.display_entries()


### PR DESCRIPTION
Since footnote fixup is a large task, split it into pieces.

This piece just lists all the footnotes and anchors in a Checker Dialog.

Algorithm is to find occurrences of "[footnote", allowing capitalization & space variation. For each one, get its label, e.g. "4" in "[Footnote 4:", then search backwards for an anchor that matches it. Don't use "/#[4]" though, because that defines width parameter for block markup.

Each anchor or footnote is added to the checker dialog, and the whole footnote should be highlighted when the line in the dialog is selected. Note that one level of nested square brackets is permitted inside a footnote, i.e. a footnote starts & ends with square brackets, and may contain open & matching close square brackets, but not brackets within those brackets.

Sort by alpha/type puts all anchors first, then all  footnotes.