### PR TITLE
Add soft wrapping

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -7,6 +7,7 @@ import logging
 import importlib.resources
 from importlib.metadata import version
 import os.path
+import tkinter as tk
 from tkinter import messagebox
 from typing import Optional
 import unicodedata
@@ -381,6 +382,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             PrefKey.UNICODE_BLOCK, UnicodeBlockDialog.commonly_used_characters_name
         )
         preferences.set_default(PrefKey.UNICODE_SEARCH_HISTORY, [])
+        preferences.set_default(PrefKey.SOFT_WRAP, tk.NONE)
 
         # Check all preferences have a default
         for pref_key in PrefKey:

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -2144,6 +2144,10 @@ class MainText(tk.Text):
         rgb_sum = sum(self.winfo_rgb(text_color))  # 0-65535 for each component
         return rgb_sum > 12767 * 3
 
+    def set_soft_wrap(self) -> None:
+        """Set soft wrap according to current Pref value."""
+        self.configure(wrap=preferences.get(PrefKey.SOFT_WRAP))
+
 
 def img_from_page_mark(mark: str) -> str:
     """Get base image name from page mark, e.g. "Pg027" gives "027".

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -682,7 +682,7 @@ class MainWindow:
             self.paned_window,
             root(),
             undo=True,
-            wrap="none",
+            wrap=preferences.get(PrefKey.SOFT_WRAP),
             autoseparators=True,
             maxundo=-1,
             highlightthickness=0,

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -120,8 +120,37 @@ class PreferencesDialog(ToplevelDialog):
             text="Automatically show current page image",
             variable=PersistentBoolean(PrefKey.AUTO_IMAGE),
         ).grid(column=0, row=5, sticky="NEW", pady=5)
+
+        soft_wrap_frame = ttk.Frame(appearance_frame)
+        soft_wrap_frame.grid(column=0, row=6, sticky="NEW", pady=(5, 0))
+        ttk.Label(soft_wrap_frame, text="Soft wrap: ").grid(
+            column=0, row=0, sticky="NEW"
+        )
+        wrap_var = PersistentString(PrefKey.SOFT_WRAP)
+        ttk.Radiobutton(
+            soft_wrap_frame,
+            command=maintext().set_soft_wrap,
+            text="None",
+            variable=wrap_var,
+            value=tk.NONE,
+        ).grid(column=1, row=0, sticky="NEW", padx=10)
+        ttk.Radiobutton(
+            soft_wrap_frame,
+            command=maintext().set_soft_wrap,
+            text="Char",
+            variable=wrap_var,
+            value=tk.CHAR,
+        ).grid(column=2, row=0, sticky="NEW", padx=10)
+        ttk.Radiobutton(
+            soft_wrap_frame,
+            command=maintext().set_soft_wrap,
+            text="Word",
+            variable=wrap_var,
+            value=tk.WORD,
+        ).grid(column=3, row=0, sticky="NEW", padx=10)
+
         bell_frame = ttk.Frame(appearance_frame)
-        bell_frame.grid(column=0, row=6, sticky="NEW", pady=(5, 0))
+        bell_frame.grid(column=0, row=7, sticky="NEW", pady=(5, 0))
         ttk.Label(bell_frame, text="Warning bell: ").grid(column=0, row=0, sticky="NEW")
         ttk.Checkbutton(
             bell_frame,
@@ -135,7 +164,9 @@ class PreferencesDialog(ToplevelDialog):
         ).grid(column=2, row=0, sticky="NEW")
 
         # Wrapping tab
-        wrapping_frame = ttk.LabelFrame(self.top_frame, text="Wrapping", padding=10)
+        wrapping_frame = ttk.LabelFrame(
+            self.top_frame, text="Text Wrapping", padding=10
+        )
         wrapping_frame.grid(column=0, row=1, sticky="NSEW", pady=(10, 0))
 
         def add_label_spinbox(row: int, label: str, key: PrefKey, tooltip: str) -> None:

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -67,6 +67,7 @@ class PrefKey(StrEnum):
     UNMATCHED_NESTABLE = auto()
     UNICODE_BLOCK = auto()
     UNICODE_SEARCH_HISTORY = auto()
+    SOFT_WRAP = auto()
 
 
 class Preferences:


### PR DESCRIPTION
Soft Wrap: None/Char/Word in Prefs dialog.

Note that column select doesn't necessarily work well if you're trying to select stuff in the wrapped part. That's no surprise, given how column select works, and that column numbers won't line up if word-wrapped. I think it would need to be documented, or the whole idea abandoned - it's not obvious how to fix it.