### PR TITLE
Dock/Undock Image Window without errors

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -50,7 +50,7 @@ from guiguts.misc_tools import (
 )
 from guiguts.page_details import PageDetailsDialog
 from guiguts.preferences import preferences, PrefKey
-from guiguts.root import root
+from guiguts.root import root, ImageWindowState
 from guiguts.search import show_search_dialog, find_next
 from guiguts.spell import spell_check
 from guiguts.tools.pptxt import pptxt
@@ -309,7 +309,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         preferences.set_callback(PrefKey.AUTO_IMAGE, self.auto_image_callback)
         preferences.set_default(PrefKey.BELL_AUDIBLE, True)
         preferences.set_default(PrefKey.BELL_VISUAL, True)
-        preferences.set_default(PrefKey.IMAGE_WINDOW, "Docked")
+        preferences.set_default(PrefKey.IMAGE_WINDOW, ImageWindowState.DOCKED)
         preferences.set_default(PrefKey.RECENT_FILES, [])
         preferences.set_default(PrefKey.LINE_NUMBERS, True)
         preferences.set_default(PrefKey.ORDINAL_NAMES, True)
@@ -622,7 +622,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             "~Dock Image",
             self.mainwindow.dock_image,
             self.mainwindow.float_image,
-            preferences.get(PrefKey.IMAGE_WINDOW) == "Docked",
+            root().image_window_state,
         )
         menu_view.add_button("~Show Image", self.show_image)
         menu_view.add_button("~Hide Image", self.hide_image)

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -12,7 +12,7 @@ from PIL import Image, ImageTk
 
 from guiguts.maintext import MainText, maintext
 from guiguts.preferences import preferences, PrefKey
-from guiguts.root import Root, root
+from guiguts.root import Root, root, ImageWindowState
 from guiguts.utilities import (
     is_mac,
     is_x11,
@@ -708,7 +708,7 @@ class MainWindow:
             tk.Wm.protocol(mainimage(), "WM_DELETE_WINDOW", self.hide_image)  # type: ignore[call-overload]
         else:
             root().wm_forget(mainimage())  # type: ignore[arg-type]
-        preferences.set(PrefKey.IMAGE_WINDOW, "Floated")
+        preferences.set(PrefKey.IMAGE_WINDOW, ImageWindowState.FLOATED)
 
     def dock_image(self, _event: Optional[tk.Event] = None) -> None:
         """Dock the image back into the main window"""
@@ -720,7 +720,7 @@ class MainWindow:
                 self.paned_window.forget(mainimage())
             except tk.TclError:
                 pass  # OK - image wasn't being managed by paned_window
-        preferences.set(PrefKey.IMAGE_WINDOW, "Docked")
+        preferences.set(PrefKey.IMAGE_WINDOW, ImageWindowState.DOCKED)
 
     def load_image(self, filename: str) -> None:
         """Load the image for the given page.
@@ -729,7 +729,7 @@ class MainWindow:
             filename: Path to image file.
         """
         mainimage().load_image(filename)
-        if preferences.get(PrefKey.IMAGE_WINDOW) == "Docked":
+        if preferences.get(PrefKey.IMAGE_WINDOW) == ImageWindowState.DOCKED:
             self.dock_image()
         else:
             self.float_image()

--- a/src/guiguts/root.py
+++ b/src/guiguts/root.py
@@ -24,6 +24,13 @@ class RootWindowState(StrEnum):
     FULLSCREEN = auto()
 
 
+class ImageWindowState(StrEnum):
+    """Enum class to store image window states."""
+
+    DOCKED = auto()
+    FLOATED = auto()
+
+
 class Root(tk.Tk):
     """Inherits from Tk root window"""
 
@@ -38,6 +45,9 @@ class Root(tk.Tk):
         self.full_screen_var = tk.BooleanVar(
             value=preferences.get(PrefKey.ROOT_GEOMETRY_STATE)
             == RootWindowState.FULLSCREEN
+        )
+        self.image_window_state = tk.BooleanVar(
+            value=preferences.get(PrefKey.IMAGE_WINDOW) == ImageWindowState.DOCKED
         )
         self.allow_config_saves = False
 


### PR DESCRIPTION
Checkbox used for Dock/Undock was initialized with a bool instead of a tk.Boolean.

Also removed use of literal strings for settings.