### PR TITLE
Trap bad regex in S/R dialog

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -2108,6 +2108,13 @@ class MainText(tk.Text):
             return ""
         return img_from_page_mark(mark)
 
+    def is_dark_theme(self) -> bool:
+        """Returns True if theme is dark, which is assumed to be the case if
+        the brightness of the text color is greater than half strength (mid-gray)."""
+        text_color = maintext().cget("foreground")
+        rgb_sum = sum(self.winfo_rgb(text_color))  # 0-65535 for each component
+        return rgb_sum > 12767 * 3
+
 
 def img_from_page_mark(mark: str) -> str:
     """Get base image name from page mark, e.g. "Pg027" gives "027".

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1480,12 +1480,16 @@ class MainText(tk.Text):
             search_string = re.escape(search_string)
         if wholeword:
             search_string = r"\b" + search_string + r"\b"
+        # Preferable to use flags rather than prepending "(?i)", for example,
+        # because if we need to report bad regex to user, it's better if it's
+        # the regex they typed.
+        flags = 0
         if backwards:
-            search_string = "(?r)" + search_string
+            flags |= re.REVERSE
         if nocase:
-            search_string = "(?i)" + search_string
+            flags |= re.IGNORECASE
 
-        match = re.search(search_string, slurp_text)
+        match = re.search(search_string, slurp_text, flags=flags)
         if match is None:
             return None, 0
 

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -79,7 +79,8 @@ class SearchDialog(ToplevelDialog):
 
         # Search
         style = ttk.Style()
-        style.configure("BadRegex.TCombobox", foreground="red")
+        new_col = "#ff4040" if maintext().is_dark_theme() else "#b00000"
+        style.configure("BadRegex.TCombobox", foreground=new_col)
 
         def is_valid_regex(new_value: str) -> bool:
             """Validation routine for Search Combobox - check value is a valid regex.


### PR DESCRIPTION
1. Change text color to red if current string is invalid regex.
2. Display regex compilation error if user still tries to use a red (bad) regex.