### PR TITLE
Globally initialize highlight tags at startup

### DIFF
--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -938,7 +938,7 @@ class File:
 
     def remove_bookmark_tags(self) -> None:
         """Remove all bookmark highlightling."""
-        maintext().tag_remove(BOOKMARK_TAG, "1.0", "end")
+        maintext().tag_remove(BOOKMARK_TAG, "1.0", tk.END)
 
 
 def bin_name(basename: str) -> str:


### PR DESCRIPTION
Rather than reconfigure highlight colors every time they're used, configure once at startup.

Rather than delete tags entirely every time we want to remove them from the UI, instead only remove the application of the tag (to text regions) and leave the tag itself defined (and configured with colors).

Define an order for highlight precedence, all in one place rather than scattered around the code.

Refactored a couple of instances of `"end"` to `tk.END`.

Fixes #537