### PR TITLE
Cursor position, selection and status bar

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -750,8 +750,18 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             preferences.set(PrefKey.ORDINAL_NAMES, force)
 
         def ordinal_str() -> str:
-            """Format ordinal of char at current insert index for statusbar."""
-            char = maintext().get(maintext().get_insert_index().index())
+            """Format ordinal of single selected char, or char at current insert
+            index for statusbar."""
+            # Get character - display nothing if more than one char selected
+            sel_ranges = maintext().selected_ranges()
+            if len(sel_ranges) == 0:
+                char = maintext().get(maintext().get_insert_index().index())
+            elif len(sel_ranges) == 1:
+                char = maintext().selected_text()
+                if len(char) != 1:
+                    return ""
+            else:
+                return ""
             # unicodedata.name fails to return name for "control" characters
             # but the only one we care about is line feed
             if preferences.get(PrefKey.ORDINAL_NAMES):

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1017,7 +1017,9 @@ class MainText(tk.Text):
         if not sel_ranges:
             return ""
         pos = sel_ranges[-1].end if end else sel_ranges[0].start
-        self.set_insert_index(pos)
+        # Use low-level calls to avoid "see" behavior of set_insert_index
+        self.mark_set(tk.INSERT, pos.index())
+        self.see(tk.INSERT)
         self.clear_selection()
         return "break"
 


### PR DESCRIPTION
1. When there is a selection, typical behavior from other apps if the user presses the left/right arrows is to deselect and position the cursor at the start/end of the selected range.
2. If exactly one character is selected, show that in the character name field in the status bar. If nothing selected, show the character after the cursor. Otherwise show nothing.

