### PR TITLE
Dynamically detect dark/light mode for "Default" theme

### DIFF
--- a/src/guiguts/highlight.py
+++ b/src/guiguts/highlight.py
@@ -40,61 +40,51 @@ class HighlightColors:
     QUOTEMARK = {
         "Light": {"bg": "#a08dfc", "fg": "black"},
         "Dark": {"bg": "#a08dfc", "fg": "white"},
-        "Default": {"bg": "#a08dfc", "fg": "black"},
     }
 
     SPOTLIGHT = {
         "Light": {"bg": "orange", "fg": "black"},
         "Dark": {"bg": "orange", "fg": "white"},
-        "Default": {"bg": "orange", "fg": "black"},
     }
 
     PAREN = {
         "Light": {"bg": "violet", "fg": "white"},
         "Dark": {"bg": "violet", "fg": "white"},
-        "Default": {"bg": "violet", "fg": "white"},
     }
 
     CURLY_BRACKET = {
         "Light": {"bg": "blue", "fg": "white"},
         "Dark": {"bg": "blue", "fg": "white"},
-        "Default": {"bg": "blue", "fg": "white"},
     }
 
     SQUARE_BRACKET = {
         "Light": {"bg": "purple", "fg": "white"},
         "Dark": {"bg": "purple", "fg": "white"},
-        "Default": {"bg": "purple", "fg": "white"},
     }
 
     STRAIGHT_DOUBLE_QUOTE = {
         "Light": {"bg": "green", "fg": "white"},
         "Dark": {"bg": "green", "fg": "white"},
-        "Default": {"bg": "green", "fg": "white"},
     }
 
     CURLY_DOUBLE_QUOTE = {
         "Light": {"bg": "limegreen", "fg": "white"},
         "Dark": {"bg": "limegreen", "fg": "white"},
-        "Default": {"bg": "limegreen", "fg": "white"},
     }
 
     STRAIGHT_SINGLE_QUOTE = {
         "Light": {"bg": "grey", "fg": "white"},
         "Dark": {"bg": "grey", "fg": "white"},
-        "Default": {"bg": "grey", "fg": "white"},
     }
 
     CURLY_SINGLE_QUOTE = {
         "Light": {"bg": "dodgerblue", "fg": "white"},
         "Dark": {"bg": "dodgerblue", "fg": "white"},
-        "Default": {"bg": "dodgerblue", "fg": "white"},
     }
 
     ALIGNCOL = {
         "Light": {"bg": "greenyellow", "fg": "black"},
-        "Dark": {"bg": "#577a32", "fg": "white"},
-        "Default": {"bg": "greenyellow", "fg": "black"},
+        "Dark": {"bg": "green", "fg": "white"},
     }
 
 
@@ -173,7 +163,11 @@ def _highlight_configure_tag(
         tag_name: Tag to be configured.
         tag_colors: Dictionary of fg/bg colors for each theme.
     """
-    theme = preferences.get(PrefKey.THEME_NAME)
+    if maintext().is_dark_theme():
+        theme = "Dark"
+    else:
+        theme = "Light"
+
     maintext().tag_configure(
         tag_name,
         background=tag_colors[theme]["bg"],


### PR DESCRIPTION
Move highlight color decision down the stack to `_highlight_configure_tag()`. Note that this only affects highlight.py; the base window colors and things like the color of selected text are out of scope here.

- Light theme: uses "Light" colors
- Dark theme: uses "Dark" colors
- Default theme: detects light/dark OS mode using `is_dark_mode()` and chooses Dark or Light colors.

If we adopt this we won't need to define Default colors for each tag type in highlight.py anymore; just Light and Dark.

Testing notes:

Using Default theme, open a document and set an alignment column (that's easiest because the coloring changes between themes). Then change the OS to the other mode and the window should change (at least it does in macOS). The highlight will not immediately change because it is triggered by on_change. Click into the window to move the cursor, or do anything else, and it should update the alignment column color.

Fixes #532