### PR TITLE
Check main window exists when closing checker

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -345,10 +345,11 @@ class CheckerDialog(ToplevelDialog):
         self.update_count_label(working=True)
         if self.text.winfo_exists():
             self.text.delete("1.0", tk.END)
-        for mark in maintext().mark_names():
-            if mark.startswith(self.get_mark_prefix()):
-                maintext().mark_unset(mark)
-        remove_spotlights()
+        if maintext().winfo_exists():
+            for mark in maintext().mark_names():
+                if mark.startswith(self.get_mark_prefix()):
+                    maintext().mark_unset(mark)
+            remove_spotlights()
 
     def new_section(self) -> None:
         """Start a new section in the dialog.


### PR DESCRIPTION
Checker dialog unsets marks and removes spotlights when it is destroyed. If the user closes the main window without closing the checker dialog first, then by the time the checker dialog is destroyed the main window no longer exists, so causes errors unsetting marks, etc. Check main window exists before tidying up.