### PR TITLE
Minor Prefs dialog improvements

### DIFF
--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -43,7 +43,7 @@ class PreferencesDialog(ToplevelDialog):
         theme_frame = ttk.Frame(appearance_frame)
         theme_frame.grid(column=0, row=0, sticky="NSEW")
         theme_frame.columnconfigure(1, weight=1)
-        ttk.Label(theme_frame, text="Theme (requires program restart): ").grid(
+        ttk.Label(theme_frame, text="Theme (change requires restart): ").grid(
             column=0, row=0, sticky="NE"
         )
         cb = ttk.Combobox(
@@ -54,7 +54,7 @@ class PreferencesDialog(ToplevelDialog):
         cb["state"] = "readonly"
         tearoff_check = ttk.Checkbutton(
             appearance_frame,
-            text="Use Tear-Off Menus (requires program restart)",
+            text="Use Tear-Off Menus (change requires restart)",
             variable=PersistentBoolean(PrefKey.TEAROFF_MENUS),
         )
         tearoff_check.grid(column=0, row=1, sticky="NEW", pady=5)

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -34,7 +34,7 @@ class PreferencesDialog(ToplevelDialog):
 
     def __init__(self) -> None:
         """Initialize preferences dialog."""
-        super().__init__("Settings", resize_y=False)
+        super().__init__("Settings", resize_x=False, resize_y=False)
         self.minsize(250, 10)
 
         # Appearance
@@ -43,22 +43,21 @@ class PreferencesDialog(ToplevelDialog):
         theme_frame = ttk.Frame(appearance_frame)
         theme_frame.grid(column=0, row=0, sticky="NSEW")
         theme_frame.columnconfigure(1, weight=1)
-        ttk.Label(theme_frame, text="Theme: ").grid(column=0, row=0, sticky="NE")
+        ttk.Label(theme_frame, text="Theme (requires program restart): ").grid(
+            column=0, row=0, sticky="NE"
+        )
         cb = ttk.Combobox(
             theme_frame, textvariable=PersistentString(PrefKey.THEME_NAME)
         )
         cb.grid(column=1, row=0, sticky="NEW")
         cb["values"] = ["Default", "Dark", "Light"]
         cb["state"] = "readonly"
-        ttk.Label(
-            appearance_frame, text="(May need to restart program for full effect)"
-        ).grid(column=0, row=1, sticky="NSEW")
         tearoff_check = ttk.Checkbutton(
             appearance_frame,
-            text="Use Tear-Off Menus (requires restart)",
+            text="Use Tear-Off Menus (requires program restart)",
             variable=PersistentBoolean(PrefKey.TEAROFF_MENUS),
         )
-        tearoff_check.grid(column=0, row=2, sticky="NEW", pady=5)
+        tearoff_check.grid(column=0, row=1, sticky="NEW", pady=5)
         if is_mac():
             tearoff_check["state"] = tk.DISABLED
             ToolTip(tearoff_check, "Not available on macOS")


### PR DESCRIPTION
1. Stop it being resizable - it shouldn't be.
2. Move warning about theme change requiring restart into "Theme" label so it's obvious what it refers to.