### PR TITLE
Add Stealth Scannos feature

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -53,6 +53,10 @@ from guiguts.misc_tools import (
     proofer_comment_check,
     asterisk_check,
     TextMarkupConvertorDialog,
+    stealth_scannos,
+    DEFAULT_SCANNOS_DIR,
+    DEFAULT_REGEX_SCANNOS,
+    DEFAULT_STEALTH_SCANNOS,
 )
 from guiguts.page_details import PageDetailsDialog
 from guiguts.preferences import preferences, PrefKey
@@ -397,6 +401,17 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         preferences.set_default(PrefKey.IMAGE_FLOAT_GEOMETRY, "400x600+100+100")
         preferences.set_default(PrefKey.IMAGE_DOCK_SASH_COORD, 300)
         preferences.set_default(PrefKey.IMAGE_SCALE_FACTOR, 0.5)
+        preferences.set_default(
+            PrefKey.SCANNOS_FILENAME,
+            str(DEFAULT_SCANNOS_DIR.joinpath(DEFAULT_REGEX_SCANNOS)),
+        )
+        preferences.set_default(
+            PrefKey.SCANNOS_HISTORY,
+            [
+                str(DEFAULT_SCANNOS_DIR.joinpath(DEFAULT_REGEX_SCANNOS)),
+                str(DEFAULT_SCANNOS_DIR.joinpath(DEFAULT_STEALTH_SCANNOS)),
+            ],
+        )
 
         # Check all preferences have a default
         for pref_key in PrefKey:
@@ -651,6 +666,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         )
         menu_tools.add_button("PP~txt...", lambda: pptxt(self.file.project_dict))
         menu_tools.add_button("~Jeebies...", jeebies_check)
+        menu_tools.add_button("Stealth S~cannos...", stealth_scannos)
         menu_tools.add_button(
             "Word ~Distance Check...", lambda: levenshtein_check(self.file.project_dict)
         )

--- a/src/guiguts/data/scannos/en-common.json
+++ b/src/guiguts/data/scannos/en-common.json
@@ -1,0 +1,285 @@
+{
+"wholeword": true,
+"scannos": [
+{
+"match": "1",
+"replacement": "I"
+},
+{
+"match": "111",
+"replacement": "Ill"
+},
+{
+"match": "ail",
+"replacement": "all"
+},
+{
+"match": "arc",
+"replacement": "are"
+},
+{
+"match": "arid",
+"replacement": "and"
+},
+{
+"match": "bad",
+"replacement": "had"
+},
+{
+"match": "ball",
+"replacement": "hall"
+},
+{
+"match": "band",
+"replacement": "hand"
+},
+{
+"match": "bar",
+"replacement": "her"
+},
+{
+"match": "bat",
+"replacement": "but"
+},
+{
+"match": "be",
+"replacement": "he"
+},
+{
+"match": "bead",
+"replacement": "head"
+},
+{
+"match": "beads",
+"replacement": "heads"
+},
+{
+"match": "bear",
+"replacement": "hear"
+},
+{
+"match": "bit",
+"replacement": "hit"
+},
+{
+"match": "bo",
+"replacement": "be"
+},
+{
+"match": "boon",
+"replacement": "been"
+},
+{
+"match": "borne",
+"replacement": "home"
+},
+{
+"match": "bow",
+"replacement": "how"
+},
+{
+"match": "bumbled",
+"replacement": "humbled"
+},
+{
+"match": "car",
+"replacement": "ear"
+},
+{
+"match": "carnage",
+"replacement": "carriage"
+},
+{
+"match": "carne",
+"replacement": "came"
+},
+{
+"match": "cast",
+"replacement": "east"
+},
+{
+"match": "cat",
+"replacement": "eat"
+},
+{
+"match": "CHATTER",
+"replacement": "CHAPTER"
+},
+{
+"match": "CHARTER",
+"replacement": "CHAPTER"
+},
+{
+"match": "cheek",
+"replacement": "check"
+},
+{
+"match": "clay",
+"replacement": "day"
+},
+{
+"match": "coining",
+"replacement": "coming"
+},
+{
+"match": "comer",
+"replacement": "corner"
+},
+{
+"match": "die",
+"replacement": "she"
+},
+{
+"match": "docs",
+"replacement": "does"
+},
+{
+"match": "ease",
+"replacement": "case"
+},
+{
+"match": "fail",
+"replacement": "fall"
+},
+{
+"match": "fax",
+"replacement": "far"
+},
+{
+"match": "fee",
+"replacement": "he"
+},
+{
+"match": "ha",
+"replacement": "he"
+},
+{
+"match": "hare",
+"replacement": "have"
+},
+{
+"match": "haying",
+"replacement": "having"
+},
+{
+"match": "hie",
+"replacement": "his"
+},
+{
+"match": "ho",
+"replacement": "he"
+},
+{
+"match": "hut",
+"replacement": "but"
+},
+{
+"match": "is",
+"replacement": "as"
+},
+{
+"match": "lie",
+"replacement": "he"
+},
+{
+"match": "lime",
+"replacement": "time"
+},
+{
+"match": "loth",
+"replacement": "10th"
+},
+{
+"match": "m",
+"replacement": "in"
+},
+{
+"match": "mall",
+"replacement": "mail"
+},
+{
+"match": "modem",
+"replacement": "modern"
+},
+{
+"match": "meat",
+"replacement": "ment"
+},
+{
+"match": "Ms",
+"replacement": "his"
+},
+{
+"match": "OP",
+"replacement": "OF"
+},
+{
+"match": "ray",
+"replacement": "away"
+},
+{
+"match": "ray",
+"replacement": "my"
+},
+{
+"match": "ringer",
+"replacement": "finger"
+},
+{
+"match": "ringers",
+"replacement": "fingers"
+},
+{
+"match": "rioted",
+"replacement": "noted"
+},
+{
+"match": "tho",
+"replacement": "the"
+},
+{
+"match": "tie",
+"replacement": "the"
+},
+{
+"match": "tier",
+"replacement": "her"
+},
+{
+"match": "tight",
+"replacement": "right"
+},
+{
+"match": "tile",
+"replacement": "the"
+},
+{
+"match": "tiling",
+"replacement": "thing"
+},
+{
+"match": "tip",
+"replacement": "up"
+},
+{
+"match": "tor",
+"replacement": "for"
+},
+{
+"match": "tram",
+"replacement": "train"
+},
+{
+"match": "tune",
+"replacement": "time"
+},
+{
+"match": "wen",
+"replacement": "well"
+},
+{
+"match": "yon",
+"replacement": "you"
+}
+]
+}

--- a/src/guiguts/data/scannos/regex.json
+++ b/src/guiguts/data/scannos/regex.json
@@ -1,0 +1,229 @@
+{
+"scannos": [
+{
+"match": "&c(,| |$)",
+"replacement": "&c.\\1",
+"hint": "Find the abbreviation &c. that doesn't have a period after it and insert one"
+},
+{
+"match": "(<\\w>) +",
+"replacement": "\\1",
+"hint": "Find HTML opening marker followed by whitespace and remove the whitespace"
+},
+{
+"match": "(?!client)\\b([csw])li([aeiou])",
+"replacement": "\\1h\\2",
+"hint": "Find a word with a possible li for h scanno and correct it"
+},
+{
+"match": "(?<=\\[)([^FSIG\\d])",
+"replacement": "\\1",
+"hint": "Find an opening square bracket followed by anything but F, S, I or G. (Footnote, Sidenote, Illustration or Greek)"
+},
+{
+"match": "([0-9]),([0-9]{4})",
+"replacement": "\\1, \\2",
+"hint": "Find dates that are missing a space between the month and year, and add a space"
+},
+{
+"match": "([\\p{Alpha}\\'])j\\b",
+"replacement": "\\1;",
+"hint": "Find character strings that end with j and change the j to a semicolon"
+},
+{
+"match": "([^gG])uess",
+"replacement": "\\1ness",
+"hint": "Find the string 'uess' not preceded by a g and change it to 'ness'"
+},
+{
+"match": "([abimou])hl([ie])",
+"replacement": "\\1bl\\2",
+"hint": "Find a string that contains hl preceded by one of (a,b,i,m,o or u) and followed by i or e and change it to bl"
+},
+{
+"match": "(\\S)  (\\S)",
+"replacement": "\\1 \\2",
+"hint": "Find two space characters, surrounded by non white-space characters, and remove one of them"
+},
+{
+"match": "(\\b[A-Z])\\. ([A-Z])\\.",
+"replacement": "\\1.\\2.",
+"hint": "Find initials with a space between them and remove the space"
+},
+{
+"match": ",(\"?\\n *\"?\\p{Upper})",
+"replacement": ".\\1",
+"hint": "Find a comma at the end of a line with the next line starting with an upper case character"
+},
+{
+"match": ",(\"?\\n{2,} *\"?\\p{Upper})",
+"replacement": ".\\1",
+"hint": "Find a paragraph that ends in a comma and change the comma to a period"
+},
+{
+"match": ",(?=\\n\\n)",
+"replacement": ".",
+"hint": "Find a comma at the end of a paragraph and replace it with a period"
+},
+{
+"match": ",(?= \\p{IsUpper}\\S)|,(?= [A-HJ-Z] )",
+"replacement": ".",
+"hint": "Find a comma followed by a space and an upper-case character (except I) and replace with a period."
+},
+{
+"match": "<(\\/?)(\\p{IsUpper}+)>",
+"replacement": "<\\1\\L\\2\\E>",
+"hint": "Find upper-case HTML markup and change it to lower-case"
+},
+{
+"match": "[b-df-hj-np-tv-xz]{5,}",
+"replacement": "",
+"hint": "Find a string containing at least 5 consonants in a row"
+},
+{
+"match": "\\.(\"?\\n *\"?\\p{Lower})",
+"replacement": ",\\1",
+"hint": "Find a period with the following word starting with a lower case character and change the period to a comma"
+},
+{
+"match": "\\.( \\p{IsLower})",
+"replacement": ",\\1",
+"hint": "Find a period followed by a space and a lower-case letter and replace it with a comma"
+},
+{
+"match": "\\Bii",
+"replacement": "ll",
+"hint": "Find the string ii not at the beginning of a word and change it to ll"
+},
+{
+"match": "\\b([csw])li([aeiou])",
+"replacement": "\\1h\\2",
+"hint": "Find a string that starts with one of c, s or w, li, then a vowel and change the li to h"
+},
+{
+"match": "\\b(\\S+) \\1\\b",
+"replacement": "\\1",
+"hint": "Find repeated words or word sequences and remove one"
+},
+{
+"match": "\\bhl",
+"replacement": "bl",
+"hint": "Find a string that starts with hl and change it to bl"
+},
+{
+"match": "\\bhr",
+"replacement": "br",
+"hint": "Find a string that starts with hr and change it to br"
+},
+{
+"match": "\\brn",
+"replacement": "m",
+"hint": "Find a string that starts with rn and change it to m"
+},
+{
+"match": "\\btb",
+"replacement": "th",
+"hint": "Find a string that starts with tb and change it to th"
+},
+{
+"match": "\\btli",
+"replacement": "th",
+"hint": "Find a string that starts with tli and change it to th"
+},
+{
+"match": " +(<\\/\\w>)",
+"replacement": "\\1",
+"hint": "Find HTML closing marker preceded by whitespace and remove the whitespace"
+},
+{
+"match": " \\'$",
+"replacement": "\\'",
+"hint": "Find a spaced single quote dangling on the end of a line"
+},
+{
+"match": "\\t",
+"replacement": " ",
+"hint": "Find a tab character and change it to space"
+},
+{
+"match": "\\xAD",
+"replacement": "-",
+"hint": "Find a soft Hyphen and change it to a (hard) Hyphen"
+},
+{
+"match": "^-[^-]",
+"replacement": "",
+"hint": "Find a line starting with a single hyphen and remove the hyphen"
+},
+{
+"match": "^.{75,}",
+"replacement": "",
+"hint": "Find long lines in the text"
+},
+{
+"match": "^[!;:,.?]",
+"replacement": "",
+"hint": "Find a line that starts with punctuation and remove the punctuation"
+},
+{
+"match": "cb",
+"replacement": "ch",
+"hint": "Find a word that contains cb and change it to ch"
+},
+{
+"match": "cl\\b",
+"replacement": "d",
+"hint": "Find a word that ends in cl and change it to d"
+},
+{
+"match": "gbt",
+"replacement": "ght",
+"hint": "Find a word that contains gbt and change it to ght"
+},
+{
+"match": "mcnt",
+"replacement": "ment",
+"hint": "Find a word containing mcnt and change it to ment"
+},
+{
+"match": "pbt",
+"replacement": "pht",
+"hint": "Find a word containing pbt and change it to pht"
+},
+{
+"match": "rn([bmp])",
+"replacement": "m\\1",
+"hint": "Find a word that contains rnb, rnm or rnp and change it to mb, mm or mp, respectively"
+},
+{
+"match": "tb",
+"replacement": "th",
+"hint": "Find a word that contains tb and change it to th"
+},
+{
+"match": "tii",
+"replacement": "th",
+"hint": "Find a word that contains tii and change it to th"
+},
+{
+"match": "tli",
+"replacement": "th",
+"hint": "Find a word that contains tli and change it to th"
+},
+{
+"match": "uess\\b",
+"replacement": "ness",
+"hint": "Find a word that ends with uess and change it to ness"
+},
+{
+"match": "v(?<!\\p{Alpha})",
+"replacement": "y",
+"hint": "Find a word that ends with a v and change it to a y"
+},
+{
+"match": "«[^»]+»\\n?",
+"replacement": "",
+"hint": "Find pairs of guillemets"
+}
+]
+}

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -79,6 +79,8 @@ class PrefKey(StrEnum):
     IMAGE_FLOAT_GEOMETRY = auto()
     IMAGE_DOCK_SASH_COORD = auto()
     IMAGE_SCALE_FACTOR = auto()
+    SCANNOS_FILENAME = auto()
+    SCANNOS_HISTORY = auto()
 
 
 class Preferences:


### PR DESCRIPTION
Two scannos files are included with the release:
regex.json and en-common.json, which are based
on the GG1 versions.

The user can also load their own scannos file. The recently loaded scannos files are in a dropdown at the top of the dialog.

The first scanno is shown, and the user can click Next or Prev. If there are no occurrences of the next/prev scanno, it autoadvances until it finds a scanno that does occur, or it hits the end/start of the scannos file.

All occurrences of the scanno are listed, and the
replace button (or Cmd/Ctrl left mouse click) will do the replacement if one is specified in the scannos file.

Scannos can also have an optional hint to explain what they do, which is displayed in the dialog.