### PR TITLE
Fix maximize function on Mac

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -628,13 +628,12 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_view.add_button("~Hide Image", self.hide_image)
         menu_view.add_button("~Message Log", self.mainwindow.messagelog.show)
         menu_view.add_separator()
-        if not is_mac():    # Full Screen behaves oddly on Macs
-            menu_view.add_checkbox(
-                "~Full Screen",
-                lambda: root().wm_attributes("-fullscreen", True),
-                lambda: root().wm_attributes("-fullscreen", False),
-                root().full_screen_var,
-            )
+        menu_view.add_checkbox(
+            "~Full Screen",
+            lambda: root().wm_attributes("-fullscreen", True),
+            lambda: root().wm_attributes("-fullscreen", False),
+            root().full_screen_var,
+        )
 
     def init_help_menu(self) -> None:
         """Create the Help menu."""

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -222,6 +222,8 @@ class Guiguts:
                 filetitle = "..." + filetitle[len_title - max_width :]
             filetitle = " - " + filetitle
         root().title(f"Guiguts {version('guiguts')}" + modtitle + filetitle)
+        if is_mac():
+            root().wm_attributes("-modified", maintext().is_modified())
 
     def quit_program(self) -> None:
         """Exit the program."""

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -50,7 +50,7 @@ from guiguts.misc_tools import (
 )
 from guiguts.page_details import PageDetailsDialog
 from guiguts.preferences import preferences, PrefKey
-from guiguts.root import root
+from guiguts.root import root, RootWindowState
 from guiguts.search import show_search_dialog, find_next
 from guiguts.spell import spell_check
 from guiguts.tools.pptxt import pptxt
@@ -622,6 +622,13 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_view.add_button("~Show Image", self.show_image)
         menu_view.add_button("~Hide Image", self.hide_image)
         menu_view.add_button("~Message Log", self.mainwindow.messagelog.show)
+        menu_view.add_separator()
+        menu_view.add_checkbox(
+            "~Full Screen",
+            lambda: root().wm_attributes("-fullscreen", True),
+            lambda: root().wm_attributes("-fullscreen", False),
+            preferences.get(PrefKey.ROOT_GEOMETRY_STATE) == RootWindowState.FULLSCREEN,
+        )
 
     def init_help_menu(self) -> None:
         """Create the Help menu."""

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -50,7 +50,7 @@ from guiguts.misc_tools import (
 )
 from guiguts.page_details import PageDetailsDialog
 from guiguts.preferences import preferences, PrefKey
-from guiguts.root import root, RootWindowState
+from guiguts.root import root
 from guiguts.search import show_search_dialog, find_next
 from guiguts.spell import spell_check
 from guiguts.tools.pptxt import pptxt
@@ -109,6 +109,9 @@ class Guiguts:
         # Known tkinter issue - must call this before any dialogs can get created,
         # or focus will not return to maintext on Windows
         root().update_idletasks()
+
+        # After menus, etc., have been created, set the zoomed/fullscreen state
+        root().set_zoom_fullscreen()
 
         self.logging_add_gui()
         logger.info("GUI initialized")
@@ -629,7 +632,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             "~Full Screen",
             lambda: root().wm_attributes("-fullscreen", True),
             lambda: root().wm_attributes("-fullscreen", False),
-            preferences.get(PrefKey.ROOT_GEOMETRY_STATE) == RootWindowState.FULLSCREEN,
+            root().full_screen_var,
         )
 
     def init_help_menu(self) -> None:

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -628,12 +628,13 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_view.add_button("~Hide Image", self.hide_image)
         menu_view.add_button("~Message Log", self.mainwindow.messagelog.show)
         menu_view.add_separator()
-        menu_view.add_checkbox(
-            "~Full Screen",
-            lambda: root().wm_attributes("-fullscreen", True),
-            lambda: root().wm_attributes("-fullscreen", False),
-            root().full_screen_var,
-        )
+        if not is_mac():    # Full Screen behaves oddly on Macs
+            menu_view.add_checkbox(
+                "~Full Screen",
+                lambda: root().wm_attributes("-fullscreen", True),
+                lambda: root().wm_attributes("-fullscreen", False),
+                root().full_screen_var,
+            )
 
     def init_help_menu(self) -> None:
         """Create the Help menu."""

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -628,7 +628,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_view.add_button("~Hide Image", self.hide_image)
         menu_view.add_button("~Message Log", self.mainwindow.messagelog.show)
         menu_view.add_separator()
-        if not is_mac():  # Full Screen behaves oddly on Macs
+        if not is_mac():    # Full Screen behaves oddly on Macs
             menu_view.add_checkbox(
                 "~Full Screen",
                 lambda: root().wm_attributes("-fullscreen", True),

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -628,7 +628,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_view.add_button("~Hide Image", self.hide_image)
         menu_view.add_button("~Message Log", self.mainwindow.messagelog.show)
         menu_view.add_separator()
-        if not is_mac():    # Full Screen behaves oddly on Macs
+        if not is_mac():  # Full Screen behaves oddly on Macs
             menu_view.add_checkbox(
                 "~Full Screen",
                 lambda: root().wm_attributes("-fullscreen", True),

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -22,6 +22,7 @@ from guiguts.widgets import (
     theme_set_tk_widget_colors,
     themed_style,
     register_focus_widget,
+    grab_focus,
 )
 
 logger = logging.getLogger(__package__)
@@ -296,6 +297,9 @@ class MainText(tk.Text):
 
         # Need to wait until maintext has been registered to set the font preference
         preferences.set(PrefKey.TEXT_FONT_FAMILY, family)
+
+        # Force focus to maintext widget
+        self.after_idle(lambda: grab_focus(self.root, self, True))
 
     def bind_event(
         self,

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -120,7 +120,7 @@ class Menu(tk.Menu):
         label: str,
         handler_on: Callable[[], None],
         handler_off: Callable[[], None],
-        initial_var: bool,
+        bool_var: tk.BooleanVar,
         accel: str = "",
     ) -> None:
         """Add a button to the menu.
@@ -130,7 +130,7 @@ class Menu(tk.Menu):
               navigation, e.g. "~Save".
             handler_on: Callback function for when checkbox gets checked
             handler_off: Callback function for when checkbox gets checked
-            var: To keep track of state
+            bool_var: Tk variable to keep track of state or set it from elsewhere
             accel: String describing optional accelerator key, used when a
               callback function is passed in as ``handler``. Will be displayed
               on the button, and will be bound to the same action as the menu
@@ -139,8 +139,6 @@ class Menu(tk.Menu):
         """
         (label_tilde, label_txt) = process_label(label)
         (accel, key_event) = process_accel(accel)
-
-        bool_var = tk.BooleanVar(value=initial_var)
 
         # If key binding given, then bind it
         if accel:

--- a/src/guiguts/root.py
+++ b/src/guiguts/root.py
@@ -10,7 +10,7 @@ from types import TracebackType
 from typing import Any
 
 from guiguts.preferences import preferences, PrefKey
-from guiguts.utilities import is_x11, is_mac
+from guiguts.utilities import is_x11
 
 logger = logging.getLogger(__package__)
 
@@ -78,9 +78,6 @@ class Root(tk.Tk):
         By setting flag now, and queuing calls to _save_config,
         we ensure the flag will be true for the first call to
         _save_config when process becomes idle."""
-        # Full Screen behaves oddly on Macs, so if user tries, revert immediately
-        if is_mac() and root().wm_attributes("-fullscreen"):
-            root().wm_attributes("-fullscreen", False)
         self.save_config = True
         self.after_idle(self._save_config)
 

--- a/src/guiguts/root.py
+++ b/src/guiguts/root.py
@@ -1,5 +1,6 @@
 """Handle Tk root window"""
 
+
 from enum import StrEnum, auto
 import logging
 import traceback

--- a/src/guiguts/root.py
+++ b/src/guiguts/root.py
@@ -1,5 +1,7 @@
 """Handle Tk root window"""
 
+
+from enum import StrEnum, auto
 import logging
 import traceback
 import tkinter as tk
@@ -9,11 +11,20 @@ from typing import Any
 
 from guiguts.maintext import maintext
 from guiguts.preferences import preferences, PrefKey
+from guiguts.utilities import is_x11
 from guiguts.widgets import grab_focus
 
 logger = logging.getLogger(__package__)
 
 _the_root = None  # pylint: disable=invalid-name
+
+
+class RootWindowState(StrEnum):
+    """Enum class to store root window states."""
+
+    NORMAL = auto()
+    ZOOMED = auto()
+    FULLSCREEN = auto()
 
 
 class Root(tk.Tk):
@@ -26,7 +37,17 @@ class Root(tk.Tk):
 
         super().__init__(**kwargs)
         self.geometry(preferences.get(PrefKey.ROOT_GEOMETRY))
-        self.state(preferences.get(PrefKey.ROOT_GEOMETRY_STATE))
+
+        # Set zoomed/fullscreen state appropriately for platform
+        state = preferences.get(PrefKey.ROOT_GEOMETRY_STATE)
+        if state == RootWindowState.ZOOMED:
+            if is_x11():
+                root().wm_attributes("-zoomed", True)
+            else:
+                self.state("zoomed")
+        elif state == RootWindowState.FULLSCREEN:
+            self.wm_attributes("-fullscreen", True)
+
         self.option_add("*tearOff", preferences.get(PrefKey.TEAROFF_MENUS))
         self.rowconfigure(0, weight=1)
         self.columnconfigure(0, weight=1)
@@ -74,13 +95,18 @@ class Root(tk.Tk):
         root dialog creation and resizing. Only the first will actually
         do a save, because the flag will only be true on the first call."""
         if self.save_config:
-            # Bug in maximized geometry leads to size being full screen size,
-            # but top-left is non-maximized top left, i.e. mid-screen.
-            # So, if maximized, don't save geometry, just save "normal/zoomed" state.
-            # Then when de-maximize happens, you have the correct size AND top-left.
-            if self.state() != "zoomed":
+            zoomed = (
+                root().wm_attributes("-zoomed")
+                if is_x11()
+                else (self.state() == "zoomed")
+            )
+            state = RootWindowState.ZOOMED if zoomed else RootWindowState.NORMAL
+            if root().wm_attributes("-fullscreen"):
+                state = RootWindowState.FULLSCREEN
+            # Only save geometry if "normal". Then de-maximize should restore correct size and top-left.
+            if state == RootWindowState.NORMAL:
                 preferences.set(PrefKey.ROOT_GEOMETRY, self.geometry())
-            preferences.set(PrefKey.ROOT_GEOMETRY_STATE, self.state())
+            preferences.set(PrefKey.ROOT_GEOMETRY_STATE, state)
 
 
 def root() -> Root:

--- a/src/guiguts/root.py
+++ b/src/guiguts/root.py
@@ -38,15 +38,11 @@ class Root(tk.Tk):
         super().__init__(**kwargs)
         self.geometry(preferences.get(PrefKey.ROOT_GEOMETRY))
 
-        # Set zoomed/fullscreen state appropriately for platform
-        state = preferences.get(PrefKey.ROOT_GEOMETRY_STATE)
-        if state == RootWindowState.ZOOMED:
-            if is_x11():
-                root().wm_attributes("-zoomed", True)
-            else:
-                self.state("zoomed")
-        elif state == RootWindowState.FULLSCREEN:
-            self.wm_attributes("-fullscreen", True)
+        self.full_screen_var = tk.BooleanVar(
+            value=preferences.get(PrefKey.ROOT_GEOMETRY_STATE)
+            == RootWindowState.FULLSCREEN
+        )
+        self.allow_config_saves = False
 
         self.option_add("*tearOff", preferences.get(PrefKey.TEAROFF_MENUS))
         self.rowconfigure(0, weight=1)
@@ -93,20 +89,39 @@ class Root(tk.Tk):
 
         Several calls to this may be queued by config changes during
         root dialog creation and resizing. Only the first will actually
-        do a save, because the flag will only be true on the first call."""
-        if self.save_config:
+        do a save, because the flag will only be true on the first call.
+
+        Will do nothing until enabled via a call to set_zoom_fullscreen."""
+        if self.allow_config_saves and self.save_config:
             zoomed = (
                 root().wm_attributes("-zoomed")
                 if is_x11()
                 else (self.state() == "zoomed")
             )
             state = RootWindowState.ZOOMED if zoomed else RootWindowState.NORMAL
-            if root().wm_attributes("-fullscreen"):
+            fullscreen = root().wm_attributes("-fullscreen")
+            self.full_screen_var.set(fullscreen)
+            if fullscreen:
                 state = RootWindowState.FULLSCREEN
             # Only save geometry if "normal". Then de-maximize should restore correct size and top-left.
             if state == RootWindowState.NORMAL:
                 preferences.set(PrefKey.ROOT_GEOMETRY, self.geometry())
             preferences.set(PrefKey.ROOT_GEOMETRY_STATE, state)
+
+    def set_zoom_fullscreen(self) -> None:
+        """Set zoomed/fullscreen state appropriately for platform.
+
+        Also enable saving of config after this point, to avoid confusion as the window gets created.
+        """
+        state = preferences.get(PrefKey.ROOT_GEOMETRY_STATE)
+        if state == RootWindowState.ZOOMED:
+            if is_x11():
+                root().wm_attributes("-zoomed", True)
+            else:
+                self.state("zoomed")
+        elif state == RootWindowState.FULLSCREEN:
+            self.wm_attributes("-fullscreen", True)
+        self.allow_config_saves = True
 
 
 def root() -> Root:

--- a/src/guiguts/root.py
+++ b/src/guiguts/root.py
@@ -117,7 +117,13 @@ class Root(tk.Tk):
             else:
                 self.state("zoomed")
         elif state == RootWindowState.FULLSCREEN:
+            # Fullscreen doesn't work quite right on macOS without withdraw
+            # and deiconify. Doesn't seem to hurt other platforms to do this.
+            # This is also needed to avoid the problem of dialogs on Mac
+            # becoming fullscreen tabs (see widgets.py:ToplevelDialog)
+            self.wm_withdraw()
             self.wm_attributes("-fullscreen", True)
+            self.wm_deiconify()
         self.allow_config_saves = True
 
 

--- a/src/guiguts/root.py
+++ b/src/guiguts/root.py
@@ -1,6 +1,5 @@
 """Handle Tk root window"""
 
-
 from enum import StrEnum, auto
 import logging
 import traceback

--- a/src/guiguts/root.py
+++ b/src/guiguts/root.py
@@ -9,10 +9,8 @@ import tkinter as tk
 from types import TracebackType
 from typing import Any
 
-from guiguts.maintext import maintext
 from guiguts.preferences import preferences, PrefKey
 from guiguts.utilities import is_x11
-from guiguts.widgets import grab_focus
 
 logger = logging.getLogger(__package__)
 
@@ -47,7 +45,6 @@ class Root(tk.Tk):
         self.option_add("*tearOff", preferences.get(PrefKey.TEAROFF_MENUS))
         self.rowconfigure(0, weight=1)
         self.columnconfigure(0, weight=1)
-        self.after_idle(lambda: grab_focus(self, maintext(), True))
         self.set_tcl_word_characters()
         self.save_config = False
         self.bind("<Configure>", self._handle_config)

--- a/src/guiguts/root.py
+++ b/src/guiguts/root.py
@@ -10,7 +10,7 @@ from types import TracebackType
 from typing import Any
 
 from guiguts.preferences import preferences, PrefKey
-from guiguts.utilities import is_x11
+from guiguts.utilities import is_x11, is_mac
 
 logger = logging.getLogger(__package__)
 
@@ -78,6 +78,9 @@ class Root(tk.Tk):
         By setting flag now, and queuing calls to _save_config,
         we ensure the flag will be true for the first call to
         _save_config when process becomes idle."""
+        # Full Screen behaves oddly on Macs, so if user tries, revert immediately
+        if is_mac() and root().wm_attributes("-fullscreen"):
+            root().wm_attributes("-fullscreen", False)
         self.save_config = True
         self.after_idle(self._save_config)
 

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -7,6 +7,7 @@ from typing import Any, Optional, TypeVar, Callable
 import regex as re
 
 from guiguts.preferences import preferences, PrefKey
+from guiguts.root import root
 from guiguts.utilities import is_windows, is_mac, process_accel
 
 NUM_HISTORY = 10
@@ -60,7 +61,10 @@ class ToplevelDialog(tk.Toplevel):
         self.bind("<Configure>", self._handle_config)
 
         # Stop macOS making all dialogs full screen if the root window is
+        self.wm_withdraw()
         self.wm_attributes("-fullscreen", False)
+        self.wm_deiconify()
+        self.transient(root())
 
         self.tooltip_list: list[ToolTip] = []
         self.bind("<Destroy>", self.tidy_up)

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -59,6 +59,9 @@ class ToplevelDialog(tk.Toplevel):
         self.save_config = False
         self.bind("<Configure>", self._handle_config)
 
+        # Stop macOS making all dialogs full screen if the root window is
+        self.wm_attributes("-fullscreen", False)
+
         self.tooltip_list: list[ToolTip] = []
         self.bind("<Destroy>", self.tidy_up)
 


### PR DESCRIPTION
Improvements to make dialogs work properly on Mac. Since this is based on prior work of @windymilla it should also fix the Linux menu bar issues in #323.

I tested this on Linux, where it seems to work fine and just as you'd expect.

@windymilla if you would, please give it a try on Windows.

On Mac, it works with the following caveats:
- The dialogs are marked transient, but only when in fullscreen. So if you are in fullscreen and then open dialogs, they are always-on-top.
- This is better than the "tab of the main window" that was happening before, IMO, by far.
- If you open dialogs while not in fullscreen, they don't have the always-on-top behavior.
- One edge case I found: if you have dialogs already open, then go fullscreen, the main window is converted to a desktop of its own and the dialogs are left behind in the desktop where they already lived. On reflection I think this is actually the usual behavior when you fullscreen an app with multiple windows or with open dialogs. E.g., if you open the Safari browser, then open its preferences (which is a dialog), and then fullscreen the Safari window, the exact same thing will happen. So this is actually normal behavior on this platform.

Fixes #323 
Closes #325 

(Added close of 325 because this is rebased onto that branch already)