### PR TITLE
Don't add newline when rewrapping

### DIFF
--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -759,6 +759,7 @@ class File:
         Args:
             section_range: Range of text to be wrapped.
         """
+        maintext().selection_ranges_store_with_marks()
         maintext().undo_block_begin()
 
         # Dummy insert & delete, so that if user undoes the wrap, the insert
@@ -772,6 +773,7 @@ class File:
         maintext().rewrap_section(
             section_range, lambda: self.unpin_page_marks(mark_list)
         )
+        maintext().selection_ranges_restore_from_marks()
 
     def pin_page_marks(self) -> list[str]:
         """Pin the page marks to locations in the text, by inserting a special

--- a/src/guiguts/utilities.py
+++ b/src/guiguts/utilities.py
@@ -675,4 +675,7 @@ class TextWrapper:
         rewrapped_para = ""
         for line in to_lines:
             rewrapped_para = "".join((rewrapped_para, line))
+        # If input paragraph did not have a terminating newline, output shouldn't
+        if paragraph[-1] != "\n":
+            rewrapped_para = rewrapped_para.rstrip("\n")
         return rewrapped_para


### PR DESCRIPTION
If the paragraph input to the text wrapper didn't have a newline, then the output wrapped paragraph shouldn't have one either.

Fixes #347