### PR TITLE
Make undo/redo work from checker dialogs

### DIFF
--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -564,9 +564,16 @@ class ScrolledReadOnlyText(tk.Text):
         # Also on creation, so it's correct for the current theme
         theme_set_tk_widget_colors(self)
 
-        # Redirect undo & redo events to main text window
-        super().bind("<<Undo>>", lambda _event: maintext().event_generate("<<Undo>>"))
-        super().bind("<<Redo>>", lambda _event: maintext().event_generate("<<Redo>>"))
+        # Redirect attempts to undo & redo to main text window
+        # Keystrokes match those in Undo/Redo menu buttons, with case handled manually here
+        _, key_event = process_accel("Cmd/Ctrl+Z")
+        super().bind(key_event, lambda _event: maintext().event_generate("<<Undo>>"))
+        _, key_event = process_accel("Cmd/Ctrl+z")
+        super().bind(key_event, lambda _event: maintext().event_generate("<<Undo>>"))
+        _, key_event = process_accel("Cmd+Shift+Z" if is_mac() else "Ctrl+Y")
+        super().bind(key_event, lambda _event: maintext().event_generate("<<Redo>>"))
+        _, key_event = process_accel("Cmd+Shift+z" if is_mac() else "Ctrl+y")
+        super().bind(key_event, lambda _event: maintext().event_generate("<<Redo>>"))
 
         if context_menu:
             add_text_context_menu(self, read_only=True)

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -564,6 +564,10 @@ class ScrolledReadOnlyText(tk.Text):
         # Also on creation, so it's correct for the current theme
         theme_set_tk_widget_colors(self)
 
+        # Redirect undo & redo events to main text window
+        super().bind("<<Undo>>", lambda _event: maintext().event_generate("<<Undo>>"))
+        super().bind("<<Redo>>", lambda _event: maintext().event_generate("<<Redo>>"))
+
         if context_menu:
             add_text_context_menu(self, read_only=True)
 


### PR DESCRIPTION
Redirect the undo/redo events from the read-only text list in checker dialogs to the main text window.

Fixes #446
