### PR TITLE
Tidy title bar when no filename

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -224,7 +224,8 @@ class Guiguts:
             max_width = int(maintext().winfo_width() / maintext().font.measure("0"))
             if len_title > max_width:
                 filetitle = "..." + filetitle[len_title - max_width :]
-            filetitle = " - " + filetitle
+            if filetitle:
+                filetitle = " - " + filetitle
         root().title(f"Guiguts {version('guiguts')}" + modtitle + filetitle)
         if is_mac():
             root().wm_attributes("-modified", maintext().is_modified())


### PR DESCRIPTION
Previous edit meant the preceding hyphen was still shown, even if there was no filename.