### PR TITLE
Show image from page label config dialog

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -644,7 +644,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         the_statusbar.add(
             "img",
             tooltip="Click: Go to image",
-            update=lambda: "Img: " + self.file.get_current_image_name(),
+            update=lambda: "Img: " + maintext().get_current_image_name(),
         )
         the_statusbar.add_binding("img", "ButtonRelease-1", self.file.goto_image)
 

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -479,42 +479,6 @@ class File:
         """
         return maintext().page_mark_next("1.0") != ""
 
-    def get_current_page_mark(self) -> str:
-        """Find page mark corresponding to where the insert cursor is.
-
-        Returns:
-            Name of preceding mark. Empty string if none found.
-        """
-        insert = maintext().get_insert_index().index()
-        mark = insert
-        good_mark = ""
-        # First check for page marks at the current cursor position & return last one
-        while (mark := maintext().page_mark_next(mark)) and maintext().compare(
-            mark, "==", insert
-        ):
-            good_mark = mark
-        # If not, then find page mark before current position
-        if not good_mark:
-            if mark := maintext().page_mark_previous(insert):
-                good_mark = mark
-        # If not, then maybe we're before the first page mark, so search forward
-        if not good_mark:
-            if mark := maintext().page_mark_next(insert):
-                good_mark = mark
-        return good_mark
-
-    def get_current_image_name(self) -> str:
-        """Find basename of the image file corresponding to where the
-        insert cursor is.
-
-        Returns:
-            Basename of image file. Empty string if none found.
-        """
-        mark = self.get_current_page_mark()
-        if mark == "":
-            return ""
-        return img_from_page_mark(mark)
-
     def get_current_image_path(self) -> str:
         """Return the path of the image file for the page where the insert
         cursor is located.
@@ -523,7 +487,7 @@ class File:
             Name of the image file for the current page, or the empty string
             if unable to get image file name.
         """
-        basename = self.get_current_image_name()
+        basename = maintext().get_current_image_name()
         if self.image_dir and basename:
             basename += ".png"
             path = os.path.join(self.image_dir, basename)
@@ -543,7 +507,7 @@ class File:
         Returns:
             Page label of current page. Empty string if none found.
         """
-        img = self.get_current_image_name()
+        img = maintext().get_current_image_name()
         if img == "":
             return ""
         return self.page_details[img]["label"]
@@ -625,7 +589,7 @@ class File:
             direction: +1 to go to next page; -1 for previous page
         """
         insert = maintext().get_insert_index().index()
-        cur_page = self.get_current_image_name()
+        cur_page = maintext().get_current_image_name()
         mark = page_mark_from_img(cur_page) if cur_page else insert
         while mark := maintext().page_mark_next_previous(mark, direction):
             if maintext().compare(mark, "!=", insert):

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -16,6 +16,8 @@ from guiguts.maintext import (
     PAGEMARK_PIN,
     BOOKMARK_TAG,
     PAGEMARK_PREFIX,
+    img_from_page_mark,
+    page_mark_from_img,
 )
 from guiguts.page_details import (
     PageDetail,
@@ -859,33 +861,6 @@ class File:
     def remove_bookmark_tags(self) -> None:
         """Remove all bookmark highlightling."""
         maintext().tag_remove(BOOKMARK_TAG, "1.0", "end")
-
-
-def img_from_page_mark(mark: str) -> str:
-    """Get base image name from page mark, e.g. "Pg027" gives "027".
-
-    Args:
-        mark: String containing name of mark whose image is needed.
-          Does not check if mark is a page mark. If it is not, the
-          full string is returned.
-
-    Returns:
-        Image name.
-    """
-    return mark.removeprefix(PAGEMARK_PREFIX)
-
-
-def page_mark_from_img(img: str) -> str:
-    """Get page mark from base image name, e.g. "027" gives "Pg027".
-
-    Args:
-        img: Name of png img file whose mark is needed.
-          Does not check validity of png img file name.
-
-    Returns:
-        Page mark string.
-    """
-    return PAGEMARK_PREFIX + img
 
 
 def bin_name(basename: str) -> str:

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1741,6 +1741,33 @@ class MainText(tk.Text):
             self.delete(start, f"{start} lineend")
 
 
+def img_from_page_mark(mark: str) -> str:
+    """Get base image name from page mark, e.g. "Pg027" gives "027".
+
+    Args:
+        mark: String containing name of mark whose image is needed.
+          Does not check if mark is a page mark. If it is not, the
+          full string is returned.
+
+    Returns:
+        Image name.
+    """
+    return mark.removeprefix(PAGEMARK_PREFIX)
+
+
+def page_mark_from_img(img: str) -> str:
+    """Get page mark from base image name, e.g. "027" gives "Pg027".
+
+    Args:
+        img: Name of png img file whose mark is needed.
+          Does not check validity of png img file name.
+
+    Returns:
+        Page mark string.
+    """
+    return PAGEMARK_PREFIX + img
+
+
 class TclRegexCompileError(Exception):
     """Raise if Tcl fails to compile regex."""
 

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1740,6 +1740,40 @@ class MainText(tk.Text):
         while start := self.search(" +$", start, regexp=True):
             self.delete(start, f"{start} lineend")
 
+    def get_current_page_mark(self) -> str:
+        """Find page mark corresponding to where the insert cursor is.
+
+        Returns:
+            Name of preceding mark. Empty string if none found.
+        """
+        insert = self.get_insert_index().index()
+        mark = insert
+        good_mark = ""
+        # First check for page marks at the current cursor position & return last one
+        while (mark := self.page_mark_next(mark)) and self.compare(mark, "==", insert):
+            good_mark = mark
+        # If not, then find page mark before current position
+        if not good_mark:
+            if mark := self.page_mark_previous(insert):
+                good_mark = mark
+        # If not, then maybe we're before the first page mark, so search forward
+        if not good_mark:
+            if mark := self.page_mark_next(insert):
+                good_mark = mark
+        return good_mark
+
+    def get_current_image_name(self) -> str:
+        """Find basename of the image file corresponding to where the
+        insert cursor is.
+
+        Returns:
+            Basename of image file. Empty string if none found.
+        """
+        mark = self.get_current_page_mark()
+        if mark == "":
+            return ""
+        return img_from_page_mark(mark)
+
 
 def img_from_page_mark(mark: str) -> str:
     """Get base image name from page mark, e.g. "Pg027" gives "027".

--- a/src/guiguts/page_details.py
+++ b/src/guiguts/page_details.py
@@ -5,7 +5,7 @@ from tkinter import simpledialog, ttk
 
 import roman  # type: ignore[import-untyped]
 
-from guiguts.maintext import maintext
+from guiguts.maintext import maintext, page_mark_from_img
 from guiguts.widgets import OkApplyCancelDialog, mouse_bind, ToolTip
 
 STYLE_COLUMN = "#2"
@@ -189,12 +189,17 @@ class PageDetailsDialog(OkApplyCancelDialog):
             event: Event containing location of mouse click
             reverse: True to "advance" in reverse!
         """
+        row_id = self.list.identify_row(event.y)
+        row = self.list.set(row_id)
+
+        # Display the page
+        png = row[COL_HEAD_IMG]
+        index = maintext().rowcol(page_mark_from_img(png))
+        maintext().set_insert_index(index)
+
         col_id = self.list.identify_column(event.x)
         if col_id not in (STYLE_COLUMN, NUMBER_COLUMN):
             return
-
-        row_id = self.list.identify_row(event.y)
-        row = self.list.set(row_id)
 
         if col_id == STYLE_COLUMN:
             if COL_HEAD_STYLE not in row:

--- a/src/guiguts/page_details.py
+++ b/src/guiguts/page_details.py
@@ -149,6 +149,17 @@ class PageDetailsDialog(OkApplyCancelDialog):
         mouse_bind(
             self.list, "Shift+1", lambda event: self.item_clicked(event, reverse=True)
         )
+
+        def display_page(_event: tk.Event) -> None:
+            """Display the page for the selected row."""
+            try:
+                png = self.list.set(self.list.focus())[COL_HEAD_IMG]
+            except KeyError:
+                return
+            index = maintext().rowcol(page_mark_from_img(png))
+            maintext().set_insert_index(index, focus=False)
+
+        self.list.bind("<<TreeviewSelect>>", display_page)
         self.list.grid(row=0, column=0, sticky=tk.NSEW)
 
         self.scrollbar = ttk.Scrollbar(
@@ -191,11 +202,6 @@ class PageDetailsDialog(OkApplyCancelDialog):
         """
         row_id = self.list.identify_row(event.y)
         row = self.list.set(row_id)
-
-        # Display the page
-        png = row[COL_HEAD_IMG]
-        index = maintext().rowcol(page_mark_from_img(png))
-        maintext().set_insert_index(index)
 
         col_id = self.list.identify_column(event.x)
         if col_id not in (STYLE_COLUMN, NUMBER_COLUMN):

--- a/src/guiguts/page_details.py
+++ b/src/guiguts/page_details.py
@@ -170,6 +170,17 @@ class PageDetailsDialog(OkApplyCancelDialog):
 
         self.populate_list(self.details)
 
+        # Position list at current page
+        if cur_img := maintext().get_current_image_name():
+            children = self.list.get_children()
+            for idx, child in enumerate(children):
+                png = self.list.set(child)[COL_HEAD_IMG]
+                if png == cur_img:
+                    self.list.selection_set(child)
+                    # "see" puts item at top, so see the position a few earlier
+                    self.list.see(children[max(0, idx - 3)])
+                    break
+
     def populate_list(self, details: PageDetails, see_index: int = 0) -> None:
         """Populate the page details list from the given details.
 


### PR DESCRIPTION
When user clicks on a row in the dialog, jump to the page in the file, so user can see the text there to aid their decision about which type of page it is. If user has Auto Img turned on, the image will show in the image viewer.

Fixes #295