### PR TITLE
Simplify use of Tk Variables & Prefs

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -9,7 +9,7 @@ import regex as re
 
 from guiguts.maintext import maintext
 from guiguts.mainwindow import ScrolledReadOnlyText
-from guiguts.preferences import PersistentString, PrefKey
+from guiguts.preferences import PersistentString, PrefKey, preferences
 from guiguts.root import root
 from guiguts.utilities import (
     IndexRowCol,
@@ -88,8 +88,6 @@ class CheckerDialog(ToplevelDialog):
         count_label: Label showing how many linked entries there are in the dialog
     """
 
-    sort_type: PersistentString
-
     def __init__(
         self,
         title: str,
@@ -106,13 +104,6 @@ class CheckerDialog(ToplevelDialog):
             rerun_command: Function to call to re-run the check.
             process_command: Function to call to "process" the current error, e.g. swap he/be
         """
-        # Initialize class variables on first instantiation, then remember
-        # values for subsequent uses of dialog.
-        try:
-            CheckerDialog.sort_type
-        except AttributeError:
-            CheckerDialog.sort_type = PersistentString(PrefKey.CHECKERDIALOG_SORT_TYPE)
-
         super().__init__(title, **kwargs)
         self.top_frame.rowconfigure(0, weight=0)
         self.header_frame = ttk.Frame(self.top_frame, padding=2)
@@ -128,11 +119,12 @@ class CheckerDialog(ToplevelDialog):
             left_frame,
             text="Sort:",
         ).grid(row=0, column=1, sticky="NSE", padx=5)
+        sort_type = PersistentString(PrefKey.CHECKERDIALOG_SORT_TYPE)
         ttk.Radiobutton(
             left_frame,
             text="Line & Col",
             command=self.display_entries,
-            variable=CheckerDialog.sort_type,
+            variable=sort_type,
             value=CheckerSortType.ROWCOL,
             takefocus=False,
         ).grid(row=0, column=2, sticky="NSE", padx=2)
@@ -140,7 +132,7 @@ class CheckerDialog(ToplevelDialog):
             left_frame,
             text="Alpha/Type",
             command=self.display_entries,
-            variable=CheckerDialog.sort_type,
+            variable=sort_type,
             value=CheckerSortType.ALPHABETIC,
             takefocus=False,
         ).grid(row=0, column=3, sticky="NSE", padx=2)
@@ -399,7 +391,10 @@ class CheckerDialog(ToplevelDialog):
         the sort setting."""
 
         sort_key: Callable[[CheckerEntry], tuple]
-        if CheckerDialog.sort_type.get() == CheckerSortType.ALPHABETIC:
+        if (
+            preferences.get(PrefKey.CHECKERDIALOG_SORT_TYPE)
+            == CheckerSortType.ALPHABETIC
+        ):
             sort_key = self.alpha_key
         else:
             sort_key = self.rowcol_key

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -287,12 +287,12 @@ class PageSeparatorDialog(ToplevelDialog):
         self.key_bind("c", chapter_button.invoke)
         self.key_bind("Key-4", chapter_button.invoke)
 
-        self.auto_type = PersistentString(PrefKey.PAGESEP_AUTO_TYPE)
+        auto_type = PersistentString(PrefKey.PAGESEP_AUTO_TYPE)
         ttk.Radiobutton(
             self.top_frame,
             text="No Auto",
             command=self.refresh,
-            variable=self.auto_type,
+            variable=auto_type,
             value=PageSepAutoType.NO_AUTO,
             takefocus=False,
         ).grid(column=0, row=1, sticky="NSEW", padx=(20, 2), pady=2)
@@ -300,7 +300,7 @@ class PageSeparatorDialog(ToplevelDialog):
             self.top_frame,
             text="Auto Advance",
             command=self.refresh,
-            variable=self.auto_type,
+            variable=auto_type,
             value=PageSepAutoType.AUTO_ADVANCE,
             takefocus=False,
         ).grid(column=1, row=1, sticky="NSEW", padx=2, pady=2)
@@ -308,7 +308,7 @@ class PageSeparatorDialog(ToplevelDialog):
             self.top_frame,
             text="Auto Fix",
             command=self.refresh,
-            variable=self.auto_type,
+            variable=auto_type,
             value=PageSepAutoType.AUTO_FIX,
             takefocus=False,
         ).grid(column=2, row=1, sticky="NSEW", padx=2, pady=2)

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -74,6 +74,10 @@ class Preferences:
           deal with side effect of loading/setting the pref, which will be
           called after all prefs have been loaded and UI is ready. Also called
           each time pref is changed.
+        persistent_vars: dictionary of Persistent variables (inherit from Tk.Variable),
+          stored here so the variable can be set whenever the pref is set. The Persistent
+          classes below handle the reverse, i.e. they set the pref whenever the variable
+          is set.
         prefsdir: directory containing user prefs & data files
     """
 
@@ -82,6 +86,7 @@ class Preferences:
         self.dict: dict[PrefKey, Any] = {}
         self.defaults: dict[PrefKey, Any] = {}
         self.callbacks: dict[PrefKey, Callable[[Any], None]] = {}
+        self.persistent_vars: dict[PrefKey, tk.Variable] = {}
         if is_x11():
             self.prefsdir = os.path.join(os.path.expanduser("~"), ".ggpreferences")
         else:
@@ -118,11 +123,14 @@ class Preferences:
             key: Name of preference.
             value: Value for preference.
         """
-        if self.get(key) != value:
-            self.dict[key] = value
-            self.save()
-            if key in self.callbacks:
-                self.callbacks[key](value)
+        if self.get(key) == value:
+            return
+        self.dict[key] = value
+        self.save()
+        if key in self.callbacks:
+            self.callbacks[key](value)
+        if key in self.persistent_vars:
+            self.persistent_vars[key].set(value)
 
     def toggle(self, key: PrefKey) -> None:
         """Toggle the value of a boolean preference.
@@ -170,6 +178,16 @@ class Preferences:
               update UI to reflect a setting.
         """
         self.callbacks[key] = callback
+
+    def link_persistent_var(self, key: PrefKey, var: tk.Variable) -> None:
+        """Link a persistent variable to a preference. Variable will be set
+        whenever the preference gets set.
+
+        Args:
+            key: Name of preference.
+            var: Persistent variable to link to preference.
+        """
+        self.persistent_vars[key] = var
 
     def keys(self) -> list[PrefKey]:
         """Return list of preferences keys.
@@ -225,6 +243,7 @@ class PersistentBoolean(tk.BooleanVar):
         """
         super().__init__(value=preferences.get(prefs_key))
         self.trace_add("write", lambda *_args: preferences.set(prefs_key, self.get()))
+        preferences.link_persistent_var(prefs_key, self)
 
 
 class PersistentInt(tk.IntVar):
@@ -254,6 +273,7 @@ class PersistentInt(tk.IntVar):
                 pass
 
         self.trace_add("write", set_pref)
+        preferences.link_persistent_var(prefs_key, self)
 
 
 class PersistentString(tk.StringVar):
@@ -271,6 +291,7 @@ class PersistentString(tk.StringVar):
         """
         super().__init__(value=preferences.get(prefs_key))
         self.trace_add("write", lambda *_args: preferences.set(prefs_key, self.get()))
+        preferences.link_persistent_var(prefs_key, self)
 
 
 preferences = Preferences()


### PR DESCRIPTION
Previously, when a PersistentBoolean/Int/String (which are inherited from Tk.Variables) was set, it also set the linked GG Pref value. This puts the reverse linkage in, which means that if a separate piece of code updates a Pref, then the Tk variable will be updated, and any associated checkbox, etc., will be updated too.

This removes the need to have dialog class variables to the Pref setting.

Should be no change in behavior.