### PR TITLE
Regex bugs

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1382,7 +1382,7 @@ class MainText(tk.Text):
         wholeword: bool,
         backwards: bool,
     ) -> tuple[Optional[FindMatch], int]:
-        """Find last occurrence of regex in text range using slurped text, and also
+        """Find occurrence of regex in text range using slurped text, and also
         where it is in the slurp text.
 
         Args:

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1350,6 +1350,7 @@ class MainText(tk.Text):
             chunk_range = IndexRange(start_point, self.end())
             backrefs = False
         slurp_text = self.get(chunk_range.start.index(), chunk_range.end.index())
+
         # Searching backwards with backrefs/lookarounds doesn't behave as required, so
         # call special routine to use forward searching to search backward
         if backrefs:
@@ -1464,7 +1465,11 @@ class MainText(tk.Text):
             and None if no match; also the index into the slurp text of the match start, which is
             needed for iterated use with the same slurp text, such as Replace All
         """
-        if not regexp:
+        if regexp:
+            # Since "^" matches start of string (when not escaped with "\"), and we want it
+            # to match start of line, replace it with lookbehind for newline.
+            search_string = re.sub(r"(?<![\[\\])\^", r"(?<=\\n)", search_string)
+        else:
             search_string = re.escape(search_string)
         if wholeword:
             search_string = r"\b" + search_string + r"\b"
@@ -1472,7 +1477,7 @@ class MainText(tk.Text):
             search_string = "(?r)" + search_string
         if nocase:
             search_string = "(?i)" + search_string
-        search_string = "(?m)" + search_string
+        # search_string = "(?m)" + search_string
 
         match = re.search(search_string, slurp_text)
         if match is None:

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -432,10 +432,10 @@ class SearchDialog(ToplevelDialog):
             focus=False,
         )
         maintext().mark_unset(MARK_FOUND_START, MARK_FOUND_END)
+        maintext().clear_selection()
         if search_again:
             find_next(backwards=backwards)
         self.display_message()
-        maintext().clear_selection()
         return "break"
 
     def replaceall_clicked(self) -> None:

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -14,8 +14,6 @@ from guiguts.utilities import (
     sound_bell,
     IndexRowCol,
     IndexRange,
-    process_accel,
-    is_mac,
     sing_plur,
 )
 from guiguts.widgets import (
@@ -198,22 +196,6 @@ class SearchDialog(ToplevelDialog):
         # Message (e.g. count)
         self.message = ttk.Label(message_frame)
         self.message.grid(row=0, column=0, sticky="NSW")
-
-        # Bindings for when focus is in Search dialog
-        if is_mac():
-            _, event = process_accel("Cmd+G")
-            self.bind(event, lambda *args: find_next())
-            _, event = process_accel("Cmd+g")
-            self.bind(event, lambda *args: find_next())
-            _, event = process_accel("Cmd+Shift+G")
-            self.bind(event, lambda *args: find_next(backwards=True))
-            _, event = process_accel("Cmd+Shift+g")
-            self.bind(event, lambda *args: find_next(backwards=True))
-        else:
-            _, event = process_accel("F3")
-            self.bind(event, lambda *args: find_next())
-            _, event = process_accel("Shift+F3")
-            self.bind(event, lambda *args: find_next(backwards=True))
 
         # Now dialog geometry is set up, set width to user pref, leaving height as it is
         self.config_width()


### PR DESCRIPTION
1. Highlight next match correctly when using Replace & Search
2. Count regexes with backreferences (or lookarounds) correctly
3. Replace All with backreferences (or lookarounds) correctly
4. Search backward for regexes with backreferences (or lookarounds)  correctly

Fixes #395
Fixes #396 
Fixes #398 