### PR TITLE
Preserve geometry of maximized main window

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -302,6 +302,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         preferences.set_default(PrefKey.SEARCHDIALOG_REGEX, False)
         preferences.set_default(PrefKey.DIALOG_GEOMETRY, {})
         preferences.set_default(PrefKey.ROOT_GEOMETRY, "800x400")
+        preferences.set_default(PrefKey.ROOT_GEOMETRY_STATE, "normal")
         preferences.set_default(PrefKey.DEFAULT_LANGUAGES, "en")
         preferences.set_default(PrefKey.WFDIALOG_SUSPECTS_ONLY, False)
         preferences.set_default(PrefKey.WFDIALOG_IGNORE_CASE, False)

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -41,6 +41,7 @@ class PrefKey(StrEnum):
     CHECKERDIALOG_SUSPECTS_ONLY = auto()
     DIALOG_GEOMETRY = auto()
     ROOT_GEOMETRY = auto()
+    ROOT_GEOMETRY_STATE = auto()
     DEFAULT_LANGUAGES = auto()
     JEEBIES_PARANOIA_LEVEL = auto()
     WRAP_LEFT_MARGIN = auto()

--- a/src/guiguts/root.py
+++ b/src/guiguts/root.py
@@ -27,6 +27,7 @@ class Root(tk.Tk):
 
         super().__init__(**kwargs)
         self.geometry(preferences.get(PrefKey.ROOT_GEOMETRY))
+        self.state(preferences.get(PrefKey.ROOT_GEOMETRY_STATE))
         self.option_add("*tearOff", preferences.get(PrefKey.TEAROFF_MENUS))
         self.rowconfigure(0, weight=1)
         self.columnconfigure(0, weight=1)
@@ -74,7 +75,13 @@ class Root(tk.Tk):
         root dialog creation and resizing. Only the first will actually
         do a save, because the flag will only be true on the first call."""
         if self.save_config:
-            preferences.set(PrefKey.ROOT_GEOMETRY, self.geometry())
+            # Bug in maximized geometry leads to size being full screen size,
+            # but top-left is non-maximized top left, i.e. mid-screen.
+            # So, if maximized, don't save geometry, just save "normal/zoomed" state.
+            # Then when de-maximize happens, you have the correct size AND top-left.
+            if self.state() != "zoomed":
+                preferences.set(PrefKey.ROOT_GEOMETRY, self.geometry())
+            preferences.set(PrefKey.ROOT_GEOMETRY_STATE, self.state())
 
 
 def root() -> Root:


### PR DESCRIPTION
There is a bug/limitation in how the geometry of the root window is reported when the window is maximized (at least on Windows). It reports that the window is the size of the full screen, but that the top left corner of the window is wherever it was before maximizing.

This means (like GG1) that when you quit and restart, GG2 starts with its top left somewhere on the screen, but the size is the full screen size, so some of the window vanishes off the bottom & right.

Fixed by also saving the "state" flag (which is normal or zoomed) and restoring that when the program is
restarted. Also, not saving the bad geometry (i.e. big window but not at top-left) reported after maximizing.

Fixes #302 