### PR TITLE
Add Unicode Blocks dialog

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -35,6 +35,7 @@ from guiguts.misc_dialogs import (
     PreferencesDialog,
     ComposeSequenceDialog,
     ComposeHelpDialog,
+    UnicodeBlockDialog,
 )
 from guiguts.misc_tools import (
     basic_fixup_check,
@@ -374,6 +375,9 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         )
         preferences.set_default(PrefKey.SPELL_THRESHOLD, 3)
         preferences.set_default(PrefKey.UNMATCHED_NESTABLE, False)
+        preferences.set_default(
+            PrefKey.UNICODE_BLOCK, UnicodeBlockDialog.commonly_used_characters_name
+        )
 
         # Check all preferences have a default
         for pref_key in PrefKey:
@@ -605,6 +609,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             lambda: fraction_convert(FractionConvertType.SUPSUB),
         )
         unicode_menu = Menu(menu_tools, "~Unicode")
+        unicode_menu.add_button("Unicode ~Blocks", UnicodeBlockDialog.show_dialog)
         unicode_menu.add_button(
             "~Normalize Selected Characters",
             unicode_normalize,

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -681,7 +681,7 @@ class UnicodeBlockDialog(ToplevelDialog):
         self.top_frame.rowconfigure(1, weight=1)
         self.chars_frame = ttk.Frame(self.top_frame, padding=10)
         self.chars_frame.grid(column=0, row=1, sticky="NSEW")
-        self.button_list: list[ttk.Button] = []
+        self.button_list: list[ttk.Label] = []
         style = ttk.Style()
         style.configure("unicodedialog.TButton", font=maintext().font)
         self.block_selected()
@@ -700,14 +700,18 @@ class UnicodeBlockDialog(ToplevelDialog):
                 count: Count of buttons added, used to determine row/column.
                 char: Character to use as label for button.
             """
-            btn = ttk.Button(
+            btn = ttk.Label(
                 self.chars_frame,
                 text=char,
-                command=lambda: insert_in_focus_widget(char),
+                # command=lambda: insert_in_focus_widget(char),
                 width=2,
+                borderwidth=2,
+                relief=tk.RAISED,
+                justify=tk.CENTER,
                 style="unicodedialog.TButton",
             )
-            pady = 5 if is_mac() else 0
+            btn.bind("<ButtonRelease-1>", lambda _e: insert_in_focus_widget(char))
+            pady = 0  # 5 if is_mac() else 0
             btn.grid(column=count % 16, row=int(count / 16), sticky="NW", ipady=pady)
             self.button_list.append(btn)
 

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -706,13 +706,31 @@ class UnicodeBlockDialog(ToplevelDialog):
                 # command=lambda: insert_in_focus_widget(char),
                 width=2,
                 borderwidth=2,
-                relief=tk.RAISED,
-                justify=tk.CENTER,
+                relief=tk.FLAT,
+                anchor=tk.CENTER,
                 style="unicodedialog.TButton",
             )
-            btn.bind("<ButtonRelease-1>", lambda _e: insert_in_focus_widget(char))
-            pady = 0  # 5 if is_mac() else 0
-            btn.grid(column=count % 16, row=int(count / 16), sticky="NW", ipady=pady)
+
+            def press(event: tk.Event) -> None:
+                event.widget["relief"] = tk.SUNKEN
+
+            def release(event: tk.Event, char: str) -> None:
+                event.widget["relief"] = tk.RAISED
+                insert_in_focus_widget(char)
+
+            def enter(event: tk.Event) -> None:
+                event.widget["relief"] = tk.RAISED
+
+            def leave(event: tk.Event) -> None:
+                relief = str(event.widget["relief"])
+                if relief == tk.RAISED:
+                    event.widget["relief"] = tk.FLAT
+
+            btn.bind("<ButtonPress-1>", press)
+            btn.bind("<ButtonRelease-1>", lambda e: release(e, char))
+            btn.bind("<Enter>", enter)
+            btn.bind("<Leave>", leave)
+            btn.grid(column=count % 16, row=int(count / 16), sticky="NSEW")
             self.button_list.append(btn)
 
         block_name = preferences.get(PrefKey.UNICODE_BLOCK)
@@ -723,9 +741,7 @@ class UnicodeBlockDialog(ToplevelDialog):
             block_range = _unicode_blocks[block_name]
             for count, c_ord in enumerate(range(block_range[0], block_range[1] + 1)):
                 add_button(count, chr(c_ord))
-        # Add tooltips after creating all buttons: that way buttons appear and there's a
-        # pause before the dialog is ready. If tooltips are added in the above loop
-        # the buttons appear with a pause between each one.
+        # Add tooltips
         for btn in self.button_list:
             char = btn["text"]
             try:

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -704,10 +704,11 @@ class UnicodeBlockDialog(ToplevelDialog):
                 self.chars_frame,
                 text=char,
                 command=lambda: insert_in_focus_widget(char),
-                width=1,
+                width=2,
                 style="unicodedialog.TButton",
             )
-            btn.grid(column=count % 16, row=int(count / 16), sticky="NW")
+            pady = 5 if is_mac() else 0
+            btn.grid(column=count % 16, row=int(count / 16), sticky="NW", ipady=pady)
             self.button_list.append(btn)
 
         block_name = preferences.get(PrefKey.UNICODE_BLOCK)
@@ -726,7 +727,7 @@ class UnicodeBlockDialog(ToplevelDialog):
             try:
                 ToolTip(btn, f"U+{ord(char):04x}: {unicodedata.name(char)}")
             except ValueError:
-                pass
+                ToolTip(btn, f"U+{ord(char):04x}")
 
 
 # Somewhat arbitrarily, certain Unicode blocks are not displayed, trying to

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -683,7 +683,7 @@ class UnicodeBlockDialog(ToplevelDialog):
         self.chars_frame.grid(column=0, row=1, sticky="NSEW")
         self.button_list: list[ttk.Label] = []
         style = ttk.Style()
-        style.configure("unicodedialog.TButton", font=maintext().font)
+        style.configure("unicodedialog.TLabel", font=maintext().font)
         self.block_selected()
 
     def block_selected(self) -> None:
@@ -708,7 +708,7 @@ class UnicodeBlockDialog(ToplevelDialog):
                 borderwidth=2,
                 relief=tk.FLAT,
                 anchor=tk.CENTER,
-                style="unicodedialog.TButton",
+                style="unicodedialog.TLabel",
             )
 
             def press(event: tk.Event) -> None:

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -65,6 +65,7 @@ class PrefKey(StrEnum):
     TEXT_FONT_SIZE = auto()
     SPELL_THRESHOLD = auto()
     UNMATCHED_NESTABLE = auto()
+    UNICODE_BLOCK = auto()
 
 
 class Preferences:

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -391,8 +391,10 @@ class Combobox(ttk.Combobox):
             self.set("")
 
 
-class ToolTip(tk.Toplevel):
-    """Create a tooltip for a widget."""
+class ToolTip:
+    """Create a tooltip for a widget.
+
+    Actual tooltip Toplevel window isn't created until it's needed."""
 
     def __init__(
         self,
@@ -413,42 +415,55 @@ class ToolTip(tk.Toplevel):
             self.widget_tl.register_tooltip(self)  # type: ignore[union-attr]
         self.use_pointer_pos = use_pointer_pos
 
-        tk.Toplevel.__init__(self)
-        self.overrideredirect(True)
-        # Make tooltip transparent initially, in case it appears briefly on startup
-        self.wm_attributes("-alpha", 0.0)
-        # Move it off screen too - belt & suspenders - "alpha" not necessarily supported
-        self.geometry("+-1000+-1000")
-
         self.delay = 0.5
         self.inside = False
-        frame = ttk.Frame(self, borderwidth=1, relief=tk.SOLID)
-        frame.grid(padx=1, pady=1)
-        ttk.Label(frame, text=msg).grid()
+        self.msg = msg
+        self.width = self.height = 0
+        self.tooltip_window: Optional[tk.Toplevel] = None
         self.enter_bind = self.widget.bind("<Enter>", self.on_enter, add="+")
         self.leave_bind = self.widget.bind("<Leave>", self.on_leave, add="+")
         self.press_bind = self.widget.bind("<ButtonRelease>", self.on_leave, add="+")
-        self.update_idletasks()
-        self.width = self.winfo_width()
-        self.height = self.winfo_height()
+
+    def _create_tooltip(self) -> None:
+        """Actually create the toolip if it doesn't exist"""
+        if self.tooltip_window is not None:
+            return
+        self.tooltip_window = tk.Toplevel()
+        self.tooltip_window.overrideredirect(True)
+        # Make tooltip transparent initially, in case it appears briefly on startup
+        self.tooltip_window.wm_attributes("-alpha", 0.0)
+        # Move it off screen too - belt & suspenders - "alpha" not necessarily supported
+        self.tooltip_window.geometry("+-1000+-1000")
+        frame = ttk.Frame(self.tooltip_window, borderwidth=1, relief=tk.SOLID)
+        frame.grid(padx=1, pady=1)
+        ttk.Label(frame, text=self.msg).grid()
+        self.tooltip_window.update_idletasks()
+        self.width = self.tooltip_window.winfo_width()
+        self.height = self.tooltip_window.winfo_height()
         # Hide tooltip then make non-transparent for later use
-        self.withdraw()
-        self.wm_attributes("-alpha", 1.0)
+        self.tooltip_window.withdraw()
+        self.tooltip_window.wm_attributes("-alpha", 1.0)
 
     def on_enter(self, _event: tk.Event) -> None:
         """When mouse enters widget, prepare to show tooltip"""
+        self._create_tooltip()
+        assert self.tooltip_window is not None
         self.inside = True
-        self.after(int(self.delay * 1000), self._show)
+        self.tooltip_window.after(int(self.delay * 1000), self._show)
 
     def on_leave(self, _event: tk.Event | None = None) -> None:
         """Hides tooltip when mouse leaves, or button pressed."""
+        self._create_tooltip()
+        assert self.tooltip_window is not None
         self.inside = False
-        self.withdraw()
+        self.tooltip_window.withdraw()
 
     def _show(self) -> None:
         """Displays the ToolTip if mouse still inside."""
         if not (self.inside and self.widget.winfo_exists()):
             return
+        self._create_tooltip()
+        assert self.tooltip_window is not None
         if self.use_pointer_pos:
             x_pos = self.widget.winfo_pointerx() + 20
             y_pos = self.widget.winfo_pointery() + 10
@@ -476,8 +491,8 @@ class ToolTip(tk.Toplevel):
                 > self.widget_tl.winfo_rooty() + self.widget_tl.winfo_height()
             ):
                 y_pos = self.widget.winfo_rooty() - self.height
-        self.geometry(f"+{x_pos}+{y_pos}")
-        self.deiconify()
+        self.tooltip_window.geometry(f"+{x_pos}+{y_pos}")
+        self.tooltip_window.deiconify()
 
     def destroy(self) -> None:
         """Destroy the ToolTip and unbind all the bindings."""
@@ -485,7 +500,8 @@ class ToolTip(tk.Toplevel):
             unbind_from(self.widget, "<Enter>", self.enter_bind)
             unbind_from(self.widget, "<Leave>", self.leave_bind)
             unbind_from(self.widget, "<ButtonPress>", self.press_bind)
-        super().destroy()
+        if self.tooltip_window is not None:
+            self.tooltip_window.destroy()
 
 
 def unbind_from(widget: tk.Widget, sequence: str, func_id: str) -> None:


### PR DESCRIPTION
In Tools->Unicode menu.
Also doubles as "Commonly-used characters" dialog, by using the first entry in the dropdown. It should remember which block was shown the last time the dialog was shown. Clicking a character should insert it. Hovering over a button should show a tooltip with the character ordinal & name.