### PR TITLE
Improve navigation in WF dialog

### DIFF
--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -27,6 +27,7 @@ from guiguts.utilities import (
     sound_bell,
     process_accel,
     cmd_ctrl_string,
+    is_mac,
 )
 from guiguts.widgets import (
     ToplevelDialog,
@@ -394,6 +395,13 @@ class WordFrequencyDialog(ToplevelDialog):
         self.text.bind("<Key>", self.goto_word_by_letter)
         self.text.bind("<Home>", lambda _e: self.goto_word(0))
         self.text.bind("<End>", lambda _e: self.goto_word(len(self.entries) - 1))
+        # Bind same keys as main window uses for top/bottom on Mac.
+        # Above bindings work already for Windows
+        if is_mac():
+            self.text.bind("<Command-Up>", lambda _e: self.goto_word(0))
+            self.text.bind(
+                "<Command-Down>", lambda _e: self.goto_word(len(self.entries) - 1)
+            )
         ToolTip(
             self.text,
             "\n".join(


### PR DESCRIPTION
1. Make focus default to list of words, except when user is typing in the threshold or regex field
2. Home & End keys go to first/last entries, like GG1
3. Arrows and Page Up/Down should scroll list
4. Typing a character jumps to the first word in the list that begins with that character, like GG1

Fixes #374