### PR TITLE
Improve image viewer

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -386,6 +386,9 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         preferences.set_default(PrefKey.SPLIT_TEXT_WINDOW, False)
         preferences.set_default(PrefKey.SPLIT_TEXT_SASH_COORD, 0)
         preferences.set_default(PrefKey.IMAGE_INVERT, False)
+        preferences.set_default(PrefKey.IMAGE_FLOAT_GEOMETRY, "400x600+100+100")
+        preferences.set_default(PrefKey.IMAGE_DOCK_SASH_COORD, 300)
+        preferences.set_default(PrefKey.IMAGE_SCALE_FACTOR, 0.5)
 
         # Check all preferences have a default
         for pref_key in PrefKey:

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Final, TypedDict, Literal, Optional
 
 import regex as re
 
+from guiguts.mainwindow import mainimage
 from guiguts.maintext import (
     maintext,
     PAGE_FLAG_TAG,
@@ -304,6 +305,9 @@ class File:
         Returns:
             True if OK to continue with intended operation.
         """
+        # Good(?) place to ensure image position gets saved
+        mainimage().handle_configure(tk.Event())
+
         if not maintext().is_modified():
             return True
 

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -303,6 +303,8 @@ class MainImage(tk.Frame):
         self.columnconfigure(0, weight=1)
 
         self.canvas.bind("<Configure>", self.handle_configure)
+        self.bind("<Enter>", self.handle_configure)
+        self.bind("<Leave>", self.handle_configure)
         self.canvas.bind("<ButtonPress-1>", self.move_from)
         self.canvas.bind("<B1-Motion>", self.move_to)
         if is_x11():

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -269,8 +269,10 @@ class MainImage(tk.Frame):
         # Separate bindings needed for docked (root) and floated (self) states
         for widget in (root(), self):
             _, cp = process_accel("Cmd/Ctrl+plus")
+            _, ce = process_accel("Cmd/Ctrl+equal")
             _, cm = process_accel("Cmd/Ctrl+minus")
             widget.bind(cp, lambda _: self.zoom_in_btn.invoke())
+            widget.bind(ce, lambda _: self.zoom_in_btn.invoke())
             widget.bind(cm, lambda _: self.zoom_out_btn.invoke())
         ttk.Button(
             zoom_frame,

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -301,12 +301,6 @@ class MainImage(tk.Frame):
         self.canvas.grid(row=2, column=0, sticky="NSEW")
         self.rowconfigure(2, weight=1)
         self.columnconfigure(0, weight=1)
-        cmdctrl = "Cmd" if is_mac() else "Ctrl"
-        ToolTip(
-            self.canvas,
-            f"Drag image\nScroll with mousewheel\nZoom with {cmdctrl}+mousewheel",
-            use_pointer_pos=True,
-        )
 
         self.canvas.bind("<Configure>", self.handle_configure)
         self.canvas.bind("<ButtonPress-1>", self.move_from)
@@ -493,9 +487,17 @@ class MainImage(tk.Frame):
     def handle_configure(self, _e: tk.Event) -> None:
         """Handle configure event."""
         if preferences.get(PrefKey.IMAGE_WINDOW) == ImageWindowState.DOCKED:
-            preferences.set(PrefKey.IMAGE_DOCK_SASH_COORD, self.parent.sash_coord(0)[0])
+            try:  # In case unlucky timing means it tries to configure during undocking & finds sash doesn't exist
+                preferences.set(
+                    PrefKey.IMAGE_DOCK_SASH_COORD, self.parent.sash_coord(0)[0]
+                )
+            except tk.TclError:
+                pass
         else:
-            preferences.set(PrefKey.IMAGE_FLOAT_GEOMETRY, tk.Wm.geometry(self))  # type: ignore[call-overload]
+            try:  # In case unlucky timing means it tries to configure during docking & widget isn't a toplevel
+                preferences.set(PrefKey.IMAGE_FLOAT_GEOMETRY, tk.Wm.geometry(self))  # type: ignore[call-overload]
+            except tk.TclError:
+                pass
 
 
 class StatusBar(ttk.Frame):

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -71,6 +71,9 @@ class PrefKey(StrEnum):
     SPLIT_TEXT_WINDOW = auto()
     SPLIT_TEXT_SASH_COORD = auto()
     IMAGE_INVERT = auto()
+    IMAGE_FLOAT_GEOMETRY = auto()
+    IMAGE_DOCK_SASH_COORD = auto()
+    IMAGE_SCALE_FACTOR = auto()
 
 
 class Preferences:


### PR DESCRIPTION
1. Store position & size of floated viewer
2. Store sash position for docked viewer
3. Store zoom scale factor
4. Add Dock toggle and Close button to viewer
5. Turn off AutoImg if user closes viewer
6. Use opacity=75% to soften contrast in viewer