### PR TITLE
Add "Save a Copy As" menu option

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -426,6 +426,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         self.menu_file.add_button(
             "Save ~As...", self.file.save_as_file, "Cmd/Ctrl+Shift+S"
         )
+        self.menu_file.add_button("Sa~ve a Copy As...", self.file.save_copy_as_file)
         self.menu_file.add_button(
             "~Close", self.close_command, "Cmd+W" if is_mac() else ""
         )

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -290,12 +290,27 @@ class File:
             initialfile=os.path.basename(self.filename),
             initialdir=os.path.dirname(self.filename),
             filetypes=[("All files", "*")],
+            title="Save As",
         ):
             self.store_recent_file(fn)
             self.filename = fn
             self.save_file()
         grab_focus(root(), maintext())
         return fn
+
+    def save_copy_as_file(self) -> None:
+        """Save copy of current text as new file, without affecting
+        current filename or "modified" flag."""
+        if fn := filedialog.asksaveasfilename(
+            initialfile=os.path.basename(self.filename),
+            initialdir=os.path.dirname(self.filename),
+            filetypes=[("All files", "*")],
+            title="Save a Copy As",
+        ):
+            self.store_recent_file(fn)
+            maintext().do_save(fn, clear_modified_flag=False)
+            self.save_bin(fn)
+        grab_focus(root(), maintext())
 
     def check_save(self) -> bool:
         """If file has been edited, check if user wants to save,
@@ -419,6 +434,7 @@ class File:
         recents.insert(0, filename)
         del recents[NUM_RECENT_FILES:]
         preferences.set(PrefKey.RECENT_FILES, recents)
+        self._filename_callback()
 
     def remove_recent_file(self, filename: str) -> None:
         """Remove given filename from list of recent files.
@@ -430,6 +446,7 @@ class File:
         if filename in recents:
             recents.remove(filename)
             preferences.set(PrefKey.RECENT_FILES, recents)
+        self._filename_callback()
 
     def set_page_marks(self, page_details: PageDetails) -> None:
         """Set page marks from keys/values in dictionary.

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -308,6 +308,7 @@ class File:
             title="Save a Copy As",
         ):
             self.store_recent_file(fn)
+            self.store_recent_file(self.filename)
             maintext().do_save(fn, clear_modified_flag=False)
             self.save_bin(fn)
         grab_focus(root(), maintext())

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -653,7 +653,7 @@ class MainText(tk.Text):
         """Return whether widget's text has been modified."""
         return self.edit_modified()
 
-    def do_save(self, fname: str) -> None:
+    def do_save(self, fname: str, clear_modified_flag: bool = True) -> None:
         """Save widget's text to file.
 
         Args:
@@ -661,6 +661,7 @@ class MainText(tk.Text):
         """
         with open(fname, "w", encoding="utf-8") as fh:
             fh.write(self.get_text())
+        if clear_modified_flag:
             self.set_modified(False)
 
     def do_open(self, fname: str) -> None:


### PR DESCRIPTION
Saves a copy of the current file, but does not change the current filename, nor the "edited" flag.
Name of saved copy does get inserted in the "Recent Documents" menu.

Fixes #459 
