### PR TITLE
Improve display of multiline Find All display

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -405,14 +405,14 @@ class CheckerDialog(ToplevelDialog):
         Use this for content; use add_header & add_footer for headers & footers.
 
         Args:
-            msg: Entry to be displayed - only first non-empty line will be displayed.
+            msg: Entry to be displayed - newline characters are replaced with "⏎".
             text_range: Optional start & end of point of interest in main text widget.
             hilite_start: Optional column to begin higlighting entry in dialog.
             hilite_end: Optional column to end higlighting entry in dialog.
             entry_type: Defaults to content
             error_prefix: Optional string prefix to indicate error
         """
-        line = re.sub(r"\n*([^\n]*)\n?.*", r"\1", msg)
+        line = re.sub("\n", "⏎", msg)
         entry = CheckerEntry(
             line,
             text_range,

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -365,11 +365,13 @@ class SearchDialog(ToplevelDialog):
                 maintext().index(match.rowcol.index() + f"+{match.count}c")
             )
             hilite_start = match.rowcol.col
-            # If multiline, and there are lines after the one that will be shown,
-            # higlight to end of line
-            strip_line = line.lstrip("\n")
-            if end_rowcol.row > match.rowcol.row and "\n" in strip_line:
-                hilite_end = len(line)
+            # If multiline, lines will be concatenated, so adjust end hilite point
+            if end_rowcol.row > match.rowcol.row:
+                not_matched = maintext().get(
+                    f"{match.rowcol.index()}+{match.count}c",
+                    f"{match.rowcol.index()}+{match.count}c lineend",
+                )
+                hilite_end = len(line) - len(not_matched)
             else:
                 hilite_end = end_rowcol.col
             checker_dialog.add_entry(


### PR DESCRIPTION
Show newlines as `⏎`

Fixes #413 