### PR TITLE
Wf bugs

### DIFF
--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -448,35 +448,19 @@ class WordFrequencyDialog(ToplevelDialog):
         """Display all the stored entries in the dialog according to
         the sort setting."""
 
-        def no_markup_key(word: str) -> tuple[str, ...]:
-            """Return additional sort keys to keep identical marked-up and non_marked-up phrases together."""
-            if preferences.get(PrefKey.WFDIALOG_DISPLAY_TYPE) == WFDisplayType.MARKEDUP:
-                no_markup = re.sub("<.*?>", "", word)
-                return (no_markup.lower(), no_markup)
-            return ()
-
         def sort_key_alpha(
             entry: WordFrequencyEntry,
         ) -> tuple[str, ...]:
             no_dia = DiacriticRemover.remove_diacritics(entry.word)
-            return no_markup_key(no_dia) + (no_dia.lower(), no_dia, entry.word)
+            return (no_dia.lower(), no_dia, entry.word)
 
         def sort_key_freq(entry: WordFrequencyEntry) -> tuple[int | str, ...]:
             no_dia = DiacriticRemover.remove_diacritics(entry.word)
-            return (
-                (-entry.frequency,)
-                + no_markup_key(no_dia)
-                + (no_dia.lower(), no_dia, entry.word)
-            )
+            return (-entry.frequency,) + (no_dia.lower(), no_dia, entry.word)
 
         def sort_key_len(entry: WordFrequencyEntry) -> tuple[int | str, ...]:
             no_dia = DiacriticRemover.remove_diacritics(entry.word)
-            no_markup = no_markup_key(no_dia)
-            if len(no_markup) == 0:
-                length = len(entry.word)
-            else:
-                length = len(no_markup[0])
-            return (-length,) + no_markup + (no_dia.lower(), no_dia, entry.word)
+            return (-len(entry.word), no_dia.lower(), no_dia, entry.word)
 
         key: Callable[[WordFrequencyEntry], tuple]
         match preferences.get(PrefKey.WFDIALOG_SORT_TYPE):
@@ -908,7 +892,7 @@ def wf_populate_markedup(wf_dialog: WordFrequencyDialog) -> None:
     wf_dialog.reset()
 
     marked_dict: WFDict = WFDict()
-    markup_types = "i|b|sc|f|g|u"
+    markup_types = "i|b|sc|f|g|u|cite|em|strong"
     matches = maintext().find_matches(
         rf"<({markup_types})>([^<]|\n)+</\1>",
         IndexRange(maintext().start(), maintext().end()),

--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -763,36 +763,44 @@ def wf_populate_hyphens(wf_dialog: WordFrequencyDialog) -> None:
         if "-" not in word:
             continue
         total_cnt += 1
-        if not preferences.get(PrefKey.WFDIALOG_SUSPECTS_ONLY):
-            wf_dialog.add_entry(word, freq)
-            word_output[word] = True
         # Check for suspects - given "w1-w2", then "w1w2", "w1 w2" and "w1--w2" are suspects.
         word_pair = re.sub(r"-\*?", " ", word)
+        nohyp_word = re.sub(r"-\*?", "", word)
+        twohyp_word = re.sub(r"-\*?", "--", word)
+        suspect = (
+            word_pair in word_pairs
+            or nohyp_word in all_words
+            or twohyp_word in emdash_words
+        )
+
+        if not preferences.get(PrefKey.WFDIALOG_SUSPECTS_ONLY):
+            wf_dialog.add_entry(word, freq, suspect=suspect)
+            word_output[word] = True
         if word_pair in word_pairs:
             if word not in word_output:
-                wf_dialog.add_entry(word, freq)
+                wf_dialog.add_entry(word, freq, suspect=suspect)
                 word_output[word] = True
             if word_pair not in word_output:
-                wf_dialog.add_entry(word_pair, word_pairs[word_pair], suspect=True)
+                wf_dialog.add_entry(word_pair, word_pairs[word_pair], suspect=suspect)
                 word_output[word_pair] = True
                 suspect_cnt += 1
         nohyp_word = re.sub(r"-\*?", "", word)
         if nohyp_word in all_words:
             if word not in word_output:
-                wf_dialog.add_entry(word, freq)
+                wf_dialog.add_entry(word, freq, suspect=suspect)
                 word_output[word] = True
             if nohyp_word not in word_output:
-                wf_dialog.add_entry(nohyp_word, all_words[nohyp_word], suspect=True)
+                wf_dialog.add_entry(nohyp_word, all_words[nohyp_word], suspect=suspect)
                 word_output[nohyp_word] = True
                 suspect_cnt += 1
         twohyp_word = re.sub(r"-\*?", "--", word)
         if twohyp_word in emdash_words:
             if word not in word_output:
-                wf_dialog.add_entry(word, freq)
+                wf_dialog.add_entry(word, freq, suspect=suspect)
                 word_output[word] = True
             if twohyp_word not in word_output:
                 wf_dialog.add_entry(
-                    twohyp_word, emdash_words[twohyp_word], suspect=True
+                    twohyp_word, emdash_words[twohyp_word], suspect=suspect
                 )
                 word_output[twohyp_word] = True
                 suspect_cnt += 1


### PR DESCRIPTION
Fix WF ligature bug
Although it was reporting the number of suspects
correctly, it was listing words that did not have a
ligature in the Suspects Only list, even when the
ligatured version didn't exist.

Fixes #303 

---

Make WF Ital/Bold include markup in alpha sort
GG1 includes the markup when doing alpha sort, but
the first GG2 attempt kept the marked and unmarked
words together by stripping markup.
This wasn't popular, so reverted to GG1 behavior.

Also add cite, em & strong to list of markups detected:
`i|b|sc|f|g|u|cite|em|strong`

Fixes #306 