### PR TITLE
Make mypy stricter

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,8 +43,8 @@ jobs:
         poetry run python -m sphinx -M coverage docs docs/build -W
     - name: Static type check with mypy
       run: |
-        poetry run mypy -p guiguts
-        poetry run mypy tests
+        poetry run mypy --disallow-untyped-defs -p guiguts
+        poetry run mypy --disallow-untyped-defs tests
     - name: Test with pytest
       run: |
         poetry run pytest

--- a/src/guiguts/highlight.py
+++ b/src/guiguts/highlight.py
@@ -469,7 +469,7 @@ def highlight_aligncol() -> None:
             highlight_aligncol_in_viewport(maintext().peer)
 
 
-def highlight_aligncol_in_viewport(viewport: Text):
+def highlight_aligncol_in_viewport(viewport: Text) -> None:
     """Do highlighting of the alignment column in a single viewport."""
     (top_index, bot_index) = get_screen_window_coordinates(viewport)
 


### PR DESCRIPTION
Add `--disallow-untyped-defs` option to mypy run.

Without this, it doesn't catch
```def highlight_aligncol_in_viewport(viewport: Text):```
which doesn't have a return type declared.

