### PR TITLE
Use text font for checker dialogs

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -191,7 +191,10 @@ class CheckerDialog(ToplevelDialog):
 
         self.top_frame.rowconfigure(1, weight=1)
         self.text = ScrolledReadOnlyText(
-            self.top_frame, context_menu=False, wrap=tk.NONE
+            self.top_frame,
+            context_menu=False,
+            wrap=tk.NONE,
+            font=maintext().font,
         )
         self.text.grid(column=0, row=1, sticky="NSEW")
 

--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -372,7 +372,10 @@ class WordFrequencyDialog(ToplevelDialog):
         # Main display list
         self.top_frame.rowconfigure(1, weight=1)
         self.text = ScrolledReadOnlyText(
-            self.top_frame, context_menu=False, wrap=tk.NONE
+            self.top_frame,
+            context_menu=False,
+            wrap=tk.NONE,
+            font=maintext().font,
         )
         self.text.grid(row=1, column=0, sticky="NSEW")
         mouse_bind(self.text, "1", self.goto_word_by_click)


### PR DESCRIPTION
All checker dialogs and WF dialog now use the same font as the main text window.

Fixes #480 