### PR TITLE
Display multi-line Find All searches better

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -5,6 +5,8 @@ import tkinter as tk
 from tkinter import ttk
 from typing import Any, Optional, Callable
 
+import regex as re
+
 from guiguts.maintext import maintext
 from guiguts.mainwindow import ScrolledReadOnlyText
 from guiguts.preferences import PersistentString, PrefKey
@@ -363,13 +365,13 @@ class CheckerDialog(ToplevelDialog):
         Use this for content; use add_header & add_footer for headers & footers.
 
         Args:
-            msg: Entry to be displayed - only first line will be displayed.
+            msg: Entry to be displayed - only first non-empty line will be displayed.
             text_range: Optional start & end of point of interest in main text widget.
             hilite_start: Optional column to begin higlighting entry in dialog.
             hilite_end: Optional column to end higlighting entry in dialog.
             entry_type: Defaults to content
         """
-        line = msg.splitlines()[0] if msg else ""
+        line = re.sub(r"\n*([^\n]*)\n?.*", r"\1", msg)
         entry = CheckerEntry(
             line,
             text_range,

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -365,13 +365,17 @@ class SearchDialog(ToplevelDialog):
 
         for match in matches:
             line = maintext().get(
-                f"{match.rowcol.index()} linestart", f"{match.rowcol.index()} lineend"
+                f"{match.rowcol.index()} linestart",
+                f"{match.rowcol.index()}+{match.count}c lineend",
             )
             end_rowcol = IndexRowCol(
                 maintext().index(match.rowcol.index() + f"+{match.count}c")
             )
             hilite_start = match.rowcol.col
-            if end_rowcol.row > match.rowcol.row:
+            # If multiline, and there are lines after the one that will be shown,
+            # higlight to end of line
+            strip_line = line.lstrip("\n")
+            if end_rowcol.row > match.rowcol.row and "\n" in strip_line:
                 hilite_end = len(line)
             else:
                 hilite_end = end_rowcol.col


### PR DESCRIPTION
Displays the first non-blank line of the match.

Example regex: `^\nabc`
This will match a newline followed by `abc`.
Without this fix, just the newline (i.e. blank line) is shown in Find All dialog. With this, the line beginning `abc` should be shown, and `abc` should be highlighted.