### PR TITLE
Add ability to add spelling to global lang dict

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -637,7 +637,9 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_tools.add_button(
             "~Spelling...",
             lambda: spell_check(
-                self.file.project_dict, self.file.add_good_word_to_project_dictionary
+                self.file.project_dict,
+                self.file.add_good_word_to_project_dictionary,
+                self.file.add_good_word_to_global_dictionary,
             ),
         )
         menu_tools.add_button("PP~txt...", lambda: pptxt(self.file.project_dict))

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -767,6 +767,17 @@ class File:
         if self.project_dict.add_good_word(word):
             self.project_dict.save(self.filename)
 
+    def add_good_word_to_global_dictionary(self, word: str) -> None:
+        """Add a good word to the user global dictionary for the current language.
+
+        Args:
+            word: The word to be added.
+        """
+        main_lang = maintext().get_language_list()[0]
+        path = Path(preferences.prefsdir, f"dict_{main_lang}_user.txt")
+        with path.open("a", encoding="utf-8") as fp:
+            fp.write(f"{word}\n")
+
     def rewrap_selection(self) -> None:
         """Wrap selected text."""
         ranges = maintext().selected_ranges()


### PR DESCRIPTION
Button in spell check dialog allows current word to be added to the user dictionary for the main language, e.g. `dict-en-user.txt`. Button shows the language to avoid confusion.

Fixes #481