### PR TITLE
Make S/R fields tall enough

### DIFF
--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -54,6 +54,7 @@ class SearchDialog(ToplevelDialog):
         except AttributeError:
             SearchDialog.selection = tk.BooleanVar(value=False)
         kwargs["resize_y"] = False
+        kwargs["disable_geometry_save"] = True
         super().__init__("Search & Replace", *args, **kwargs)
         self.minsize(400, 100)
 
@@ -264,6 +265,7 @@ class SearchDialog(ToplevelDialog):
 
         # Now dialog geometry is set up, set width to user pref, leaving height as it is
         self.config_width()
+        self.allow_geometry_save()
 
     def show_multi_replace(self, show: bool, resize: bool = True) -> None:
         """Show or hide the multi-replace buttons.

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -72,7 +72,7 @@ class SearchDialog(ToplevelDialog):
         options_frame.rowconfigure(0, weight=1)
         options_frame.rowconfigure(1, weight=1)
         message_frame = ttk.Frame(self.top_frame, padding=1)
-        message_frame.grid(row=6, column=0, columnspan=4, sticky="NSEW")
+        message_frame.grid(row=6, column=0, columnspan=5, sticky="NSEW", pady=(5, 0))
         self.separator = ttk.Separator(self.top_frame, orient=tk.VERTICAL)
         self.separator.grid(row=0, column=3, rowspan=6, padx=2, sticky="NSEW")
 
@@ -246,8 +246,9 @@ class SearchDialog(ToplevelDialog):
             self.repl_all_btn.append(repl_all_btn)
 
         # Message (e.g. count)
-        self.message = ttk.Label(message_frame)
-        self.message.grid(row=0, column=0, sticky="NSW")
+        message_frame.columnconfigure(0, weight=1)
+        self.message = ttk.Label(message_frame, borderwidth=1, relief="sunken")
+        self.message.grid(row=0, column=0, sticky="NSEW")
 
         self.show_multi_replace(
             preferences.get(PrefKey.SEARCHDIALOG_MULTI_REPLACE), resize=False

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -59,7 +59,7 @@ class SearchDialog(ToplevelDialog):
         self.top_frame.columnconfigure(0, weight=1)
         for row in range(5):
             self.top_frame.rowconfigure(row, weight=0)
-        self.top_frame.rowconfigure(5, weight=1)
+        self.top_frame.rowconfigure(6, weight=1)
         options_frame = ttk.Frame(
             self.top_frame, padding=3, borderwidth=1, relief=tk.GROOVE
         )

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -57,8 +57,9 @@ class SearchDialog(ToplevelDialog):
 
         # Frames
         self.top_frame.columnconfigure(0, weight=1)
-        for row in range(6):
-            self.top_frame.rowconfigure(row, weight=1)
+        for row in range(5):
+            self.top_frame.rowconfigure(row, weight=0)
+        self.top_frame.rowconfigure(5, weight=1)
         options_frame = ttk.Frame(
             self.top_frame, padding=3, borderwidth=1, relief=tk.GROOVE
         )

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -247,7 +247,9 @@ class SearchDialog(ToplevelDialog):
 
         # Message (e.g. count)
         message_frame.columnconfigure(0, weight=1)
-        self.message = ttk.Label(message_frame, borderwidth=1, relief="sunken")
+        self.message = ttk.Label(
+            message_frame, borderwidth=1, relief="sunken", padding=5
+        )
         self.message.grid(row=0, column=0, sticky="NSEW")
 
         self.show_multi_replace(
@@ -256,6 +258,7 @@ class SearchDialog(ToplevelDialog):
 
         # Now dialog geometry is set up, set width to user pref, leaving height as it is
         self.config_width()
+        self.set_min_height()
 
     def show_multi_replace(self, show: bool, resize: bool = True) -> None:
         """Show or hide the multi-replace buttons.
@@ -288,6 +291,22 @@ class SearchDialog(ToplevelDialog):
         height += offset if show else -offset
         geometry = re.sub(r"(\d+x)\d+(.+)", rf"\g<1>{height}\g<2>", geometry)
         self.geometry(geometry)
+        # Recalculate minimum height
+        self.set_min_height()
+
+    def set_min_height(self) -> None:
+        """Set minimum height of dialog to be large enough that the
+        message bar is not hidden.
+        """
+        self.update()  # Ensure geometry is fixed before setting min height
+        height = (
+            self.message.winfo_rooty()
+            - self.winfo_rooty()
+            + self.message.winfo_height()
+            + 5
+        )
+        width, _ = self.minsize()
+        self.minsize(width, height)
 
     def search_box_set(self, search_string: str) -> None:
         """Set string in search box.


### PR DESCRIPTION
Fixes #506

If font size was too large, and S/R dialog too short, then underscores wouldn't fit in the field because the fields resized vertically with the dialog. Now they don't.