### PR TITLE
Full functionality 'Footnote Fixup' tool

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -15,7 +15,7 @@ import webbrowser
 from guiguts.checkers import CheckerSortType
 from guiguts.data import themes
 from guiguts.file import File, the_file, NUM_RECENT_FILES
-from guiguts.footnotes import footnote_check
+from guiguts.footnotes import footnote_check, FootnoteIndexStyle
 from guiguts.illo_sn_fixup import illosn_check
 from guiguts.highlight import (
     highlight_single_quotes,
@@ -348,6 +348,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         preferences.set_default(
             PrefKey.LEVENSHTEIN_EDIT_DISTANCE, LevenshteinEditDistance.ONE
         )
+        preferences.set_default(PrefKey.FOOTNOTE_INDEX_STYLE, FootnoteIndexStyle.NUMBER)
         preferences.set_default(PrefKey.WRAP_LEFT_MARGIN, 0)
         preferences.set_default(PrefKey.WRAP_RIGHT_MARGIN, 72)
         preferences.set_default(PrefKey.WRAP_BLOCKQUOTE_INDENT, 2)

--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -299,7 +299,7 @@ class FootnoteChecker:
 
         An issue arises if the last line of the file is a footnote.
         Inserting a blank line ("\n") programatically will place it
-        *before* the footnote's end "Checker" mark if tk.RIGHT gravity
+        before the footnote's end "Checker" mark if tk.RIGHT gravity
         was specified when the mark was set. We want the blank line
         placed after the mark otherwise the "\n" will be carried with
         the footnote if it is moved.

--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -1,13 +1,19 @@
 """Footnote checking, fixing and tidying functionality"""
 
 import logging
+from enum import StrEnum, auto
 from tkinter import ttk
 from typing import Optional
 import regex as re
+import roman  # type: ignore[import-untyped]
 
 from guiguts.checkers import CheckerDialog, CheckerEntry
 from guiguts.maintext import maintext
 from guiguts.misc_tools import tool_save
+from guiguts.preferences import (
+    PersistentString,
+    PrefKey,
+)
 from guiguts.utilities import (
     IndexRowCol,
     IndexRange,
@@ -19,6 +25,14 @@ logger = logging.getLogger(__package__)
 _the_footnote_checker: Optional["FootnoteChecker"] = (
     None  # pylint: disable=invalid-name
 )
+
+
+class FootnoteIndexStyle(StrEnum):
+    """Enum class to store FN index style types."""
+
+    NUMBER = auto()
+    LETTER = auto()
+    ROMAN = auto()
 
 
 class AnchorRecord:
@@ -89,6 +103,9 @@ class FootnoteChecker:
         self.fn_records: list[FootnoteRecord] = []
         self.an_records: list[AnchorRecord] = []
         self.checker_dialog: CheckerDialog = checker_dialog
+        self.fn_index_style = PersistentString(PrefKey.FOOTNOTE_INDEX_STYLE)
+        self.fn_check_errors = False
+        self.fns_have_been_moved = False
 
     def reset(self) -> None:
         """Reset FootnoteChecker."""
@@ -122,9 +139,416 @@ class FootnoteChecker:
             f"{fn_cur_start} -1l linestart", f"{fn_cur_end} +1l linestart"
         )
         maintext().delete(f"{fn_prev_end} -1c", f"{fn_prev_end} lineend")
-        maintext().insert(fn_prev_end, "\n" + continuation_text + "\n")
+        # ORIG maintext().insert(fn_prev_end, "\n" + continuation_text + "\n")
+        maintext().insert(fn_prev_end, "\n" + continuation_text)
         self.checker_dialog.remove_entry_current()
         maintext().see(fn_prev_end)
+        self.run_check()
+        # display_footnote_entries()
+
+    def autoset_chapter_lz(self) -> None:
+        """Insert a 'FOOTNOTES:' LZ header line before each chapter break."""
+
+        search_range = IndexRange(maintext().start(), maintext().end())
+        match_regex = r"\n\n\n\n\n"
+        # Loop, finding all chapter breaks; i.e. block of 4 blank lines.
+        while beg_match := maintext().find_match(
+            match_regex, search_range, regexp=True, nocase=True
+        ):
+            chpt_break_start = beg_match.rowcol.index()
+            # Insert a 'FOOTNOTES:' LZ header line before the chapter break.
+            maintext().insert(
+                f"{chpt_break_start} +1l linestart", "\n\n" + "FOOTNOTES:" + "\n"
+            )
+            # BASED ON end_point = maintext().rowcol(f"{end_match.rowcol.index()}+1c")
+            restart_point = maintext().rowcol(f"{chpt_break_start} +4l")
+            search_range = IndexRange(restart_point, maintext().end())
+        # The file has changed so rebuild an/fn records and refresh dialog.
+        footnote_check()
+
+    def autoset_end_lz(self) -> None:
+        """Insert a 'FOOTNOTES:' LZ header line at end of file."""
+        last_line_end = maintext().end().index()
+        # Insert the 'FOOTNOTES:' LZ header line after last line of file.
+        maintext().insert(
+            f"{last_line_end} +1l linestart", "\n\n" + "FOOTNOTES:" + "\n"
+        )
+
+    def move_footnotes_to_paragraphs(self) -> None:
+        """Implements a button command"""
+        assert _the_footnote_checker is not None
+
+        # Each footnote anchored in a paragraph is moved and inserted immediately after
+        # the blank line that ends the paragraph containing its anchor. No landing zone
+        # headers ('FOOTNOTES:') are added. The moving of footnotes is started from the
+        # last anchor in the file and works upward to the first anchor. After each move
+        # the anchor and footnote records must be updated.
+
+        # If the last line of the file is not a blank line then add one.
+        end_of_file = maintext().end().index()
+        if maintext().get(f"{end_of_file} linestart", f"{end_of_file} lineend") != "":
+            maintext().insert(end_of_file, "\n")
+
+        an_records = self.get_an_records()
+        fn_records = self.get_fn_records()
+        an_records_reversed = an_records.copy()
+        an_records_reversed.reverse()
+
+        # First pass.
+
+        # Find footnotes and insert a shadow copy of each FN at the required place
+        # below the paragraph in which they are anchored. Leave the original FNs
+        # in place for the moment. Anchor and footnote record arrays are rebuilt
+        # each time a shadow footnote is inserted. Their records, of course, will
+        # still refer to the original footnotes; the shadow footnotes are masked
+        # during this pass.
+
+        for index in range(0, len(an_records)):
+            #an_record = an_records_reversed[index]
+            an_record = an_records[index]
+            # Get the record of the footnote it anchors.
+            fn_record = fn_records[an_record.fn_index]
+            fn_start = fn_record.start.index()
+            fn_end = fn_record.end.index()
+            fn_lines = maintext().get(fn_start, fn_end)
+            # Find the end of paragraph in which the footnote anchor is
+            # located. Start at the line containing the anchor.
+            search_range = IndexRange(an_record.start, maintext().end())
+            match_regex = r"^$"
+            mid_para_fn = False
+            while blank_line_match := maintext().find_match(
+                match_regex, search_range, regexp=True
+            ):
+                # This blank line might be one separating a mid-paragraph footnote
+                # from the text above so would not be the end of paragraph.
+                blank_line_start = blank_line_match.rowcol.index()
+                next_line_text = maintext().get(
+                    f"{blank_line_start} +1l linestart",
+                    f"{blank_line_start} +1l lineend",
+                )
+                # If the line below this blank line is not (the first line of)
+                # a footnote then we have found the 'end of paragraph'.
+                if next_line_text[0:10] != ("[Footnote " or "[Xootnote "):
+                    # Was the actual end of paragraph blank line.
+                    break
+                # Otherwise we have landed on a blank line above one or more mid-paragraph
+                # footnotes.
+                restart_search_point = maintext().rowcol(f"{blank_line_start} +1l linestart")
+                # Keep looking for a suitable blank line at which to insert footnote.
+                search_range = IndexRange(restart_search_point, maintext().end())
+            # If the insert point is a blank line immediately after a Page Marker, place
+            # the insert point immediately before the Page Marker as GG1 does.
+            line_before = maintext().get(
+                    f"{blank_line_start} -1l linestart", f"{blank_line_start} -1l lineend"
+            )
+            # Insert a shadow copy of the footnote and leave the original in place for the moment.
+            # A shadow copy is the footnote lines with the beginning '[F' changed to '[X'.
+            fn_lines = "[X" + fn_lines[2:]
+            # Insert the shadow copy of the footnote line(s) after the blank
+            # line..
+            if line_before[0:11] == "-----File: ":
+                maintext().insert(f"{blank_line_start} -1l linestart", fn_lines + "\n")
+            else:
+                maintext().insert(f"{blank_line_start} lineend", fn_lines + "\n")
+            # The file has changed so update anchor and footnote records.
+            self.run_check()
+            an_records = self.get_an_records()
+            an_records_reversed = an_records.copy()
+            an_records_reversed.reverse()
+            fn_records = self.get_fn_records()
+
+        # Second pass.
+
+        # Remove the orginal footnotes starting from the bottom of the file.
+        # fn_records = self.get_fn_records()
+        fn_records_reversed = fn_records.copy()
+        fn_records_reversed.reverse()
+        for fn_record in fn_records_reversed:
+            # Get the record of the footnote it anchors.
+            fn_start = fn_record.start.index()
+            fn_end = fn_record.end.index()
+            # Delete the footnote and the blank line above it.
+            maintext().delete(f"{fn_start} -1l linestart", f"{fn_end} +1l linestart")
+
+        # Third pass.
+
+        # Change each shadow footnote into a proper one then rebuild the anchor
+        # and footnote record arrays, etc.
+
+        self.reset()
+        search_range = IndexRange(maintext().start(), maintext().end())
+        match_regex = r"\[Xootnote"
+        # Loop, finding all shadow footnotes (i.e. beginning with "[Xootnote").
+        while beg_match := maintext().find_match(
+            match_regex, search_range, regexp=True, nocase=True
+        ):
+            fn_start = beg_match.rowcol.index()
+            fn_line = maintext().get(f"{fn_start} linestart", f"{fn_start} lineend")
+            # Replace the '[X' of shadow footnote with '[F'.
+            replacement_line = "[F" + fn_line[2:]
+            # Change shadow footnote into a proper one.
+            maintext().delete(fn_start, f"{fn_start} lineend")
+            maintext().insert(fn_start, "\n" + replacement_line)
+            # Restart search for next shadow FN from end of current matched line
+            fn_endpoint = maintext().rowcol(f"{fn_start} lineend")
+            search_range = IndexRange(fn_endpoint, maintext().end())
+
+        # End of final pass over footnotes.
+
+        # Set flag to disable the two 'move FN' buttons when dialog refreshed
+        # so user cannot execute a second FN move that might corrupt the file.
+        self.fns_have_been_moved = True
+        # The original footnotes have been deleted and their shadow replacements
+        # are now proper footnotes in the correct positions below paragraphs.
+        # Rebuild anchor and footnote record arrays and update the dialog, etc.
+        self.run_check()
+        self.define_buttons()
+        display_footnote_entries()
+
+    def move_footnotes_to_lz(self) -> None:
+        """Implements a button command"""
+
+        # Footnotes are always moved downward to a landing zone on a higher-numbered
+        # line. Even if a footnote sits immediately below a landing zone, it will be
+        # moved to the next one down in the file. If a footnote is located after the
+        # last autoset landing zone then a new landing zone ('FOOTNOTES:') is created
+        # after the last line in the file and the footnote moved below it. Note that
+        # that landing zone is in the same location as the one created when you click
+        # the 'Autoset End LZ' button.
+
+        # Start the moves from the last footnote in the file and work upward to the
+        # first footnote. Each footnote moved is inserted immediately below the LZ
+        # header so pushing down higher-numbered footnotes already moved.
+
+        assert _the_footnote_checker is not None
+        fn_records = _the_footnote_checker.get_fn_records()
+        fn_records_reversed = fn_records.copy()
+        fn_records_reversed.reverse()
+        for fn_record in fn_records_reversed:
+            fn_start = fn_record.start.index()
+            fn_end = fn_record.end.index()
+            fn_lines = maintext().get(fn_start, fn_end)
+            # Is there an LZ below this footnote in the file?
+            # If not, create one and move footnote below it.
+            # Otherwise move footnote below the LZ that was
+            # found
+            search_range = IndexRange(fn_record.end, maintext().end())
+            match_regex = r"FOOTNOTES:"
+            if lz_match := maintext().find_match(
+                match_regex, search_range, regexp=True
+            ):
+                # There is a LZ below the footnote.
+                lz_start = lz_match.rowcol.index()
+                below_lz = f"{lz_start} lineend"
+                # Insert the copy of the footnote line(s) below the LZ.
+                maintext().insert(below_lz, "\n\n" + fn_lines)
+                # Delete the original footnote line(s) along with the
+                # blank line above it.
+                maintext().delete(
+                    f"{fn_start} -1l linestart", f"{fn_end} +1l linestart"
+                )
+            else:
+                # This branch should be entered 0 or 1 times only.
+                # Here with a footnote with no landing zone below.
+                # There are two situations where this can happen:
+                #  1. The last footnote is in the last chapter of
+                #     the book and chapter LZ has been selected.
+                #     This means that the last 4-line chapter break
+                #     found will be the one separating the penultimate
+                #     chapter from the final chapter. There is no LZ
+                #     after the last paragraph of the last chapter.
+                #  2. No LZ was specified before clicking the move
+                #     to landing zones button.
+                #
+                # Insert a LZ after the last line of the file
+                # and move the footnote below it. Other footnotes
+                # with a lower index may be inserted immediately
+                # above it but that will be done in the 'then'
+                # branch above because there is now a LZ below
+                # those footnotes.
+
+                # Add the LZ at end of file.
+                self.autoset_end_lz()
+                below_lz = maintext().end().index()
+                # Insert the copy of the footnote line(s) below the new LZ.
+                maintext().insert(below_lz, "\n" + fn_lines)
+                # Delete the original footnote line(s) along with the blank
+                # line above it.
+                maintext().delete(
+                    f"{fn_start} -1l linestart", f"{fn_end} +1l linestart"
+                )
+        # Set flag to disable the two 'move FN' buttons when dialog refreshed
+        # so user cannot execute a second FN move that might corrupt the file.
+        self.fns_have_been_moved = True
+        # The file has changed so rebuild an/fn records and refresh dialog.
+        footnote_check()
+
+    def tidy_footnotes(self) -> None:
+        """Tidy footnotes after a move.
+
+        Copies and deletes the original then reinserts edited version at same place.
+        """
+        assert _the_footnote_checker is not None
+        fn_records = _the_footnote_checker.get_fn_records()
+        for fn_record in fn_records:
+            fn_start = fn_record.start.index()
+            fn_end = fn_record.end.index()
+            fn_label_and_text_part = maintext().get(f"{fn_start} +10c", f"{fn_end} -1c")
+            fn_label_and_text_part = re.sub(r"(^.+?):", r"[\1]", fn_label_and_text_part)
+            maintext().delete(fn_start, fn_end)
+            maintext().insert(fn_start, fn_label_and_text_part)
+
+    def get_anchor_hilite_columns(
+        self, an_record: AnchorRecord, an_line_text: str
+    ) -> tuple:
+        """Get new hilite start/end of anchor after it's reindexed.
+
+        The line with an anchor to be reindexed has to be fetched from the file
+        each time the reindex() function wants to replace an anchor label. The
+        original hilite start/end in the anchor record cannot be relied on as
+        the length of the label may change as a result of indexing. That problem
+        is compounded if there is more than one anchor on the same line.
+
+        To find the (new position of the) anchor in the line text, first find the
+        label of the footnote that it anchors and extract its label. Then search
+        for the string '[label]' on the line noting its start/end positions when
+        located.
+
+        Returns:
+            a tuple containing the new hilite start/end positions of the anchor.
+        """
+        assert _the_footnote_checker is not None
+        fn_records = _the_footnote_checker.get_fn_records()
+        # Get FN record that is 'anchored' by this anchor record.
+        fn_record = fn_records[an_record.fn_index]
+        # Extract the label text from '[Footnote label: ...]'.
+        fn_line_text = fn_record.text
+        fn_label_start = 10
+        fn_label_end = fn_line_text.find(":")
+        fn_label = fn_line_text[fn_label_start:fn_label_end]
+        # Now find '[label]' on the anchor line and note its start/end positions.
+        # Note that there maybe more than one footnote anchor on a line.
+        an_start = an_line_text.find(f"[{fn_label}]")
+        an_end = an_start + len(f"[{fn_label}]")
+        return an_start, an_end
+
+    def generate_letter_combinations(self) -> dict:
+        """Return a dictionary of letter labels.
+
+        1->A,...,26->Z, 27->AA, 28->AB,...
+
+        Generates 1,999 combinations (A->BXW). This is an arbitrary number
+        which can be decreased (or increased in the unlikely event of a
+        PPer processing a text with more than 1,999 footnotes and they are
+        to be reindexed using letters).
+
+        NB A dictionary is generated because an integer value cannot be converted
+        using the usual aritmetic to convert from one base (10) to another base (26)
+        since the letter sequence we want, notionally base 26, does not include a
+        'zero' value.
+        """
+        letters = " ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        letter_seq_dict = {}
+        count = 1
+        # A to Z
+        for i in range(1, 27):
+            letter_seq_dict[count] = letters[i]
+            count += 1
+        # AA to ZZ
+        for i in range(1, 27):
+            for j in range(1, 27):
+                letter_seq_dict[count] = letters[i] + letters[j]
+                count += 1
+        # AAA to ZZZ (but stops well before that last combo)
+        for i in range(1, 27):
+            if count == 2000:
+                break
+            for j in range(1, 27):
+                if count == 2000:
+                    break
+                for k in range(1, 27):
+                    letter_seq_dict[count] = letters[i] + letters[j] + letters[k]
+                    count += 1
+                    if count == 2000:
+                        break
+        return letter_seq_dict
+
+    def set_anchor(self) -> None:
+        """Insert anchor using label of selected footnote."""
+        assert _the_footnote_checker is not None
+        fn_records = _the_footnote_checker.get_fn_records()
+        insert_index = maintext().get_insert_index().index()
+        # Get label from selected FN.
+        fn_record = fn_records[self.get_selected_fn_index()]
+        fn_line_text = fn_record.text
+        fn_label_start = 10
+        fn_label_end = fn_line_text.find(":")
+        fn_label = fn_line_text[fn_label_start:fn_label_end]
+        maintext().insert(f"{insert_index}", f"[{fn_label}]")
+
+    def set_lz_at_cursor(self) -> None:
+        """Insert FOOTNOTE: header at cursor."""
+        insert_index = maintext().get_insert_index().index()
+        maintext().insert(f"{insert_index}", "\n\n" + "FOOTNOTES:" + "\n")
+
+    def reindex(self) -> None:
+        """Reindex all footnotes using fn_index_style
+
+        Three radio buttons set fn_index_style. It is persistent
+        across runs so style chosen last time will be the current
+        labelling style until a different radio button clicked.
+
+        fn_index_style values are 'number', 'letter' or 'roman'
+        """
+        assert _the_footnote_checker is not None
+
+        # Check index style used last time Footnotes Fixup was run or default if first run.
+        index_style = self.fn_index_style.get()
+        an_records = self.get_an_records()
+        fn_records = self.get_fn_records()
+        if index_style == "letter":
+            letters_dict = self.generate_letter_combinations()
+        for index in range(1, len(an_records) + 1):
+            if index_style == "number":
+                label = index
+            elif index_style == "roman":
+                label = roman.toRoman(index)
+                label = label + "."  # type: ignore[operator]
+            elif index_style == "letter":
+                label = letters_dict[
+                    index
+                ]  # pylint: disable=possibly-used-before-assignment
+            else:
+                # Default
+                label = index
+            an_record = an_records[index - 1]
+            an_line_text = maintext().get(
+                f"{an_record.start.index()} linestart",
+                f"{an_record.start.index()} lineend",
+            )
+            hl_start, hl_end = self.get_anchor_hilite_columns(an_record, an_line_text)
+            replacement_text = (
+                f"{an_line_text[0:hl_start]}[{label}]{an_line_text[hl_end:]}"
+            )
+            an_start = f"{an_record.start.index()} linestart"
+            maintext().delete(an_start, f"{an_start} lineend")
+            maintext().insert(an_start, replacement_text)
+            #
+            fn_record = fn_records[index - 1]
+            fn_line_text = fn_record.text
+            hl_start = fn_record.hilite_start
+            hl_end = fn_record.hilite_end
+            fn_line_text = (
+                f"{fn_line_text[0:hl_start + 9]}{label}{fn_line_text[hl_end:]}"
+            )
+            fn_start = f"{fn_record.start.index()} linestart"
+            # Replace (first line of) footnote using new label value.
+            # maintext().delete(f"{fn_start} linestart", f"{fn_start} +1l linestart")
+            # maintext().insert(f"{fn_start} linestart", fn_line_text + "\n")
+            maintext().delete(f"{fn_start}", f"{fn_start} lineend")
+            maintext().insert(f"{fn_start}", fn_line_text)
+        # Re-run the footnote checks and display the reindexed footnote entries.
+        footnote_check()
 
     def get_selected_fn_index(self) -> int:
         """Get the index of the selected footnote.
@@ -143,6 +567,168 @@ class FootnoteChecker:
             if fn_record.start == fn_start:
                 return fn_index
         return -1
+
+    def define_buttons(self) -> None:
+        """Helper function to create dialog window for run_check."""
+        assert _the_footnote_checker is not None
+
+        frame = ttk.Frame(self.checker_dialog.header_frame)
+        frame.grid(column=0, row=1, sticky="NSEW")
+        fixit_frame = ttk.LabelFrame(frame, text="Fixing Footnotes", padding=10)
+        fixit_frame.grid(column=0, row=0, sticky="NSEW")
+        join_button = ttk.Button(
+            fixit_frame,
+            text="Join Selected FN to Previous",
+            width=28,
+            command=_the_footnote_checker.join_to_previous,
+        )
+        fixit_frame.grid_columnconfigure(0, weight=0)
+        join_button.grid(column=0, row=0, sticky="W")
+        anchor_button = ttk.Button(
+            fixit_frame,
+            text="Set Anchor for Selected FN",
+            width=28,
+            command=_the_footnote_checker.set_anchor,
+        )
+        fixit_frame.grid_columnconfigure(1, weight=1)
+        anchor_button.grid(column=1, row=0, sticky="E")
+
+        # Reindexing
+        reindex_frame = ttk.LabelFrame(frame, text="Reindexing Footnotes", padding=10)
+        reindex_frame.grid(column=0, row=2, sticky="NSEW")
+        all_to_num = ttk.Radiobutton(
+            reindex_frame,
+            text="All to Number",
+            variable=self.fn_index_style,
+            value=FootnoteIndexStyle.NUMBER,
+            width=14,
+            takefocus=False,
+        )
+        reindex_frame.grid_columnconfigure(0, weight=1)
+        all_to_num.grid(column=0, row=0, sticky="NS")
+        all_to_let = ttk.Radiobutton(
+            reindex_frame,
+            text="All to Letter",
+            width=14,
+            variable=self.fn_index_style,
+            value=FootnoteIndexStyle.LETTER,
+            takefocus=False,
+        )
+        reindex_frame.grid_columnconfigure(1, weight=1)
+        all_to_let.grid(column=1, row=0, sticky="NS")
+        all_to_rom = ttk.Radiobutton(
+            reindex_frame,
+            text="All to Roman",
+            width=14,
+            variable=self.fn_index_style,
+            value=FootnoteIndexStyle.ROMAN,
+            takefocus=False,
+        )
+        reindex_frame.grid_columnconfigure(2, weight=1)
+        all_to_rom.grid(column=2, row=0, sticky="NS")
+        reindex_button = ttk.Button(
+            reindex_frame,
+            text="Reindex",
+            width=28,
+            command=self.reindex,
+        )
+        reindex_frame.grid_columnconfigure(1, weight=1)
+        reindex_button.grid(column=1, row=2, sticky="NS")
+
+        # Landing zones
+        lz_frame = ttk.LabelFrame(
+            frame, text="Moving Footnotes and Landing Zones", padding=10
+        )
+        lz_frame.grid(column=0, row=3, sticky="NSEW")
+        # Row 0
+        lz_set_at_cursor_button = ttk.Button(
+            lz_frame,
+            text="Set LZ @ Cursor",
+            width=28,
+            command=_the_footnote_checker.set_lz_at_cursor,
+        )
+        lz_frame.grid_columnconfigure(0, weight=1)
+        lz_set_at_cursor_button.grid(column=0, row=0, sticky="NSEW")
+        #
+        lz_set_at_chapter_button = ttk.Button(
+            lz_frame,
+            text="Autoset Chap. LZ",
+            width=28,
+            command=_the_footnote_checker.autoset_chapter_lz,
+        )
+        lz_frame.grid_columnconfigure(1, weight=1)
+        lz_set_at_chapter_button.grid(column=1, row=0, sticky="NSEW")
+        #
+        lz_set_at_end_button = ttk.Button(
+            lz_frame,
+            text="Autoset End LZ",
+            width=28,
+            command=_the_footnote_checker.autoset_end_lz,
+        )
+        lz_frame.grid_columnconfigure(2, weight=1)
+        lz_set_at_end_button.grid(column=2, row=0, sticky="NSEW")
+        # Row 1
+        move_to_lz_button = ttk.Button(
+            lz_frame,
+            text="Move FNs to Landing Zone(s)",
+            width=28,
+            command=_the_footnote_checker.move_footnotes_to_lz,
+        )
+        lz_frame.grid_columnconfigure(0, weight=0)
+        move_to_lz_button.grid(column=0, row=1, sticky="W")
+        #
+        move_to_para_button = ttk.Button(
+            lz_frame,
+            text="Move FNs to Paragraphs",
+            width=28,
+            command=_the_footnote_checker.move_footnotes_to_paragraphs,
+        )
+        lz_frame.grid_columnconfigure(2, weight=1)
+        move_to_para_button.grid(column=2, row=1, sticky="E")
+
+        # Tidying the footnotes
+        lz_frame = ttk.LabelFrame(frame, text="Tidying Footnotes", padding=10)
+        lz_frame.grid(column=0, row=4, sticky="NSEW")
+        fn_tidy_button = ttk.Button(
+            lz_frame,
+            text="Tidy Footnotes",
+            width=28,
+            command=_the_footnote_checker.tidy_footnotes,
+        )
+        lz_frame.grid_columnconfigure(0, weight=1)
+        fn_tidy_button.grid(column=0, row=2, sticky="NS")
+        if self.fn_check_errors:
+            reindex_button.config(state="disable")
+            lz_set_at_cursor_button.config(state="disable")
+            lz_set_at_chapter_button.config(state="disable")
+            lz_set_at_end_button.config(state="disable")
+            move_to_lz_button.config(state="disable")
+            move_to_para_button.config(state="disable")
+        else:
+            reindex_button.config(state="normal")
+            lz_set_at_cursor_button.config(state="normal")
+            lz_set_at_chapter_button.config(state="normal")
+            lz_set_at_end_button.config(state="normal")
+            move_to_lz_button.config(state="normal")
+            move_to_para_button.config(state="normal")
+        if self.fns_have_been_moved:
+            join_button.config(state="disable")
+            anchor_button.config(state="disable")
+            reindex_button.config(state="disable")
+            lz_set_at_cursor_button.config(state="disable")
+            lz_set_at_chapter_button.config(state="disable")
+            lz_set_at_end_button.config(state="disable")
+            move_to_lz_button.config(state="disable")
+            move_to_para_button.config(state="disable")
+        else:
+            join_button.config(state="normal")
+            anchor_button.config(state="normal")
+            reindex_button.config(state="normal")
+            lz_set_at_cursor_button.config(state="normal")
+            lz_set_at_chapter_button.config(state="normal")
+            lz_set_at_end_button.config(state="normal")
+            move_to_lz_button.config(state="normal")
+            move_to_para_button.config(state="normal")
 
     def run_check(self) -> None:
         """Run the initial footnote check."""
@@ -275,6 +861,7 @@ def footnote_check() -> None:
         _the_footnote_checker = FootnoteChecker(checker_dialog)
     elif not _the_footnote_checker.checker_dialog.winfo_exists():
         _the_footnote_checker.checker_dialog = checker_dialog
+    _the_footnote_checker.fns_have_been_moved = False
 
     ToolTip(
         checker_dialog.text,
@@ -288,16 +875,49 @@ def footnote_check() -> None:
         use_pointer_pos=True,
     )
 
-    frame = ttk.Frame(checker_dialog.header_frame)
-    frame.grid(column=0, row=1, sticky="NSEW")
-    ttk.Button(
-        frame,
-        text="Join to Previous",
-        command=_the_footnote_checker.join_to_previous,
-    ).grid(column=0, row=0, sticky="NSW")
-
+    _the_footnote_checker.define_buttons()
     _the_footnote_checker.run_check()
     display_footnote_entries()
+
+
+def check_fn_string(fn_record: FootnoteRecord) -> str:
+    """Identify common footnote typos in a footnote record.
+
+    NB Only looks at the start of (the first line of) the footnote.
+
+    Args:
+        footnote_record: record of a footnote in the file.
+
+    Returns:
+        str: 'OK' if FN conformant else an error description.
+    """
+    # GG1 fixes the next two typos but GG2 just flags them as for any other error.
+    if fn_record.text[0:2] == "[ ":
+        return "SPACE ERROR"
+    if fn_record.text[0:2] == "[f":
+        return "CASE ERROR"
+    fn_start = fn_record.start
+    if (
+        fn_record.text[0:11] == "[Footnote: "
+        and maintext().get(f"{fn_start.index()}-1c", fn_start.index()) != "*"
+    ):
+        return "MISSING LABEL"
+    # Missing colon?
+    pattern = r"\*?\[Footnote [^:\s]{1,9}\s"
+    if re.search(pattern, fn_record.text[0:16]):
+        return "MISSING COLON"
+    # A conformant out-of-line FN starts '[Footnote str: text'.
+    # 'str' can be a single symbol, up to three letters, up
+    # to four Arabic numerals, or up to eight Roman numerals
+    # plus a '.' (essentially between 1-100).
+    #
+    # Try numeric label first, then letter label, then a single symbol
+    # and only look for a label of Roman numerals if the other label
+    # styles don't match.
+    pattern = r"\*?\[Footnote \p{N}{1,4}:\s|\*?\[Footnote \p{L}{1,3}:\s|\*?\[Footnote [^\p{N}|\p{L}]{1}:\s|\*?\[Footnote [IVXLCDMivxlcdm]{1,8}\.:\s"
+    if not re.search(pattern, fn_record.text[0:22]):
+        return "INVALID LABEL"
+    return "OK"
 
 
 def display_footnote_entries() -> None:
@@ -307,49 +927,62 @@ def display_footnote_entries() -> None:
     checker_dialog.reset()
     fn_records = _the_footnote_checker.get_fn_records()
     an_records = _the_footnote_checker.get_an_records()
+    # Boolean to determine if buttons are to be set disabled or normal.
+    _the_footnote_checker.fn_check_errors = False
     for fn_index, fn_record in enumerate(fn_records):
-        error_prefix = ""
-        if fn_record.an_index is None:
-            fn_start = fn_record.start
-            if maintext().get(f"{fn_start.index()}-1c", fn_start.index()) == "*":
-                error_prefix = "CONTINUATION: "
+        # Flag common footnote typos. All non-conformant FNs
+        # must be fixed before reindexing, etc., can be done.
+        error_prefix = check_fn_string(fn_record)
+        # Value of error_prefix is either 'OK' or an error description;
+        # e.g. 'MISSING LABEL, 'MISSING COLON', etc.
+        if error_prefix == "OK":
+            # The footnote string is conformant now consider its context; does
+            # it have an anchor; is it a continuation footnote; is it out of
+            # sequence with its anchor, etc.
+            error_prefix = ""
+            if fn_record.an_index is None:
+                fn_start = fn_record.start
+                if maintext().get(f"{fn_start.index()}-1c", fn_start.index()) == "*":
+                    error_prefix = "CONTINUATION: "
+                else:
+                    error_prefix = "NO ANCHOR: "
             else:
-                error_prefix = "NO ANCHOR: "
-        else:
-            an_record = an_records[fn_record.an_index]
-            # Check that no other footnote has the same anchor as this one
-            for fni2, fn2 in enumerate(fn_records):
-                if fn2.an_index is None:
-                    continue
-                an2 = an_records[fn2.an_index]
-                if fn_index != fni2 and an_record.start == an2.start:
-                    error_prefix = "SAME ANCHOR: "
-                    break
-            # Check anchor of previous footnote and this one are in order (footnotes are always in order)
-            if (
-                fn_index > 0
-                and fn_record.an_index is not None
-                and fn_records[fn_index - 1].an_index is not None
-            ):
-                an_prev = an_records[fn_records[fn_index - 1].an_index]  # type: ignore[index]
-                if an_prev.start.row > an_record.start.row or (
-                    an_prev.start.row == an_record.start.row
-                    and an_prev.start.col > an_record.start.col
+                an_record = an_records[fn_record.an_index]
+                # Check that no other footnote has the same anchor as this one
+                for fni2, fn2 in enumerate(fn_records):
+                    if fn2.an_index is None:
+                        continue
+                    an2 = an_records[fn2.an_index]
+                    if fn_index != fni2 and an_record.start == an2.start:
+                        error_prefix = "SAME ANCHOR: "
+                        break
+                # Check anchor of previous footnote and this one are in order (footnotes are always in order)
+                if (
+                    fn_index > 0
+                    and fn_record.an_index is not None
+                    and fn_records[fn_index - 1].an_index is not None
                 ):
-                    error_prefix += "SEQUENCE: "
-            # Check anchor of next footnote and this one are in order (footnotes are always in order)
-            if (
-                "SEQUENCE: " not in error_prefix
-                and fn_index < len(fn_records) - 1
-                and fn_record.an_index is not None
-                and fn_records[fn_index + 1].an_index is not None
-            ):
-                an_next = an_records[fn_records[fn_index + 1].an_index]  # type: ignore[index]
-                if an_next.start.row < an_record.start.row or (
-                    an_next.start.row == an_record.start.row
-                    and an_next.start.col < an_record.start.col
+                    an_prev = an_records[fn_records[fn_index - 1].an_index]  # type: ignore[index]
+                    if an_prev.start.row > an_record.start.row or (
+                        an_prev.start.row == an_record.start.row
+                        and an_prev.start.col > an_record.start.col
+                    ):
+                        error_prefix += "SEQUENCE: "
+                # Check anchor of next footnote and this one are in order (footnotes are always in order)
+                if (
+                    "SEQUENCE: " not in error_prefix
+                    and fn_index < len(fn_records) - 1
+                    and fn_record.an_index is not None
+                    and fn_records[fn_index + 1].an_index is not None
                 ):
-                    error_prefix += "SEQUENCE: "
+                    an_next = an_records[fn_records[fn_index + 1].an_index]  # type: ignore[index]
+                    if an_next.start.row < an_record.start.row or (
+                        an_next.start.row == an_record.start.row
+                        and an_next.start.col < an_record.start.col
+                    ):
+                        error_prefix += "SEQUENCE: "
+        if error_prefix != "":
+            _the_footnote_checker.fn_check_errors = True
         checker_dialog.add_entry(
             fn_record.text,
             IndexRange(fn_record.start, fn_record.end),
@@ -364,4 +997,5 @@ def display_footnote_entries() -> None:
             an_record.hilite_start,
             an_record.hilite_end,
         )
+    _the_footnote_checker.define_buttons()
     checker_dialog.display_entries()

--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -298,11 +298,11 @@ class FootnoteChecker:
         """Add a blank line at end of the file.
 
         An issue arises if the last line of the file is a footnote.
-        Inserting a blank line ("\n") programatically will place it
+        Inserting a newline character programatically will place it
         before the footnote's end "Checker" mark if tk.RIGHT gravity
         was specified when the mark was set. We want the blank line
-        placed after the mark otherwise the "\n" will be carried with
-        the footnote if it is moved.
+        placed after the mark otherwise the newline character will
+        be carried with the footnote if it is moved.
 
         There will be at most one such "Checker" mark at the end of
         file in this case.

--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -571,8 +571,9 @@ class FootnoteChecker:
         the AN record hilite start/end column positions of a second or subsequent anchor
         on the same line cannot be relied on because the label of a previous anchor on
         that line might have expanded. Example:
-            'B' -> 'AA' if the FN and its AN represented by label 'B' is the 53rd AN/FN
-            and the anchor of the 54th FN is on the same line.
+
+        'B' -> 'AA' if the FN and its AN represented by label 'B' is the 53rd AN/FN
+        and the anchor of the 54th FN is on the same line.
 
         On termination of the reindex() function these marks are unset.
 

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -49,6 +49,7 @@ class PrefKey(StrEnum):
     DEFAULT_LANGUAGES = auto()
     JEEBIES_PARANOIA_LEVEL = auto()
     LEVENSHTEIN_EDIT_DISTANCE = auto()
+    FOOTNOTE_INDEX_STYLE = auto()
     WRAP_LEFT_MARGIN = auto()
     WRAP_RIGHT_MARGIN = auto()
     WRAP_BLOCKQUOTE_INDENT = auto()


### PR DESCRIPTION
Does not include inline footnotes which will have a separate tool if that is required.

Implements the fast 2-pass version of 'Move FNs to Paragraphs' which uses marks.

Fixes bug caused by interaction with use of marks when last line of the file is a footnote.

Uses the elegant GG1 alpha() function to convert footnote labels to alphabetic form.

Unlike GG1 it correctly handles 'mid-paragraph' footnotes; that is, footnotes at the bottom of the page that are anchored in the paragraph above which continues on to the following page(s).

Footnote Fixup will work consistently before or after Page Marker removal.