### PR TITLE
Two WF fixes

### DIFF
--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -558,7 +558,7 @@ class WordFrequencyDialog(ToplevelDialog):
         low_char = event.char.lower()
         for idx, entry in enumerate(self.entries):
             if entry.word.lower().startswith(low_char):
-                self.goto_word(idx, force_first=True)
+                self.text.select_line(idx + 1)
                 return "break"
         return ""
 

--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -993,12 +993,13 @@ def wf_populate_markedup(wf_dialog: WordFrequencyDialog) -> None:
 
     whole_text = maintext().get_text()
 
-    matches = re.findall(rf"(?<!\w)(<({MARKUP_TYPES})>([^<]|\n)+</\2>)(?!\w)",
+    matches = re.findall(
+        rf"(?<!\w)(<({MARKUP_TYPES})>([^<]|\n)+</\2>)(?!\w)",
         whole_text,
         flags=search_flags,
     )
     for match in matches:
-        marked_phrase:str = match[0]
+        marked_phrase: str = match[0]
         if nocase:
             marked_phrase = marked_phrase.lower()
         marked_phrase = marked_phrase.replace("\n", RETURN_ARROW)

--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -989,24 +989,24 @@ def wf_populate_markedup(wf_dialog: WordFrequencyDialog) -> None:
 
     marked_dict: WFDict = WFDict()
     nocase = preferences.get(PrefKey.WFDIALOG_IGNORE_CASE)
-    matches = maintext().find_matches(
-        rf"<({MARKUP_TYPES})>([^<]|\n)+</\1>",
-        IndexRange(maintext().start(), maintext().end()),
-        nocase=nocase,
-        regexp=True,
+    search_flags = re.IGNORECASE if nocase else 0
+
+    whole_text = maintext().get_text()
+
+    matches = re.findall(rf"(?<!\w)(<({MARKUP_TYPES})>([^<]|\n)+</\2>)(?!\w)",
+        whole_text,
+        flags=search_flags,
     )
     for match in matches:
-        marked_phrase = maintext().get_match_text(match)
+        marked_phrase:str = match[0]
         if nocase:
             marked_phrase = marked_phrase.lower()
         marked_phrase = marked_phrase.replace("\n", RETURN_ARROW)
         tally_word(marked_dict, marked_phrase)
 
-    whole_text = maintext().get_text()
     total_cnt = 0
     suspect_cnt = 0
     unmarked_count = {}
-    search_flags = re.IGNORECASE if nocase else 0
     for marked_phrase, marked_count in marked_dict.items():
         # Suspect if the bare phrase appears an excess number of times,
         # i.e. all occurrences > marked up occurrences


### PR DESCRIPTION
First, don't jump in main text with WF letter shortcut.
Just show the first word that starts with the given letter, but don't move the main text to show the location. That only happens if the user clicks on a WF word.

Fixes #482

Second, Make WF count & search consistent.
It was counting, but not searching for phrases like `<i>c</i>4`, i.e. where there was a word character immediately before/after the marked up phrase. The `<i>c</i>` should not be found by word count because it is not a word - the "word" is `c4`.

Fixes #476