### PR TITLE
Add compose sequence dialog

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -25,7 +25,7 @@ from guiguts.mainwindow import (
     ErrorHandler,
     process_accel,
 )
-from guiguts.misc_dialogs import PreferencesDialog
+from guiguts.misc_dialogs import PreferencesDialog, ComposeSequenceDialog
 from guiguts.misc_tools import (
     basic_fixup_check,
     page_separator_fixup,
@@ -539,6 +539,11 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         unicode_menu.add_button(
             "~Normalize Selected Characters",
             unicode_normalize,
+        )
+        unicode_menu.add_button(
+            "~~Compose Sequence...",
+            ComposeSequenceDialog.show_dialog,
+            "Cmd/Ctrl+;",
         )
 
     def init_view_menu(self) -> None:

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -541,7 +541,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             unicode_normalize,
         )
         unicode_menu.add_button(
-            "~~Compose Sequence...",
+            "~Compose Sequence...",
             ComposeSequenceDialog.show_dialog,
             "Cmd/Ctrl+;",
         )

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -19,7 +19,11 @@ from guiguts.utilities import (
     force_tcl_wholeword,
     convert_to_tcl_regex,
 )
-from guiguts.widgets import theme_set_tk_widget_colors, themed_style
+from guiguts.widgets import (
+    theme_set_tk_widget_colors,
+    themed_style,
+    register_focus_widget,
+)
 
 logger = logging.getLogger(__package__)
 
@@ -219,6 +223,9 @@ class MainText(tk.Text):
         self.bind_event(
             "<<ThemeChanged>>", lambda _event: theme_set_tk_widget_colors(self)
         )
+
+        # Register this widget to have its focus tracked for inserting special characters
+        register_focus_widget(self)
 
         # Configure tags
         self.tag_configure(PAGE_FLAG_TAG, background="gold", foreground="black")

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -198,17 +198,15 @@ class ComposeSequenceDialog(OkApplyCancelDialog):
         """
         sequence = self.string.get()
         char = ""
-        # Allow 0x, \x, x or U+ as optional prefix to hex Unicode ordinal
-        if match := re.fullmatch(
-            r"(0x|\\x|x|U\+)?([0-9a-f]{4})", sequence, re.IGNORECASE
-        ):
-            # If 4 hex digits, it's complete
-            char = chr(int(match[2], 16))
+        if match := re.fullmatch(r"[0-9a-f]{4}", sequence, re.IGNORECASE):
+            # Exactly 4 hex digits translates to a single Unicode character
+            char = chr(int(sequence, 16))
         elif force:
             if match := re.fullmatch(
-                r"(0x|\\x|x|U\+)?([0-9a-fA-F]{2,4})", sequence, re.IGNORECASE
+                r"(0x|\\x|x|U\+?)?([0-9a-fA-F]{2,})", sequence, re.IGNORECASE
             ):
-                # Or user can force conversion with fewer than 4 hex digits
+                # Or user can force interpretation as hex with fewer than 4 digits,
+                # or with more than 4 by using a prefix: 0x, \x, x, U or U+
                 char = chr(int(match[2], 16))
             elif match := re.fullmatch(r"#(\d{2,})", sequence):
                 # Or specify in decimal following '#' character

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -18,7 +18,13 @@ from guiguts.utilities import (
     is_mac,
     sing_plur,
 )
-from guiguts.widgets import ToplevelDialog, Combobox, mouse_bind, ToolTip
+from guiguts.widgets import (
+    ToplevelDialog,
+    Combobox,
+    mouse_bind,
+    ToolTip,
+    register_focus_widget,
+)
 
 logger = logging.getLogger(__package__)
 
@@ -90,6 +96,8 @@ class SearchDialog(ToplevelDialog):
         # Search
         self.search_box = Combobox(search_frame1, PrefKey.SEARCH_HISTORY, width=30)
         self.search_box.grid(row=0, column=0, padx=2, pady=(5, 0), sticky="NSEW")
+        # Register search box to have its focus tracked for inserting special characters
+        register_focus_widget(self.search_box)
         self.search_box.focus()
 
         search_button = ttk.Button(
@@ -165,6 +173,8 @@ class SearchDialog(ToplevelDialog):
         # Replace
         self.replace_box = Combobox(search_frame1, PrefKey.REPLACE_HISTORY, width=30)
         self.replace_box.grid(row=1, column=0, padx=2, pady=(4, 6), sticky="NSEW")
+        # Register replace box to have its focus tracked for inserting special characters
+        register_focus_widget(self.replace_box)
 
         ttk.Button(
             search_frame1,


### PR DESCRIPTION
Shortcut is `Ctrl/Cmd+semicolon` or use the Tools--> Unicode menu.
The only sequences defined so far are:
1. Up to 4 hex digits - dialog closes when 4 are typed.
2. Hex digits can optionally be preceded by `x`, `U+`, etc.
3. Or use `#nnn` where `nnn` is any number of decimal digits. Use Apply/OK to terminate these.