### PR TITLE
Provide nesting control in some unmatched checks

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -364,6 +364,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             lambda *value: maintext().set_font(),
         )
         preferences.set_default(PrefKey.SPELL_THRESHOLD, 3)
+        preferences.set_default(PrefKey.UNMATCHED_NESTABLE, False)
 
         # Check all preferences have a default
         for pref_key in PrefKey:

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -63,6 +63,7 @@ class PrefKey(StrEnum):
     TEXT_FONT_FAMILY = auto()
     TEXT_FONT_SIZE = auto()
     SPELL_THRESHOLD = auto()
+    UNMATCHED_NESTABLE = auto()
 
 
 class Preferences:


### PR DESCRIPTION
For bracket and curly quote unmatched checks, there is now a checkbutton that allows the user to control
whether nesting is permitted, e.g.
`[Footnote: [**proofer note] text of footnote]`

User can change the setting and re-run.

Fixes #326