### PR TITLE
Add page label info to page marker flags

### DIFF
--- a/src/guiguts/page_details.py
+++ b/src/guiguts/page_details.py
@@ -251,7 +251,7 @@ class PageDetailsDialog(OkApplyCancelDialog):
                     "Set Number", "Enter page number", parent=self
                 )
                 new_value = pagenum if pagenum else value
-            self.details[row[COL_HEAD_IMG]]["number"] = new_value
+            self.details[row[COL_HEAD_IMG]]["number"] = str(new_value)
 
         # Refresh the list
         self.details.recalculate()


### PR DESCRIPTION
Add the info necessary to construct the labels when in GG1. Format is `[ImgNNN|Arabic|+1]`
"Arabic" can be "Roman"
"+1" can be "No Count" or a page number

This version must be used in conjunction with a version of GG1 that has the added info - it won't work with older versions of GG1, like 1.6.2.

[GG1 PR#1308](https://github.com/DistributedProofreaders/guiguts/pull/1308)