### PR TITLE
Highlight single/double quotes in a selection

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,11 @@ File
     
 .. automodule:: file
 
+Highlight
+=========
+
+.. automodule:: highlight
+
 MainText
 ========
      

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -16,6 +16,11 @@ from guiguts.checkers import CheckerSortType
 from guiguts.data import themes
 from guiguts.file import File, the_file, NUM_RECENT_FILES
 from guiguts.footnotes import footnote_check
+from guiguts.highlight import (
+    highlight_single_quotes,
+    highlight_double_quotes,
+    remove_highlights,
+)
 from guiguts.maintext import maintext
 from guiguts.mainwindow import (
     MainWindow,
@@ -456,6 +461,21 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             "Find ~Previous",
             lambda: find_next(backwards=True),
             "Cmd+Shift+G" if is_mac() else "Shift+F3",
+        )
+        menu_search.add_button(
+            "Highlight Single Quotes in Selection",
+            highlight_single_quotes,
+            "",
+        )
+        menu_search.add_button(
+            "Highlight Double Quotes in Selection",
+            highlight_double_quotes,
+            "",
+        )
+        menu_search.add_button(
+            "Remove Highlights",
+            remove_highlights,
+            "",
         )
         self.init_bookmark_menu(menu_search)
 

--- a/src/guiguts/highlight.py
+++ b/src/guiguts/highlight.py
@@ -1,0 +1,102 @@
+"""Highlight functionality"""
+
+from enum import auto
+
+from guiguts.maintext import maintext
+from guiguts.preferences import preferences, PrefKey
+
+
+class Highlight:
+    """Global highlight settings"""
+
+    TAG_QUOTEMARK = auto()
+
+    # Possible future enhancement:
+    #
+    # GG1 allowed you to set three colors:
+    # - Background color (text areas, text inputs, main editor textarea)
+    # - Button highlight color (hover on buttons, checkboxes, radio selects)
+    # - Scanno/quote highlight color (which would apply here)
+    #
+    # Unclear what we should/will do in GG2 with themes & dark mode support.
+
+    # Must be a definition for each available theme
+    COLORS_QUOTEMARK = {
+        "Light": {"bg": "#a08dfc", "fg": "black"},
+        "Dark": {"bg": "#a08dfc", "fg": "white"},
+        "Default": {"bg": "#a08dfc", "fg": "black"},
+    }
+
+
+def highlight_selection(
+    pat: str,
+    tag_name: str,
+    nocase: bool = False,
+    regexp: bool = False,
+    wholeword: bool = False,
+) -> None:
+    """Highlight matches in the current selection.
+    Args:
+        pat: string or regexp to find in the current selection
+        tag_name: tkinter tag to apply to matched text region(s)
+    Optional keyword args:
+        nocase (default False): set True for case-insensitivity
+        regexp (default False): whether to assume 's' is a regexp
+        wholeword (defalut False): whether to match only whole words
+    """
+
+    if not (ranges := maintext().selected_ranges()):
+        return
+
+    for _range in ranges:
+        matches = maintext().find_matches(
+            pat, _range, nocase=nocase, regexp=regexp, wholeword=wholeword
+        )
+        for match in matches:
+            maintext().tag_add(
+                tag_name, match.rowcol.index(), match.rowcol.index() + "+1c"
+            )
+
+
+def get_active_theme() -> str:
+    """Return the current theme name"""
+    return preferences.get(PrefKey.THEME_NAME)
+
+
+def remove_highlights() -> None:
+    """Remove acvite highlights"""
+    maintext().tag_delete(str(Highlight.TAG_QUOTEMARK))
+
+
+def highlight_quotemarks(pat: str) -> None:
+    """Highlight quote marks in current selection which match a pattern"""
+    theme = get_active_theme()
+    remove_highlights()
+    maintext().tag_configure(
+        str(Highlight.TAG_QUOTEMARK),
+        background=Highlight.COLORS_QUOTEMARK[theme]["bg"],
+        foreground=Highlight.COLORS_QUOTEMARK[theme]["fg"],
+    )
+    highlight_selection(pat, str(Highlight.TAG_QUOTEMARK), regexp=True)
+
+
+def highlight_single_quotes() -> None:
+    """Highlight single quotes in current selection.
+
+    ' APOSTROPHE
+    ‘’ {LEFT, RIGHT} SINGLE QUOTATION MARK
+    ‹› SINGLE {LEFT, RIGHT}-POINTING ANGLE QUOTATION MARK
+    ‛‚ SINGLE {HIGH-REVERSED-9, LOW-9} QUOTATION MARK
+    """
+    highlight_quotemarks("['‘’‹›‛‚]")
+
+
+def highlight_double_quotes() -> None:
+    """Highlight double quotes in current selection.
+
+    " QUOTATION MARK
+    “” {LEFT, RIGHT} DOUBLE QUOTATION MARK
+    «» {LEFT, RIGHT}-POINTING DOUBLE ANGLE QUOTATION MARK
+    ‟„ DOUBLE {HIGH-REVERSED-9, LOW-9} QUOTATION MARK
+    """
+    highlight_quotemarks('["“”«»‟„]')


### PR DESCRIPTION
Add ability to highlight single or double quotes in the current selection, and to remove current highlights. Based on GG1's behavior. All 3 are available as menu items in the Search menu.

Testing notes:
- Select some text, then choose each item from the menu
- Modes are exclusive; highlight single, then double, will un-highlight single before highlighting double
- Remove highlights should remove any current highlights
- Both straight and curly quotes are supported
- Column selection is supported
- If you select text, highlight, then select different text (even if they overlap) and highlight again, old highlights are removed first, then new highlights in the selected area applied.
- Choosing the menu item with no selection in effect, does nothing

All of these behaviors are based on GG1's behavior with these exceptions:
- GG1 doesn't support these functions in column select; so that is a new behavior
- The highlight color is configurable in GG1; I have them static here for now. This probably needs to be thought through, i.e. can this be integrated into the theme system?

Fixes #260