### PR TITLE
Dollar fix

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1007,8 +1007,9 @@ class MainText(tk.Text):
         return self.rowcol("1.0")
 
     def end(self) -> IndexRowCol:
-        """Return IndexRowCol for end of text in widget, i.e. "end"."""
-        return self.rowcol(tk.END)
+        """Return IndexRowCol for end of text in widget, i.e. "end - 1c"
+        because text widget "end" is start of line below last char."""
+        return self.rowcol(tk.END + "-1c")
 
     def move_to_selection_start(self) -> str:
         """Set insert position to start of any selection text."""

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -294,14 +294,13 @@ class SearchDialog(ToplevelDialog):
 
         slurp_text = maintext().get(find_range.start.index(), find_range.end.index())
         slice_start = 0
-        slurp_start = IndexRowCol(find_range.start.row, find_range.start.col)
 
         matches: list[FindMatch] = []
         while True:
             match, match_start = maintext().find_match_in_range(
                 search_string,
                 slurp_text[slice_start:],
-                slurp_start,
+                find_range,
                 nocase=nocase,
                 regexp=regexp,
                 wholeword=wholeword,
@@ -315,6 +314,7 @@ class SearchDialog(ToplevelDialog):
             slurp_start = IndexRowCol(
                 maintext().index(f"{match.rowcol.index()}+{match.count}c")
             )
+            find_range = IndexRange(slurp_start, find_range.end)
         return matches
 
     def count_clicked(self) -> Optional[list[FindMatch]]:

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -611,7 +611,7 @@ def get_search_start(backwards: bool) -> IndexRowCol:
     We are searching forward;
     Current insert point is at start of previously found match;
     Start of previous match is still selected (or it was a zero-length match)
-    If all are true, advance 1 character to avoid re-finding match.
+    If all are true, advance to end of match.
 
     Additionally, searching for zero-length matches when already at start
     or end of file, needs special handling
@@ -651,7 +651,7 @@ def get_search_start(backwards: bool) -> IndexRowCol:
                     start_rowcol = maintext().rowcol(start_index + "+1c")
             elif sel_ranges := maintext().selected_ranges():
                 if maintext().compare(sel_ranges[0].start.index(), "==", start_index):
-                    start_rowcol = maintext().rowcol(start_index + "+1c")
+                    start_rowcol = maintext().rowcol(MARK_FOUND_END)
     return start_rowcol
 
 

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -310,9 +310,12 @@ class SearchDialog(ToplevelDialog):
                 break
             matches.append(match)
             # Adjust start of slice of slurped text, and where that point is in the file
-            slice_start += match_start + match.count
+            advance = max(match.count, 1)
+            slice_start += match_start + advance
+            if slice_start >= len(slurp_text):  # No text left to match
+                break
             slurp_start = IndexRowCol(
-                maintext().index(f"{match.rowcol.index()}+{match.count}c")
+                maintext().index(f"{match.rowcol.index()}+{advance}c")
             )
             find_range = IndexRange(slurp_start, find_range.end)
         return matches
@@ -607,21 +610,46 @@ def get_search_start(backwards: bool) -> IndexRowCol:
     Start from current insert point unless the following are true:
     We are searching forward;
     Current insert point is at start of previously found match;
-    Start of previous match is still selected
+    Start of previous match is still selected (or it was a zero-length match)
     If all are true, advance 1 character to avoid re-finding match.
+
+    Additionally, searching for zero-length matches when already at start
+    or end of file, needs special handling
 
     Args:
         backwards: True if searching backwards.
     """
     start_rowcol = maintext().get_insert_index()
-    if not backwards:
-        start_index = start_rowcol.index()
-        try:
-            at_previous_match = maintext().compare(MARK_FOUND_START, "==", start_index)
-        except tk.TclError:
-            at_previous_match = False  # MARK not found
-        if at_previous_match:
-            if sel_ranges := maintext().selected_ranges():
+    start_index = start_rowcol.index()
+    try:
+        at_previous_match = maintext().compare(MARK_FOUND_START, "==", start_index)
+    except tk.TclError:
+        at_previous_match = False  # MARK not found
+    # We've previously done a search, and are now doing another, so various special
+    # cases needed to avoid getting stuck at a match
+    if at_previous_match:
+        zero_len = maintext().compare(MARK_FOUND_START, "==", MARK_FOUND_END)
+        if backwards:
+            if zero_len:
+                # If at start of file, and wrapping, then next reverse search is from end,
+                # otherwise, just go back one character
+                if preferences.get(PrefKey.SEARCHDIALOG_WRAP) and maintext().compare(
+                    MARK_FOUND_START, "==", "1.0"
+                ):
+                    start_rowcol = maintext().end()
+                else:
+                    start_rowcol = maintext().rowcol(start_index + "-1c")
+        else:
+            if zero_len:
+                # If at end of file, and wrapping, then next search is from start,
+                # otherwise, just go forward one character
+                if preferences.get(PrefKey.SEARCHDIALOG_WRAP) and maintext().compare(
+                    MARK_FOUND_START, "==", maintext().end().index()
+                ):
+                    start_rowcol = maintext().start()
+                else:
+                    start_rowcol = maintext().rowcol(start_index + "+1c")
+            elif sel_ranges := maintext().selected_ranges():
                 if maintext().compare(sel_ranges[0].start.index(), "==", start_index):
                     start_rowcol = maintext().rowcol(start_index + "+1c")
     return start_rowcol


### PR DESCRIPTION
Instead of only matching "end of string" (where string could be just the selected text), match any "end of line",
and only "end of string" if it's also "end of line".
Should match treatment of `^`

Fixes #419 