### PR TITLE
Highlight alignment column

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -22,6 +22,7 @@ from guiguts.highlight import (
     highlight_double_quotes,
     remove_highlights,
     highlight_quotbrac_callback,
+    highlight_aligncol_callback,
 )
 from guiguts.maintext import maintext
 from guiguts.mainwindow import (
@@ -595,6 +596,12 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_search.add_checkbox(
             "Highlight S~urrounding Quotes & Brackets",
             root().highlight_quotbrac,
+        )
+        menu_search.add_checkbox(
+            "Highlight Al~ignment Column",
+            root().highlight_aligncol,
+            lambda: highlight_aligncol_callback(True),
+            lambda: highlight_aligncol_callback(False),
         )
         menu_search.add_separator()
         self.init_bookmark_menu(menu_search)

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -523,6 +523,7 @@ class MainText(tk.Text):
         # import here to avoid circular import problem.
         from guiguts.highlight import (  # pylint: disable=import-outside-toplevel
             highlight_quotbrac,
+            highlight_aligncol,
         )
 
         if not self.numbers_need_updating:
@@ -530,6 +531,7 @@ class MainText(tk.Text):
             self.root.after_idle(self._call_config_callbacks)
             self.root.after_idle(self.save_sash_coords)
             self.root.after_idle(highlight_quotbrac)
+            self.root.after_idle(highlight_aligncol)
             self.numbers_need_updating = True
 
     def save_sash_coords(self) -> None:

--- a/src/guiguts/root.py
+++ b/src/guiguts/root.py
@@ -45,6 +45,8 @@ class Root(tk.Tk):
         self.allow_config_saves = False
         self.split_text_window = PersistentBoolean(PrefKey.SPLIT_TEXT_WINDOW)
         self.highlight_quotbrac = PersistentBoolean(PrefKey.HIGHLIGHT_QUOTBRAC)
+        self.highlight_aligncol = tk.BooleanVar()
+        self.aligncol = -1
 
         self.option_add("*tearOff", preferences.get(PrefKey.TEAROFF_MENUS))
         self.rowconfigure(0, weight=1)


### PR DESCRIPTION
Adds "Highlight Alignment Column" to the Search menu. This should work the same way the GG1 feature did: when activated, whatever column the cursor is on will be set as the alignment column and highlighted with a color, until turned off.

I re-used the same color as GG1 in light mode, and chose a more muted shade for the dark theme.

(Marking this as a draft for now; until #519 is merged, this PR will have all the diffs from that PR, because this branch is based on that other branch.)

Fixes #43 