### PR TITLE
Add "Find Proofer Comments" to Search menu

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -50,6 +50,7 @@ from guiguts.misc_tools import (
     FractionConvertType,
     fraction_convert,
     unicode_normalize,
+    proofer_comment_check,
 )
 from guiguts.page_details import PageDetailsDialog
 from guiguts.preferences import preferences, PrefKey
@@ -519,19 +520,21 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             "Cmd+Shift+G" if is_mac() else "Shift+F3",
         )
         menu_search.add_button(
-            "Highlight Single Quotes in Selection",
+            "Find Proofer ~Comments",
+            proofer_comment_check,
+        )
+        menu_search.add_separator()
+        menu_search.add_button(
+            "Highlight Single ~Quotes in Selection",
             highlight_single_quotes,
-            "",
         )
         menu_search.add_button(
-            "Highlight Double Quotes in Selection",
+            "Highlight ~Double Quotes in Selection",
             highlight_double_quotes,
-            "",
         )
         menu_search.add_button(
-            "Remove Highlights",
+            "~Remove Highlights",
             remove_highlights,
-            "",
         )
         self.init_bookmark_menu(menu_search)
 

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -1137,3 +1137,45 @@ def unicode_normalize() -> None:
             if not unicodedata.is_normalized("NFC", text):
                 normalized_text = unicodedata.normalize("NFC", text)
                 maintext().replace(start_idx, end_idx, normalized_text)
+
+
+def proofer_comment_check() -> None:
+    """Find all proofer comments."""
+
+    matches = maintext().find_matches(
+        "[**",
+        IndexRange(maintext().start(), maintext().end()),
+        nocase=False,
+        regexp=False,
+    )
+
+    class ProoferCommentCheckerDialog(CheckerDialog):
+        """Minimal class inheriting from CheckerDialog so that it can exist
+        simultaneously with other checker dialogs."""
+
+    checker_dialog = ProoferCommentCheckerDialog.show_dialog(
+        "Proofer Comments", rerun_command=proofer_comment_check
+    )
+    ToolTip(
+        checker_dialog.text,
+        "\n".join(
+            [
+                "Left click: Select & find comment",
+                "Right click: Remove comment from this list",
+            ]
+        ),
+        use_pointer_pos=True,
+    )
+    checker_dialog.reset()
+    for match in matches:
+        line = maintext().get(
+            f"{match.rowcol.index()} linestart",
+            f"{match.rowcol.index()}+{match.count}c lineend",
+        )
+        end_rowcol = IndexRowCol(
+            maintext().index(match.rowcol.index() + f"+{match.count}c")
+        )
+        checker_dialog.add_entry(
+            line, IndexRange(match.rowcol, end_rowcol), match.rowcol.col, end_rowcol.col
+        )
+    checker_dialog.display_entries()


### PR DESCRIPTION
Pops a list of occurrences of `[**`
Because it is likely that user might want to do other checks while resolving proofer comments, the new dialog is independent of other checkers, so can be shown at the same time as Find All, Jeebies, etc

Fixes #356