### PR TITLE
Use different image alpha for dark/light themes

### DIFF
--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -428,7 +428,8 @@ class MainImage(tk.Frame):
         image = image.resize(
             size=(scaled_width, scaled_height), resample=Image.Resampling.LANCZOS
         )
-        image.putalpha(190)  # Reduce contrast by making slightly transparent
+        alpha_value = 180 if maintext().is_dark_theme() else 200
+        image.putalpha(alpha_value)  # Reduce contrast by making slightly transparent
         self.imagetk = ImageTk.PhotoImage(image)
         if self.imageid:
             self.canvas.delete(self.imageid)


### PR DESCRIPTION
There are 4 combinations: dark/light theme combined with image inverted/not.
This ensures all 4 look reasonable by using a different alpha (transparency) value for dark/light themes.
If needed we could use different values for whether the image is inverted or not, and have 4 different alpha values.

Fixes #499