### PR TITLE
 Fix Jeebies "Check Level" radio button behaviour

### DIFF
--- a/src/guiguts/tools/jeebies.py
+++ b/src/guiguts/tools/jeebies.py
@@ -79,7 +79,6 @@ class JeebiesChecker:
         ttk.Radiobutton(
             frame,
             text="Paranoid",
-            command=jeebies_check,
             variable=self.paranoia_level,
             value=JeebiesParanoiaLevel.PARANOID,
             takefocus=False,
@@ -87,7 +86,6 @@ class JeebiesChecker:
         ttk.Radiobutton(
             frame,
             text="Normal",
-            command=jeebies_check,
             variable=self.paranoia_level,
             value=JeebiesParanoiaLevel.NORMAL,
             takefocus=False,
@@ -95,7 +93,6 @@ class JeebiesChecker:
         ttk.Radiobutton(
             frame,
             text="Tolerant",
-            command=jeebies_check,
             variable=self.paranoia_level,
             value=JeebiesParanoiaLevel.TOLERANT,
             takefocus=False,


### PR DESCRIPTION
Fixes issue #367. The "Check Level"
buttons no longer re-run Jeebies when
clicked. They just set the check level
and the user then clicks "Re-run" to
apply the Jeebies check at that level.