### PR TITLE
Fix flake8 error messages

### DIFF
--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -119,7 +119,7 @@ class FootnoteChecker:
             )
             if colon_match is None:
                 colon_pos = maintext().rowcol(
-                    f"{start.index()}+{beg_match.count+1}c wordend"
+                    f"{start.index()}+{beg_match.count + 1}c wordend"
                 )
             else:
                 colon_pos = colon_match.rowcol

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1404,7 +1404,7 @@ class MainText(tk.Text):
                         tidy_function()
                         next_line_rowcol = IndexRowCol(self.index(WRAP_NEXT_LINE_MARK))
                         logger.error(
-                            f"No closing markup found to match /{block_type} at line {next_line_rowcol.row-1}"
+                            f"No closing markup found to match /{block_type} at line {next_line_rowcol.row - 1}"
                         )
                         return
 
@@ -1484,7 +1484,7 @@ class MainText(tk.Text):
                     tidy_function()
                     next_line_rowcol = IndexRowCol(self.index(WRAP_NEXT_LINE_MARK))
                     logger.error(
-                        f"{match[1]} markup error at line {next_line_rowcol.row-1}"
+                        f"{match[1]} markup error at line {next_line_rowcol.row - 1}"
                     )
                     return
                 else:
@@ -1516,7 +1516,7 @@ class MainText(tk.Text):
                     tidy_function()
                     next_line_rowcol = IndexRowCol(self.index(WRAP_NEXT_LINE_MARK))
                     logger.error(
-                        f"Block quote markup error at line {next_line_rowcol.row-1}"
+                        f"Block quote markup error at line {next_line_rowcol.row - 1}"
                     )
                     return
             bq_depth += bq_depth_change

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -516,10 +516,10 @@ class PageSeparatorDialog(ToplevelDialog):
             if re.search(rf"^<{markup_type}>", markup_next):
                 maintext().delete(
                     f"{sep_range.end.index()}",
-                    f"{sep_range.end.index()} +{len_markup+2}c",
+                    f"{sep_range.end.index()} +{len_markup + 2}c",
                 )
                 maintext().delete(
-                    f"{sep_range.start.index()}-1l lineend -{len_markup+len_punc+3}c",
+                    f"{sep_range.start.index()}-1l lineend -{len_markup + len_punc + 3}c",
                     f"{sep_range.start.index()}-1l lineend -{len_punc}c",
                 )
 
@@ -1035,7 +1035,7 @@ def fraction_convert(conversion_type: FractionConvertType) -> None:
                 maintext().insert(match_index, new_frac)
                 maintext().delete(
                     f"{match_index}+{len(new_frac)}c",
-                    f"{match_index}+{len(new_frac)+len(gmatch[0])-offset}c",
+                    f"{match_index}+{len(new_frac) + len(gmatch[0]) - offset}c",
                 )
             else:
                 len_frac = len(base_frac) - offset


### PR DESCRIPTION
When using python 3.12, flake8 reports that some
arithmetic operators (inside braces inside formatted strings) do not have spaces around them.

It's correct - they didn't.