### PR TITLE
Add remaining compose sequences

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -570,7 +570,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         unicode_menu.add_button(
             "~Compose Sequence...",
             ComposeSequenceDialog.show_dialog,
-            "Cmd/Ctrl+M",
+            "Cmd/Ctrl+I",
         )
 
     def init_view_menu(self) -> None:

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -31,7 +31,11 @@ from guiguts.mainwindow import (
     ErrorHandler,
     process_accel,
 )
-from guiguts.misc_dialogs import PreferencesDialog, ComposeSequenceDialog
+from guiguts.misc_dialogs import (
+    PreferencesDialog,
+    ComposeSequenceDialog,
+    ComposeHelpDialog,
+)
 from guiguts.misc_tools import (
     basic_fixup_check,
     page_separator_fixup,
@@ -586,6 +590,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_help = Menu(menubar(), "~Help")
         menu_help.add_button("Guiguts ~Manual", self.show_help_manual)
         menu_help.add_button("About ~Guiguts", self.help_about)
+        menu_help.add_button("~Compose Sequences", ComposeHelpDialog.show_dialog)
 
     def init_os_menu(self) -> None:
         """Create the OS-specific menu.

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -569,7 +569,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         unicode_menu.add_button(
             "~Compose Sequence...",
             ComposeSequenceDialog.show_dialog,
-            "Cmd/Ctrl+;",
+            "Cmd/Ctrl+semicolon",
         )
 
     def init_view_menu(self) -> None:

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -336,6 +336,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             ),
         )
         preferences.set_default(PrefKey.TEAROFF_MENUS, False)
+        preferences.set_default(PrefKey.COMPOSE_HISTORY, [])
 
         # Check all preferences have a default
         for pref_key in PrefKey:
@@ -542,7 +543,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_tools.add_button("~Rewrap All", self.file.rewrap_all)
         menu_tools.add_button("R~ewrap Selection", self.file.rewrap_selection)
         menu_tools.add_separator()
-        unmatched_menu = Menu(menu_tools, "~Unmatched")
+        unmatched_menu = Menu(menu_tools, "Un~matched")
         unmatched_menu.add_button("Bloc~k Markup...", unmatched_block_markup)
         unmatched_menu.add_button("~DP Markup...", unmatched_dp_markup)
         unmatched_menu.add_button("~Brackets...", unmatched_brackets)
@@ -569,7 +570,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         unicode_menu.add_button(
             "~Compose Sequence...",
             ComposeSequenceDialog.show_dialog,
-            "Cmd/Ctrl+semicolon",
+            "Cmd/Ctrl+M",
         )
 
     def init_view_menu(self) -> None:
@@ -590,7 +591,9 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_help = Menu(menubar(), "~Help")
         menu_help.add_button("Guiguts ~Manual", self.show_help_manual)
         menu_help.add_button("About ~Guiguts", self.help_about)
-        menu_help.add_button("~Compose Sequences", ComposeHelpDialog.show_dialog)
+        menu_help.add_button(
+            "List of ~Compose Sequences", ComposeHelpDialog.show_dialog
+        )
 
     def init_os_menu(self) -> None:
         """Create the OS-specific menu.

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -294,7 +294,7 @@ def init_compose_dict() -> None:
     init_chars("⅞", "7/8")
     init_chars("⅑", "1/9")
     init_chars("⅒", "1/10")
-    for num, char in enumerate("⁰ⁱ²³⁴⁵⁶⁷⁸⁹"):
+    for num, char in enumerate("⁰¹²³⁴⁵⁶⁷⁸⁹"):
         init_chars(char, f"^{num}")
     for num, char in enumerate("₀₁₂₃₄₅₆₇₈₉"):
         init_chars(char, f",{num}")
@@ -515,7 +515,7 @@ class ComposeHelpDialog(ToplevelDialog):
 
     def __init__(self) -> None:
         """Initialize class members from page details."""
-        super().__init__("Compose Sequences")
+        super().__init__("List of Compose Sequences")
 
         self.column_headings = ("Character", "Sequence", "Name")
         widths = (70, 70, 600)

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -236,6 +236,46 @@ def init_compose_dict() -> None:
     """Initialize dictionary of compose sequences."""
     if _compose_dict:
         return  # Already initialized
+    init_char_reversible("‘", "'<")
+    init_char_reversible("’", "'>")
+    init_char_reversible("“", '"<')
+    init_char_reversible("”", '">')
+    init_chars("±", "+-")
+    init_chars("·", "^.", "*.", ".*")
+    init_chars("×", "*x", "x*")
+    init_chars("÷", ":-")
+    init_char_reversible("°", "oo", "*o")
+    init_char_reversible("′", "1'")
+    init_char_reversible("″", "2'")
+    init_char_reversible("‴", "3'")
+    init_char_reversible(" ", "  ", "* ")
+    init_chars("—", "--")
+    init_char_reversible("–", "- ")
+    init_chars("⁂", "**")
+    init_char_reversible("º", "o_")
+    init_char_reversible("ª", "a_")
+    init_chars("‖", "||")
+    init_chars("¡", "!!")
+    init_chars("¿", "??")
+    init_chars("«", "<<")
+    init_chars("»", ">>")
+    init_char_case("Æ", "AE")
+    init_char_case("Œ", "OE")
+    init_char_case("ẞ", "SS")
+    init_char_case("Ð", "DH", "ETH")
+    init_char_case("Þ", "TH")
+    init_chars("©", "(c)", "(C)")
+    init_chars("†", "dag", "DAG")
+    init_chars("‡", "ddag", "DDAG")
+    init_accent("£", "L", "-")
+    init_accent("¢", "C", "/", "|")
+    init_chars("§", "sec", "s*", "*s", "SEC", "S*", "*S")
+    init_chars("¶", "pil", "p*", "*p", "PIL", "P*", "*P")
+    init_chars("ſ", "sf", "SF")
+    init_chars("‚", ",'")
+    init_chars("‛", "^'")
+    init_chars("„", ',"')
+    init_chars("‟", '^"')
     init_chars("½", "1/2")
     init_chars("⅓", "1/3")
     init_chars("⅔", "2/3")
@@ -254,52 +294,10 @@ def init_compose_dict() -> None:
     init_chars("⅞", "7/8")
     init_chars("⅑", "1/9")
     init_chars("⅒", "1/10")
-    init_chars("¡", "!!")
-    init_chars("¿", "??")
-    init_chars("«", "<<")
-    init_chars("»", ">>")
-    init_char_case("Æ", "AE")
-    init_char_case("Œ", "OE")
-    init_char_case("ẞ", "SS")
-    init_char_case("Ð", "DH", "ETH")
-    init_char_case("Þ", "TH")
-    init_char_case("©", "CO", "(C)")
-    init_char_case("†", "DAG")
-    init_char_case("‡", "DDAG")
-    init_char_case("§", "SEC", "S*", "*S")
-    init_char_case("¶", "PIL", "P*", "*P")
-    init_char_case(
-        "ſ",
-        "SF",
-    )
-    init_char_reversible("‘", "'<", "'6")
-    init_char_reversible("’", "'>", "'9")
-    init_char_reversible("“", '"<', '"6')
-    init_char_reversible("”", '">', '"9')
-    init_char_reversible("‚", "',")
-    init_char_reversible("‛", "'^")
-    init_char_reversible("„", '",')
-    init_char_reversible("‟", '"^')
-    init_char_reversible("±", "*+", "+-")
-    init_char_reversible("·", ".^", "*.")
-    init_char_reversible("×", "xx", "*x")
-    init_char_reversible("÷", ":-")
-    init_char_reversible("°", "oo", "*o")
-    init_char_reversible("′", "*'", "1'")
-    init_char_reversible("″", '*"', "2'")
-    init_char_reversible("‴", "3'")
-    init_char_reversible("‰", "%0", r"%o")
-    init_char_reversible(" ", "  ", "* ")
-    init_char_reversible("—", "--")
-    init_char_reversible("–", "- ")
-    init_char_reversible("⁂", "**")
-    init_char_reversible("º", "o_")
-    init_char_reversible("ª", "a_")
-    init_char_reversible("‖", "||")
     for num, char in enumerate("⁰ⁱ²³⁴⁵⁶⁷⁸⁹"):
-        init_char_reversible(char, f"^{num}")
+        init_chars(char, f"^{num}")
     for num, char in enumerate("₀₁₂₃₄₅₆₇₈₉"):
-        init_char_reversible(char, f",{num}")
+        init_chars(char, f",{num}")
 
     # Accented characters
     init_accent("À", "A", "`", "\\")
@@ -335,8 +333,6 @@ def init_compose_dict() -> None:
     init_accent("Ñ", "N", "~")
     init_accent("Ÿ", "Y", '"', ":")
     init_accent("Ý", "Y", "'", "/")
-    init_accent("£", "L", "/", "\\")
-    init_accent("¢", "C", "/", "|")
 
     # Combining characters
     init_combining("\u0300", "\u0316", "\\", "`")  # grave
@@ -349,8 +345,8 @@ def init_compose_dict() -> None:
     init_combining("\u0307", "\u0323", ".")  # dot
     init_combining("\u0308", "\u0324", ":", '"')  # diaresis
     init_combining("\u0309", "", "?")  # hook above
-    init_combining("\u030A", "\u0325", "o", "O", "*")  # ring
-    init_combining("\u030C", "\u032C", "v", "V")  # caron
+    init_combining("\u030A", "\u0325", "*")  # ring
+    init_combining("\u030C", "\u032C", "v")  # caron
     init_combining("", "\u0327", ",")  # cedilla
     init_combining("", "\u0328", ";")  # ogonek
 
@@ -415,7 +411,7 @@ def init_char_case(char: str, *sequences: str) -> None:
 
     Args:
         char: Character to be added.
-        *sequences: Sequences of reversible keys to generate the character.
+        *sequences: Sequences of keys to generate the character.
     """
     lchar = char.lower()
     for sequence in sequences:
@@ -522,7 +518,7 @@ class ComposeHelpDialog(ToplevelDialog):
         super().__init__("Compose Sequences")
 
         self.column_headings = ("Character", "Sequence", "Name")
-        widths = (70, 70, 320)
+        widths = (70, 70, 600)
         self.help = ttk.Treeview(
             self.top_frame,
             columns=self.column_headings,
@@ -559,11 +555,31 @@ class ComposeHelpDialog(ToplevelDialog):
         mouse_bind(self.help, "1", self.insert_char)
 
         init_compose_dict()
-        for sequence, char in sorted(_compose_dict.items(), key=lambda x: x[1]):
+
+        # Avoid displaying help for reversed 2-char sequence, e.g. "o*" and "*o"
+        # Remember ones that have been entered already
+        reverse_done = {}
+        for sequence, char in _compose_dict.items():
+            seq_display = sequence.replace(" ", "␣")
+            if len(sequence) == 2:
+                rev_sequence = sequence[::-1]
+                if rev_sequence in reverse_done:
+                    continue
+                rev_char = _compose_dict.get(rev_sequence)
+                if rev_char == char and rev_sequence != sequence:
+                    seq_display += f"  or  {rev_sequence.replace(' ', '␣')}"
+                    reverse_done[sequence] = char
+            # Don't add uppercase version if it leads to identical character, e.g. "dag"/"DAG" for dagger
+            if (
+                char == _compose_dict.get(sequence.lower())
+                and sequence != sequence.lower()
+            ):
+                continue
             try:
-                entry = (char, sequence, unicodedata.name(char))
+                name = unicodedata.name(char)
             except ValueError:
                 continue  # Some Greek combinations don't exist
+            entry = (char, seq_display, name)
             self.help.insert("", tk.END, values=entry)
 
         children = self.help.get_children()
@@ -578,4 +594,8 @@ class ComposeHelpDialog(ToplevelDialog):
         """
         row_id = self.help.identify_row(event.y)
         row = self.help.set(row_id)
-        insert_in_focus_widget(row[self.column_headings[0]])
+        try:
+            char = row[self.column_headings[0]]
+        except KeyError:
+            return
+        insert_in_focus_widget(char)

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -2,6 +2,7 @@
 
 import tkinter as tk
 from tkinter import ttk
+import unicodedata
 
 import regex as re
 
@@ -17,6 +18,7 @@ from guiguts.widgets import (
     ToolTip,
     insert_in_focus_widget,
     OkApplyCancelDialog,
+    mouse_bind,
 )
 
 
@@ -154,8 +156,15 @@ class PreferencesDialog(ToplevelDialog):
         )
 
 
+_compose_dict: dict[str, str] = {}
+
+
 class ComposeSequenceDialog(OkApplyCancelDialog):
-    """Dialog to enter Compose Sequences."""
+    """Dialog to enter Compose Sequences.
+
+    Attributes:
+        dict: Dictionary mapping sequence of keystrokes to character.
+    """
 
     def __init__(self) -> None:
         """Initialize compose sequence dialog."""
@@ -171,6 +180,7 @@ class ComposeSequenceDialog(OkApplyCancelDialog):
         entry.bindtags((bindings[1], bindings[0], bindings[2], bindings[3]))
         entry.bind("<Key>", lambda _event: self.interpret_and_insert())
         entry.focus()
+        init_compose_dict()
 
     def apply_changes(self) -> bool:
         """Overridden function called when Apply/OK buttons are pressed.
@@ -198,7 +208,10 @@ class ComposeSequenceDialog(OkApplyCancelDialog):
         """
         sequence = self.string.get()
         char = ""
-        if match := re.fullmatch(r"[0-9a-f]{4}", sequence, re.IGNORECASE):
+        # First check if sequence is in dictionary
+        if sequence in _compose_dict:
+            char = _compose_dict[sequence]
+        elif match := re.fullmatch(r"[0-9a-f]{4}", sequence, re.IGNORECASE):
             # Exactly 4 hex digits translates to a single Unicode character
             char = chr(int(sequence, 16))
         elif force:
@@ -217,3 +230,352 @@ class ComposeSequenceDialog(OkApplyCancelDialog):
         insert_in_focus_widget(char)
         if not force:
             self.destroy()
+
+
+def init_compose_dict() -> None:
+    """Initialize dictionary of compose sequences."""
+    if _compose_dict:
+        return  # Already initialized
+    init_chars("½", "1/2")
+    init_chars("⅓", "1/3")
+    init_chars("⅔", "2/3")
+    init_chars("¼", "1/4")
+    init_chars("¾", "3/4")
+    init_chars("⅕", "1/5")
+    init_chars("⅖", "2/5")
+    init_chars("⅗", "3/5")
+    init_chars("⅘", "4/5")
+    init_chars("⅙", "1/6")
+    init_chars("⅚", "5/6")
+    init_chars("⅐", "1/7")
+    init_chars("⅛", "1/8")
+    init_chars("⅜", "3/8")
+    init_chars("⅝", "5/8")
+    init_chars("⅞", "7/8")
+    init_chars("⅑", "1/9")
+    init_chars("⅒", "1/10")
+    init_chars("¡", "!!")
+    init_chars("¿", "??")
+    init_chars("«", "<<")
+    init_chars("»", ">>")
+    init_char_case("Æ", "AE")
+    init_char_case("Œ", "OE")
+    init_char_case("ẞ", "SS")
+    init_char_case("Ð", "DH", "ETH")
+    init_char_case("Þ", "TH")
+    init_char_case("©", "CO", "(C)")
+    init_char_case("†", "DAG")
+    init_char_case("‡", "DDAG")
+    init_char_case("§", "SEC", "S*", "*S")
+    init_char_case("¶", "PIL", "P*", "*P")
+    init_char_case(
+        "ſ",
+        "SF",
+    )
+    init_char_reversible("‘", "'<", "'6")
+    init_char_reversible("’", "'>", "'9")
+    init_char_reversible("“", '"<', '"6')
+    init_char_reversible("”", '">', '"9')
+    init_char_reversible("‚", "',")
+    init_char_reversible("‛", "'^")
+    init_char_reversible("„", '",')
+    init_char_reversible("‟", '"^')
+    init_char_reversible("±", "*+", "+-")
+    init_char_reversible("·", ".^", "*.")
+    init_char_reversible("×", "xx", "*x")
+    init_char_reversible("÷", ":-")
+    init_char_reversible("°", "oo", "*o")
+    init_char_reversible("′", "*'", "1'")
+    init_char_reversible("″", '*"', "2'")
+    init_char_reversible("‴", "3'")
+    init_char_reversible("‰", "%0", r"%o")
+    init_char_reversible(" ", "  ", "* ")
+    init_char_reversible("—", "--")
+    init_char_reversible("–", "- ")
+    init_char_reversible("⁂", "**")
+    init_char_reversible("º", "o_")
+    init_char_reversible("ª", "a_")
+    init_char_reversible("‖", "||")
+    for num, char in enumerate("⁰ⁱ²³⁴⁵⁶⁷⁸⁹"):
+        init_char_reversible(char, f"^{num}")
+    for num, char in enumerate("₀₁₂₃₄₅₆₇₈₉"):
+        init_char_reversible(char, f",{num}")
+
+    # Accented characters
+    init_accent("À", "A", "`", "\\")
+    init_accent("Á", "A", "'", "/")
+    init_accent("Â", "A", "^")
+    init_accent("Ã", "A", "~")
+    init_accent("Ä", "A", '"', ":")
+    init_accent("Å", "A", "o", "*")
+    init_accent("Ā", "A", "-", "=")
+    init_accent("È", "E", "`", "\\")
+    init_accent("É", "E", "'", "/")
+    init_accent("Ê", "E", "^")
+    init_accent("Ë", "E", '"', ":")
+    init_accent("Ē", "E", "-", "=")
+    init_accent("Ì", "I", "`", "\\")
+    init_accent("Í", "I", "'", "/")
+    init_accent("Î", "I", "^")
+    init_accent("Ï", "I", '"', ":")
+    init_accent("Ī", "I", "-", "=")
+    init_accent("Ò", "O", "`", "\\")
+    init_accent("Ó", "O", "'")
+    init_accent("Ô", "O", "^")
+    init_accent("Õ", "O", "~")
+    init_accent("Ö", "O", '"', ":")
+    init_accent("Ø", "O", "/")
+    init_accent("Ō", "O", "-", "=")
+    init_accent("Ù", "U", "`", "\\")
+    init_accent("Ú", "U", "'", "/")
+    init_accent("Û", "U", "^")
+    init_accent("Ü", "U", '"', ":")
+    init_accent("Ū", "U", "-", "=")
+    init_accent("Ç", "C", ",")
+    init_accent("Ñ", "N", "~")
+    init_accent("Ÿ", "Y", '"', ":")
+    init_accent("Ý", "Y", "'", "/")
+    init_accent("£", "L", "/", "\\")
+    init_accent("¢", "C", "/", "|")
+
+    # Combining characters
+    init_combining("\u0300", "\u0316", "\\", "`")  # grave
+    init_combining("\u0301", "\u0317", "/", "'")  # acute
+    init_combining("\u0302", "\u032D", "^")  # circumflex
+    init_combining("\u0303", "\u0330", "~")  # tilde
+    init_combining("\u0304", "\u0331", "-", "=")  # macron
+    init_combining("\u0306", "\u032E", ")")  # breve
+    init_combining("\u0311", "\u032F", "(")  # inverted breve
+    init_combining("\u0307", "\u0323", ".")  # dot
+    init_combining("\u0308", "\u0324", ":", '"')  # diaresis
+    init_combining("\u0309", "", "?")  # hook above
+    init_combining("\u030A", "\u0325", "o", "O", "*")  # ring
+    init_combining("\u030C", "\u032C", "v", "V")  # caron
+    init_combining("", "\u0327", ",")  # cedilla
+    init_combining("", "\u0328", ";")  # ogonek
+
+    # Greek characters
+    init_greek_alphabet()
+    init_greek_accent("Ὰ", "A", "ᾼ")
+    init_greek_accent("Ὲ", "E")
+    init_greek_accent("Ὴ", "H", "ῌ")
+    init_greek_accent("Ὶ", "I")
+    init_greek_accent("Ὸ", "O")
+    init_greek_accent("Ὺ", "U")
+    init_greek_accent("Ὼ", "W", "ῼ")
+    init_greek_breathing("Ἀ", "A", "ᾈ")
+    init_greek_breathing("Ἐ", "E")
+    init_greek_breathing("Ἠ", "H", "ᾘ")
+    init_greek_breathing("Ἰ", "I")
+    init_greek_breathing("Ὀ", "O")
+    init_greek_breathing("὘", "U")
+    init_greek_breathing("Ὠ", "W", "ᾨ")
+
+
+def init_accent(char: str, base: str, *accents: str) -> None:
+    """Add entries to the dictionary for upper & lower case versions
+    of the given char, using each of the accents.
+
+    Args:
+        char: Upper case version of character to be added.
+        base: Upper case base English character to be accented.
+        *accents: Characters that can be used to add the accent.
+    """
+    for accent in accents:
+        init_char_case(char, base + accent)
+        init_char_case(char, accent + base)
+
+
+def init_chars(char: str, *sequences: str) -> None:
+    """Add entries to the dictionary for the given char.
+
+    Args:
+        char: Character to be added.
+        *sequences: Sequences of keys to generate the character.
+    """
+    for sequence in sequences:
+        _compose_dict[sequence] = char
+
+
+def init_char_reversible(char: str, *sequences: str) -> None:
+    """Add entries to the dictionary for the given char with
+    2 reversible characters per sequence.
+
+    Args:
+        char: Character to be added.
+        *sequences: Sequences of reversible keys to generate the character.
+    """
+    for sequence in sequences:
+        _compose_dict[sequence] = char
+        _compose_dict[sequence[::-1]] = char
+
+
+def init_char_case(char: str, *sequences: str) -> None:
+    """Add upper & lower case entries to the dictionary for the given char & sequence.
+
+    Args:
+        char: Character to be added.
+        *sequences: Sequences of reversible keys to generate the character.
+    """
+    lchar = char.lower()
+    for sequence in sequences:
+        lsequence = sequence.lower()
+        _compose_dict[sequence] = char
+        _compose_dict[lsequence] = lchar
+
+
+def init_combining(above: str, below: str, *accents: str) -> None:
+    """Add entries to the dictionary for combining characters.
+
+    Args:
+        above: Combining character above (empty if none to be added).
+        base: Combining character below (empty if none to be added).
+        *accents: Characters that follow `+` and `_` to create the combining characters.
+    """
+    for accent in accents:
+        if above:
+            _compose_dict["+" + accent] = above
+        if below:
+            _compose_dict["_" + accent] = below
+
+
+def init_greek_alphabet() -> None:
+    """Add entries to the dictionary for non-accented Greek alphabet letters.
+
+    Greek letter sequences are prefixed with `=` sign.
+    """
+    ualpha = ord("Α")
+    lalpha = ord("α")
+    for offset, base in enumerate("ABGDEZHQIKLMNXOPRJSTUFCYW"):
+        _compose_dict["=" + base] = chr(ualpha + offset)
+        _compose_dict["=" + base.lower()] = chr(lalpha + offset)
+
+
+def init_greek_accent(char: str, base: str, uiota: str = "") -> None:
+    """Add varia & oxia accented Greek letters to dictionary.
+
+    Greek letter sequences are prefixed with `=` sign.
+
+    Args:
+        char: Upper case version of character with varia to be added.
+            Next ordinal gives the character with oxia.
+        base: Upper case base English character to be accented.
+        uiota: Optional upper case version of character with iota subscript.
+            Prev & next ordinals give same with accents for lower case only.
+            Note there is no upper case with accent and iota, and not all
+            vowels have an iota version.
+    """
+    _compose_dict["=\\" + base] = _compose_dict["=`" + base] = char
+    _compose_dict["=/" + base] = _compose_dict["='" + base] = chr(ord(char) + 1)
+    lbase = base.lower()
+    lchar = char.lower()
+    _compose_dict["=\\" + lbase] = _compose_dict["=`" + lbase] = lchar
+    _compose_dict["=/" + lbase] = _compose_dict["='" + lbase] = chr(ord(lchar) + 1)
+    if not uiota:
+        return
+    _compose_dict["=|" + base] = uiota
+    liota = uiota.lower()
+    _compose_dict["=|" + lbase] = liota
+    _compose_dict["=\\|" + lbase] = _compose_dict["=`|" + lbase] = chr(ord(liota) - 1)
+    _compose_dict["=/|" + lbase] = _compose_dict["='|" + lbase] = chr(ord(liota) + 1)
+
+
+def init_greek_breathing(char: str, base: str, uiota: str = "") -> None:
+    """Add accented Greek letters including breathing to dictionary.
+
+    Greek letter sequences are prefixed with `=` sign.
+
+    Args:
+        char: Upper case char in middle group of 16, e.g. alpha with various accents.
+        base: Upper case base English character to be accented.
+        iota: Optional upper case verison with iota subscript if needed.
+    """
+    lbase = base.lower()
+    ord_list = (ord(char), ord(uiota)) if uiota else (ord(char),)
+    for char_ord in ord_list:
+        _compose_dict["=)" + base] = chr(char_ord)
+        _compose_dict["=(" + base] = chr(char_ord + 1)
+        _compose_dict["=(`" + base] = _compose_dict["=(\\" + base] = chr(char_ord + 2)
+        _compose_dict["=)`" + base] = _compose_dict["=)\\" + base] = chr(char_ord + 3)
+        _compose_dict["=('" + base] = _compose_dict["=(/" + base] = chr(char_ord + 4)
+        _compose_dict["=)'" + base] = _compose_dict["=)/" + base] = chr(char_ord + 5)
+        _compose_dict["=(^" + base] = _compose_dict["=(~" + base] = chr(char_ord + 6)
+        _compose_dict["=)^" + base] = _compose_dict["=)~" + base] = chr(char_ord + 7)
+        _compose_dict["=)" + lbase] = chr(char_ord - 8)
+        _compose_dict["=(" + lbase] = chr(char_ord - 7)
+        _compose_dict["=(`" + lbase] = _compose_dict["=(\\" + lbase] = chr(char_ord - 6)
+        _compose_dict["=)`" + lbase] = _compose_dict["=)\\" + lbase] = chr(char_ord - 5)
+        _compose_dict["=('" + lbase] = _compose_dict["=(/" + lbase] = chr(char_ord - 4)
+        _compose_dict["=)'" + lbase] = _compose_dict["=)/" + lbase] = chr(char_ord - 3)
+        _compose_dict["=(^" + lbase] = _compose_dict["=(~" + lbase] = chr(char_ord - 2)
+        _compose_dict["=)^" + lbase] = _compose_dict["=)~" + base] = chr(char_ord - 1)
+        # Add iota sequence character in case going round loop a second time
+        base = "|" + base
+        lbase = "|" + lbase
+
+
+class ComposeHelpDialog(ToplevelDialog):
+    """A dialog to show the compose sequences."""
+
+    def __init__(self) -> None:
+        """Initialize class members from page details."""
+        super().__init__("Compose Sequences")
+
+        self.column_headings = ("Character", "Sequence", "Name")
+        widths = (70, 70, 320)
+        self.help = ttk.Treeview(
+            self.top_frame,
+            columns=self.column_headings,
+            show="headings",
+            height=10,
+            selectmode=tk.NONE,
+        )
+        ToolTip(
+            self.help,
+            "Click to insert character",
+            use_pointer_pos=True,
+        )
+        for col, column in enumerate(self.column_headings):
+            self.help.column(
+                f"#{col + 1}",
+                minwidth=10,
+                width=widths[col],
+                stretch=False,
+                anchor=tk.W,
+            )
+            self.help.heading(
+                f"#{col + 1}",
+                text=column,
+                anchor=tk.W,
+            )
+        self.help.grid(row=0, column=0, sticky=tk.NSEW)
+
+        self.scrollbar = ttk.Scrollbar(
+            self.top_frame, orient=tk.VERTICAL, command=self.help.yview
+        )
+        self.help.configure(yscroll=self.scrollbar.set)  # type: ignore[call-overload]
+        self.scrollbar.grid(row=0, column=1, sticky=tk.NS)
+
+        mouse_bind(self.help, "1", self.insert_char)
+
+        init_compose_dict()
+        for sequence, char in sorted(_compose_dict.items(), key=lambda x: x[1]):
+            try:
+                entry = (char, sequence, unicodedata.name(char))
+            except ValueError:
+                continue  # Some Greek combinations don't exist
+            self.help.insert("", tk.END, values=entry)
+
+        children = self.help.get_children()
+        if children:
+            self.help.see(children[0])
+
+    def insert_char(self, event: tk.Event) -> None:
+        """Insert character corresponding to row clicked.
+
+        Args:
+            event: Event containing location of mouse click
+        """
+        row_id = self.help.identify_row(event.y)
+        row = self.help.set(row_id)
+        insert_in_focus_widget(row[self.column_headings[0]])

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -19,6 +19,7 @@ from guiguts.widgets import (
     insert_in_focus_widget,
     OkApplyCancelDialog,
     mouse_bind,
+    Combobox,
 )
 
 
@@ -171,15 +172,18 @@ class ComposeSequenceDialog(OkApplyCancelDialog):
         super().__init__("Compose Sequence", resize_x=False, resize_y=False)
         ttk.Label(self.top_frame, text="Compose: ").grid(column=0, row=0, sticky="NSEW")
         self.string = tk.StringVar()
-        entry = ttk.Entry(self.top_frame, textvariable=self.string, name="entry1")
-        entry.grid(column=1, row=0, sticky="NSEW")
+        self.entry = Combobox(
+            self.top_frame, PrefKey.COMPOSE_HISTORY, textvariable=self.string
+        )
+        # self.entry = ttk.Entry(self.top_frame, textvariable=self.string, name="entry1")
+        self.entry.grid(column=1, row=0, sticky="NSEW")
         # In tkinter, binding order is widget, class, toplevel, all
         # Swap first two, so that class binding has time to set textvariable
         # before the widget binding below is executed.
-        bindings = entry.bindtags()
-        entry.bindtags((bindings[1], bindings[0], bindings[2], bindings[3]))
-        entry.bind("<Key>", lambda _event: self.interpret_and_insert())
-        entry.focus()
+        bindings = self.entry.bindtags()
+        self.entry.bindtags((bindings[1], bindings[0], bindings[2], bindings[3]))
+        self.entry.bind("<Key>", lambda _event: self.interpret_and_insert())
+        self.entry.focus()
         init_compose_dict()
 
     def apply_changes(self) -> bool:
@@ -191,7 +195,7 @@ class ComposeSequenceDialog(OkApplyCancelDialog):
             Always returns True, meaning OK button (or Return key) will close dialog.
         """
         self.interpret_and_insert(force=True)
-        self.string.set("")
+        self.entry.select_range(0, tk.END)
         return True
 
     def interpret_and_insert(self, force: bool = False) -> None:
@@ -228,6 +232,7 @@ class ComposeSequenceDialog(OkApplyCancelDialog):
         if not char or not char.isprintable():
             return
         insert_in_focus_widget(char)
+        self.entry.add_to_history(self.string.get())
         if not force:
             self.destroy()
 

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -55,6 +55,7 @@ class PrefKey(StrEnum):
     PAGESEP_AUTO_TYPE = auto()
     THEME_NAME = auto()
     TEAROFF_MENUS = auto()
+    COMPOSE_HISTORY = auto()
 
 
 class Preferences:

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -251,17 +251,29 @@ class OkApplyCancelDialog(ToplevelDialog):
         button_frame.grid(row=1, column=0, sticky="NSEW")
         button_frame.columnconfigure(0, weight=1)
         ok_button = ttk.Button(
-            button_frame, text="OK", default="active", command=self.ok_pressed
+            button_frame,
+            text="OK",
+            default="active",
+            command=self.ok_pressed,
+            takefocus=False,
         )
         ok_button.grid(row=0, column=0)
         button_frame.columnconfigure(1, weight=1)
         apply_button = ttk.Button(
-            button_frame, text="Apply", default="normal", command=self.apply_changes
+            button_frame,
+            text="Apply",
+            default="normal",
+            command=self.apply_changes,
+            takefocus=False,
         )
         apply_button.grid(row=0, column=1)
         button_frame.columnconfigure(2, weight=1)
         cancel_button = ttk.Button(
-            button_frame, text="Cancel", default="normal", command=self.cancel_pressed
+            button_frame,
+            text="Cancel",
+            default="normal",
+            command=self.cancel_pressed,
+            takefocus=False,
         )
         cancel_button.grid(row=0, column=2)
         self.bind("<Return>", lambda event: self.ok_pressed())


### PR DESCRIPTION
This adds fractions, various other characters, quotes, super/subscript numbers, and Greek characters.

Also adds a Help-->Compose Sequences dialog, which lists all valid compose sequences, and allows the user to click on a letter in that help to insert it directly.