### PR TITLE
Use python regexes in Search/Replace

### DIFF
--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -661,7 +661,6 @@ class File:
             search_range,
             nocase=False,
             regexp=True,
-            wholeword=False,
             backwards=False,
         ):
             maintext().delete(
@@ -684,7 +683,6 @@ class File:
             search_range,
             nocase=False,
             regexp=True,
-            wholeword=False,
         )
         if not flag_matches:
             return False

--- a/src/guiguts/highlight.py
+++ b/src/guiguts/highlight.py
@@ -42,7 +42,6 @@ def highlight_selection(
     tag_name: str,
     nocase: bool = False,
     regexp: bool = False,
-    wholeword: bool = False,
 ) -> None:
     """Highlight matches in the current selection.
     Args:
@@ -51,16 +50,13 @@ def highlight_selection(
     Optional keyword args:
         nocase (default False): set True for case-insensitivity
         regexp (default False): whether to assume 's' is a regexp
-        wholeword (defalut False): whether to match only whole words
     """
 
     if not (ranges := maintext().selected_ranges()):
         return
 
     for _range in ranges:
-        matches = maintext().find_matches(
-            pat, _range, nocase=nocase, regexp=regexp, wholeword=wholeword
-        )
+        matches = maintext().find_matches(pat, _range, nocase=nocase, regexp=regexp)
         for match in matches:
             maintext().tag_add(
                 tag_name, match.rowcol.index(), match.rowcol.index() + "+1c"

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1347,7 +1347,8 @@ class MainText(tk.Text):
         wholeword: bool,
         backwards: bool,
     ) -> tuple[Optional[FindMatch], int]:
-        """Find last occurrence of regex in text range using slurped text.
+        """Find last occurrence of regex in text range using slurped text, and also
+        where it is in the slurp text.
 
         Args:
             search_string: Regex to be searched for.
@@ -1359,8 +1360,9 @@ class MainText(tk.Text):
             backwards: True to search backwards from the end, i.e. find last occurrence.
 
         Returns:
-            FindMatch containing index in file of start and count of characters in match.
-            None if no match.
+            Tuple: a FindMatch containing index in file of start and count of characters in match,
+            and None if no match; also the index into the slurp text of the match start, which is
+            needed for iterated use with the same slurp text, such as Replace All
         """
         if not regexp:
             search_string = re.escape(search_string)

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -14,8 +14,6 @@ from guiguts.utilities import (
     is_mac,
     IndexRowCol,
     IndexRange,
-    force_tcl_wholeword,
-    convert_to_tcl_regex,
     TextWrapper,
 )
 from guiguts.widgets import (
@@ -1156,10 +1154,9 @@ class MainText(tk.Text):
     def find_match(
         self,
         search_string: str,
-        start_range: IndexRowCol | IndexRange,
+        start_range: IndexRange,
         nocase: bool = False,
         regexp: bool = False,
-        wholeword: bool = False,
         backwards: bool = False,
     ) -> Optional[FindMatch]:
         """Find occurrence of string/regex in given range.
@@ -1168,26 +1165,16 @@ class MainText(tk.Text):
             search_string: String/regex to be searched for.
             start_range: Range in which to search, or just start point to search whole file.
             nocase: True to ignore case.
-            regexp: True if string is a regex; False for exact string match.
-            wholeword: True to only search for whole words (i.e. word boundary at start & end).
+            regexp: True if string is a *Tcl* regex; False for exact string match.
             backwards: True to search backwards through text.
 
         Returns:
             FindMatch containing index of start and count of characters in match.
             None if no match.
         """
-        if isinstance(start_range, IndexRowCol):
-            start_index = start_range.index()
-            stop_index = ""
-        else:
-            assert isinstance(start_range, IndexRange)
-            start_index = start_range.start.index()
-            stop_index = start_range.end.index()
+        start_index = start_range.start.index()
+        stop_index = start_range.end.index()
 
-        if regexp:
-            search_string = convert_to_tcl_regex(search_string)
-        if wholeword:
-            search_string, regexp = force_tcl_wholeword(search_string, regexp)
         count_var = tk.IntVar()
         try:
             match_start = self.search(
@@ -1214,7 +1201,6 @@ class MainText(tk.Text):
         text_range: IndexRange,
         nocase: bool,
         regexp: bool,
-        wholeword: bool,
     ) -> list[FindMatch]:
         """Find all occurrences of string/regex in given range.
 
@@ -1222,8 +1208,7 @@ class MainText(tk.Text):
             search_string: String/regex to be searched for.
             text_range: Range in which to search.
             nocase: True to ignore case.
-            regexp: True if string is a regex; False for exact string match.
-            wholeword: True to only search for whole words (i.e. word boundary at start & end).
+            regexp: True if string is a *Tcl* regex; False for exact string match.
 
         Returns:
             List of FindMatch objects, each containing index of start and count of characters in a match.
@@ -1231,10 +1216,6 @@ class MainText(tk.Text):
         """
         start_index = text_range.start.index()
         stop_index = text_range.end.index()
-        if regexp:
-            search_string = convert_to_tcl_regex(search_string)
-        if wholeword:
-            search_string, regexp = force_tcl_wholeword(search_string, regexp)
 
         matches = []
         count_var = tk.IntVar()

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -498,7 +498,6 @@ class PageSeparatorDialog(ToplevelDialog):
             IndexRange(maintext().start(), maintext().end()),
             nocase=False,
             regexp=True,
-            wholeword=False,
             backwards=False,
         )
         if match is None:

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -631,10 +631,14 @@ def get_regex_replacement(
         Replacement string.
     """
     flags = 0 if preferences.get(PrefKey.SEARCHDIALOG_MATCH_CASE) else re.IGNORECASE
-    replace_regex = re.sub(r"^\(\?<=.*?\)", "", replace_regex)
-    print(replace_regex, flush=True)
-    # $searchterm =~ s/\Q(?<=\E.*?\)//;
-    # $searchterm =~ s/\Q(?=\E.*?\)//;
+
+    # Since below we do a sub on the match text, rather than the whole text, we need
+    # to handle start/end word boundaries and look-behind/ahead by removing them.
+    # At some point the sub will be done manually, handing groups, execution of
+    # python code, etc., like in GG1. At that point, these fixes can probably go.
+    search_regex = re.sub(r"^\(\?<=.*?\)", "", search_regex)
+    search_regex = re.sub(r"\(\?=.*?\)$", "", search_regex)
+    search_regex = search_regex.removeprefix(r"\b").removesuffix(r"\b")
 
     return re.sub(search_regex, replace_regex, match_text, flags=flags)
 

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -444,6 +444,7 @@ class SearchDialog(ToplevelDialog):
 
         replace_range, range_name = get_search_range()
 
+        regexp = preferences.get(PrefKey.SEARCHDIALOG_REGEX)
         if replace_range:
             replace_match = replace_string
             count = 0
@@ -452,19 +453,27 @@ class SearchDialog(ToplevelDialog):
             maintext().mark_set(MARK_END_RANGE, replace_range.end.index())
             maintext().undo_block_begin()
             while True:
-                try:
-                    match = maintext().find_match(
+                if regexp:
+                    match = maintext().find_match_regex_range(
                         search_string,
                         replace_range,
                         nocase=not preferences.get(PrefKey.SEARCHDIALOG_MATCH_CASE),
-                        regexp=preferences.get(PrefKey.SEARCHDIALOG_REGEX),
                         wholeword=preferences.get(PrefKey.SEARCHDIALOG_WHOLE_WORD),
-                        backwards=False,
                     )
-                except TclRegexCompileError as exc:
-                    self.display_message(str(exc))
-                    sound_bell()
-                    return
+                else:
+                    try:
+                        match = maintext().find_match(
+                            search_string,
+                            replace_range,
+                            nocase=not preferences.get(PrefKey.SEARCHDIALOG_MATCH_CASE),
+                            regexp=regexp,
+                            wholeword=preferences.get(PrefKey.SEARCHDIALOG_WHOLE_WORD),
+                            backwards=False,
+                        )
+                    except TclRegexCompileError as exc:
+                        self.display_message(str(exc))
+                        sound_bell()
+                        return
 
                 if not match:
                     break

--- a/src/guiguts/utilities.py
+++ b/src/guiguts/utilities.py
@@ -293,38 +293,6 @@ def cmd_ctrl_string() -> str:
     return "Command" if is_mac() else "Control"
 
 
-def force_tcl_wholeword(string: str, regex: bool) -> tuple[str, bool]:
-    """Change string to only match whole word(s) by converting to
-    a regex (if not already), then prepending and appending Tcl-style
-    word boundary flags.
-
-    Args:
-        string: String to be converted to a match wholeword regex.
-        regex: True if string is already a regex.
-
-    Returns:
-        Tuple containing converted string and new regex flag value (always True)
-    """
-    if not regex:
-        string = re.escape(string)
-    return r"\y" + string + r"\y", True
-
-
-def convert_to_tcl_regex(regex: str) -> str:
-    """Convert regex to a Tcl-style regex.
-
-    Currently, only converts backslash-b to backslash-y.
-    Does not convert backslash-backslash-b.
-
-    Args:
-        regex: The regex to be converted
-
-    Returns:
-        Converted regex.
-    """
-    return re.sub(r"(?<!\\)\\b", r"\\y", regex)
-
-
 class DiacriticRemover:
     """Supports removal of diacritics from strings."""
 

--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -574,28 +574,25 @@ class WordFrequencyDialog(ToplevelDialog):
         ) == WFDisplayType.MARKEDUP and not word.startswith("<"):
             regexp = True
             match_word = r"(^|[^>\w])" + re.escape(newline_word) + r"($|[^<\w])"
-            wholeword = False
         elif (
             preferences.get(PrefKey.WFDIALOG_DISPLAY_TYPE) == WFDisplayType.CHAR_COUNTS
         ):
             regexp = False
             match_word = newline_word
-            wholeword = False
         elif self.whole_word_search(word):
-            regexp = False
-            match_word = newline_word
-            wholeword = True
+            regexp = True
+            match_word = (
+                rf"\y{re.escape(newline_word)}\y"  # Tcl regex: \y is word boundary
+            )
         else:  # Word begins/ends with non-word char - do manual whole-word
             regexp = True
             match_word = r"(^|\W)" + re.escape(newline_word) + r"($|\W)"
-            wholeword = False
 
         match = maintext().find_match(
             match_word,
             IndexRange(start, maintext().end()),
             nocase=preferences.get(PrefKey.WFDIALOG_IGNORE_CASE),
             regexp=regexp,
-            wholeword=wholeword,
             backwards=False,
         )
         if match is None:
@@ -918,7 +915,6 @@ def wf_populate_markedup(wf_dialog: WordFrequencyDialog) -> None:
         IndexRange(maintext().start(), maintext().end()),
         nocase=preferences.get(PrefKey.WFDIALOG_IGNORE_CASE),
         regexp=True,
-        wholeword=False,
     )
     for match in matches:
         marked_phrase = maintext().get_match_text(match)
@@ -952,7 +948,6 @@ def wf_populate_markedup(wf_dialog: WordFrequencyDialog) -> None:
                 IndexRange(maintext().start(), maintext().end()),
                 nocase=preferences.get(PrefKey.WFDIALOG_IGNORE_CASE),
                 regexp=True,
-                wholeword=False,
             )
             unmarked_count[unmarked_phrase] = len(matches)
             if unmarked_count[unmarked_phrase] > 0:


### PR DESCRIPTION
To avoid bugs and limitations in Tcl regexes, slurp the relevant part of the file into a python string and do the searches there before converting the match locations back into line/col format as needed.

Also fix bug in Replace where word boundaries, and look-ahead caused Replace to do nothing even though the match had been found.

This affects, Search, Replace, Search & Replace, Count, Find All and Replace All.
Could potentially affect WF, where you click a word and it takes you to the location in the file.

Fixes #266 
Fixes #297 
