### PR TITLE
Improve scan directory handling

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -55,7 +55,7 @@ from guiguts.search import show_search_dialog, find_next
 from guiguts.spell import spell_check
 from guiguts.tools.pptxt import pptxt
 from guiguts.tools.jeebies import jeebies_check, JeebiesParanoiaLevel
-from guiguts.utilities import is_mac, is_windows
+from guiguts.utilities import is_mac, folder_dir_str
 from guiguts.widgets import themed_style, theme_name_internal_from_user
 from guiguts.word_frequency import word_frequency, WFDisplayType, WFSortType
 
@@ -405,7 +405,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             self.file.add_good_and_bad_words,
         )
         proj_menu.add_button(
-            f"Set ~Scan Image {'Folder' if is_windows() else 'Directory'}...",
+            f"Set ~Scan Image {folder_dir_str()}...",
             self.file.choose_image_dir,
         )
         proj_menu.add_button("~Add Page Marker Flags", self.file.add_page_flags)

--- a/src/guiguts/utilities.py
+++ b/src/guiguts/utilities.py
@@ -284,7 +284,7 @@ def folder_dir_str(lowercase: bool = False) -> str:
     Args:
         lowercase: If True, return lowercase version.
     """
-    fd_string = "Folder" if is_windows() else "Directory"
+    fd_string = "Directory" if is_x11() else "Folder"
     return fd_string.lower() if lowercase else fd_string
 
 


### PR DESCRIPTION
1. Use "Folder" on macOS, not "Directory" in menu buttons
2. Use `projectID0123456789abc_comments.html` file to extract project ID, and save it in the project json (bin) file.
3. When user turns on Auto Img or tries to load an image for the first time for that project, first look if there is a `pngs` subdir in the project dir. If not, is there a subdir `projectID0123456789abc_images`?

Fixes #328 