### PR TITLE
Correctly locate spelling errors with single quote

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -765,7 +765,7 @@ class MainText(tk.Text):
 
     def get_lines(self) -> Generator[tuple[str, int], None, None]:
         """Yield each line & line number in main text window."""
-        for line_num in range(1, self.end().row):
+        for line_num in range(1, self.end().row + 1):
             line = maintext().get(f"{line_num}.0", f"{line_num}.0 lineend")
             yield line, line_num
 

--- a/src/guiguts/spell.py
+++ b/src/guiguts/spell.py
@@ -111,6 +111,7 @@ class SpellChecker:
                     # open single quote; trim it and check again
                     if spell_check_result == SPELL_CHECK_OK_NO and word.startswith("'"):
                         word = word[1:]
+                        col += 1
                         spell_check_result = self.spell_check_word(word, project_dict)
 
                     # If trailing straight/curly apostrophe, it might be


### PR DESCRIPTION
If spelling error was preceded by single straight quote, code did a second check to see if the word was in the dictionary without the quote (to cope with the case that the quote might be an apostrophe `'tis` or an open quote from speech, etc. However, it didn't correct its notion of where the word was on the line to account for the (now missing) quote. It therefore highlighted the line one space too far left.

Also, noticed during testing & fixed, if the last line of file didn't have a terminating newline, spell check didn't spell check that last line.

Fixes #477