### PR TITLE
Show "Working" in checker dialogs

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -349,7 +349,7 @@ class CheckerDialog(ToplevelDialog):
         self.section_count = 0
         self.selected_text = ""
         self.selected_text_range = None
-        self.update_count_label()
+        self.update_count_label(working=True)
         if self.text.winfo_exists():
             self.text.delete("1.0", tk.END)
         for mark in maintext().mark_names():
@@ -540,9 +540,17 @@ class CheckerDialog(ToplevelDialog):
             self.showing_suspects_only() and entry.severity < CheckerEntrySeverity.ERROR
         )
 
-    def update_count_label(self) -> None:
-        """Update the label showing how many linked entries & suspects are in dialog."""
+    def update_count_label(self, working: bool = False) -> None:
+        """Update the label showing how many linked entries & suspects are in dialog.
+
+        Args:
+            working: If set to True, display a "Working..." label instead.
+        """
         if self.count_label.winfo_exists():
+            if working:
+                self.count_label["text"] = "Working..."
+                self.count_label.update()
+                return
             es = sing_plur(self.count_linked_entries, "Entry", "Entries")
             ss = (
                 f"({sing_plur(self.count_suspects, 'Suspect')})"

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -238,13 +238,6 @@ class CheckerDialog(ToplevelDialog):
         self.selected_text_range: Optional[IndexRange] = None
         self.reset()
 
-        def delete_dialog() -> None:
-            """Call its reset method, then destroy the dialog"""
-            self.reset()
-            self.destroy()
-
-        self.wm_protocol("WM_DELETE_WINDOW", delete_dialog)
-
     @classmethod
     def show_dialog(
         cls: type[TlDlg],

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -355,6 +355,7 @@ class CheckerDialog(ToplevelDialog):
         for mark in maintext().mark_names():
             if mark.startswith(self.get_mark_prefix()):
                 maintext().mark_unset(mark)
+        remove_spotlights()
 
     def new_section(self) -> None:
         """Start a new section in the dialog.

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -146,6 +146,7 @@ class ToplevelDialog(tk.Toplevel):
         for tooltip in self.tooltip_list:
             tooltip.destroy()
         self.tooltip_list = []
+        self.reset()
 
     def reset(self) -> None:
         """Reset the dialog.


### PR DESCRIPTION
Instead of showing "0 entries" when dialog is created or process is re-run, show "Working..." instead.