### PR TITLE
Highlight cursor line

### DIFF
--- a/src/guiguts/highlight.py
+++ b/src/guiguts/highlight.py
@@ -22,6 +22,7 @@ class HighlightTag(StrEnum):
     STRAIGHT_SINGLE_QUOTE = auto()
     CURLY_SINGLE_QUOTE = auto()
     ALIGNCOL = auto()
+    CURSOR_LINE = auto()
 
 
 class HighlightColors:
@@ -85,6 +86,11 @@ class HighlightColors:
     ALIGNCOL = {
         "Light": {"bg": "greenyellow", "fg": "black"},
         "Dark": {"bg": "green", "fg": "white"},
+    }
+
+    CURSOR_LINE = {
+        "Light": {"bg": "#efefef", "fg": "black"},
+        "Dark": {"bg": "#303030", "fg": "white"},
     }
 
 
@@ -482,3 +488,16 @@ def highlight_aligncol_in_viewport(viewport: Text):
 def remove_highlights_aligncol() -> None:
     """Remove highlights for alignment column"""
     maintext().tag_delete(HighlightTag.ALIGNCOL)
+
+
+def highlight_cursor_line() -> None:
+    """Add a highlight to entire line cursor is focused on."""
+    maintext().tag_delete(HighlightTag.CURSOR_LINE)
+
+    # Don't re-highlight if there's currently a selection
+    if not maintext().selected_ranges():
+        _highlight_configure_tag(HighlightTag.CURSOR_LINE, HighlightColors.CURSOR_LINE)
+
+        row = maintext().get_insert_index().row
+        maintext().tag_add(HighlightTag.CURSOR_LINE, f"{row}.0", f"{row+1}.0")
+        maintext().tag_lower(HighlightTag.CURSOR_LINE)

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -541,6 +541,7 @@ class MainText(tk.Text):
         from guiguts.highlight import (  # pylint: disable=import-outside-toplevel
             highlight_quotbrac,
             highlight_aligncol,
+            highlight_cursor_line,
         )
 
         if not self.numbers_need_updating:
@@ -549,6 +550,7 @@ class MainText(tk.Text):
             self.root.after_idle(self.save_sash_coords)
             self.root.after_idle(highlight_quotbrac)
             self.root.after_idle(highlight_aligncol)
+            self.root.after_idle(highlight_cursor_line)
             self.numbers_need_updating = True
 
     def save_sash_coords(self) -> None:


### PR DESCRIPTION
Subtly highlights the line the cursor is positioned on.

This tag is lowered to be below other tags, to avoid interfering with other highlighting. It may be that it should be the last thing run in `after_idle` for that reason.

(Marking as draft until #525 is merged)

Fixes #522 