### PR TITLE
Implement "Highlight Character, String or Regex" dialog

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -58,7 +58,7 @@ from guiguts.misc_tools import (
 from guiguts.page_details import PageDetailsDialog
 from guiguts.preferences import preferences, PrefKey
 from guiguts.root import root
-from guiguts.search import show_search_dialog, find_next
+from guiguts.search import show_search_dialog, find_next, show_highlight_dialog
 from guiguts.spell import spell_check
 from guiguts.tools.pptxt import pptxt
 from guiguts.tools.jeebies import jeebies_check, JeebiesParanoiaLevel
@@ -420,6 +420,9 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         preferences.set_callback(
             PrefKey.HIGHLIGHT_QUOTBRAC, self.highlight_quotbrac_callback
         )
+        preferences.set_default(PrefKey.HIGHLIGHT_DIALOG_SEARCH_HISTORY, [])
+        preferences.set_default(PrefKey.HIGHLIGHT_DIALOG_USE_REGEX, False)
+        preferences.set_default(PrefKey.HIGHLIGHT_DIALOG_MATCH_CASE, True)
 
         # Check all preferences have a default
         for pref_key in PrefKey:
@@ -589,6 +592,10 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         menu_search.add_button(
             "Highlight ~Double Quotes in Selection",
             maintext().highlight_double_quotes,
+        )
+        menu_search.add_button(
+            "~Highlight Character, String, or Regex...",
+            show_highlight_dialog,
         )
         menu_search.add_button(
             "~Remove Highlights",

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -149,7 +149,7 @@ class TextLineNumbers(tk.Canvas):
 class HighlightTag(StrEnum):
     """Global highlight tag settings."""
 
-    QUOTEMARK = auto()
+    MANUAL = auto()
     SPOTLIGHT = auto()
     PAREN = auto()
     CURLY_BRACKET = auto()
@@ -175,7 +175,7 @@ class HighlightColors:
     # Unclear what we should/will do in GG2 with themes & dark mode support.
 
     # Must be a definition for each available theme
-    QUOTEMARK = {
+    MANUAL = {
         "Light": {"bg": "#a08dfc", "fg": "black"},
         "Dark": {"bg": "#a08dfc", "fg": "white"},
     }
@@ -2494,17 +2494,19 @@ class MainText(tk.Text):
             matches = self.find_matches(pat, _range, nocase=nocase, regexp=regexp)
             for match in matches:
                 self.tag_add(
-                    tag_name, match.rowcol.index(), match.rowcol.index() + "+1c"
+                    tag_name,
+                    match.rowcol.index(),
+                    f"{match.rowcol.index()}+{match.count}c",
                 )
 
     def remove_highlights(self) -> None:
-        """Remove active highlights."""
-        self.tag_remove(HighlightTag.QUOTEMARK, "1.0", tk.END)
+        """Remove manually-triggered highlights."""
+        self.tag_remove(HighlightTag.MANUAL, "1.0", tk.END)
 
     def highlight_quotemarks(self, pat: str) -> None:
         """Highlight quote marks in current selection which match a pattern."""
         self.remove_highlights()
-        self.highlight_selection(pat, HighlightTag.QUOTEMARK, regexp=True)
+        self.highlight_selection(pat, HighlightTag.MANUAL, regexp=True)
 
     def highlight_single_quotes(self) -> None:
         """Highlight single quotes (straight or curly) in current selection."""
@@ -2873,7 +2875,7 @@ class MainText(tk.Text):
         #
         for tag, colors in (
             (HighlightTag.SPOTLIGHT, HighlightColors.SPOTLIGHT),
-            (HighlightTag.QUOTEMARK, HighlightColors.QUOTEMARK),
+            (HighlightTag.MANUAL, HighlightColors.MANUAL),
             # "sel" is for active selections - don't override the default color
             ("sel", None),
             (HighlightTag.PAREN, HighlightColors.PAREN),

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -82,6 +82,9 @@ class PrefKey(StrEnum):
     SCANNOS_FILENAME = auto()
     SCANNOS_HISTORY = auto()
     HIGHLIGHT_QUOTBRAC = auto()
+    HIGHLIGHT_DIALOG_SEARCH_HISTORY = auto()
+    HIGHLIGHT_DIALOG_USE_REGEX = auto()
+    HIGHLIGHT_DIALOG_MATCH_CASE = auto()
 
 
 class Preferences:


### PR DESCRIPTION
Implements the "Highlight Character, String or Regex" dialog.

Fixes #41 

## Testing notes

Generally this should behave the same as in GG1, with a couple of exceptions. Notably, it co-exists with "highlight alignment column" and "highlight surrounding brackets/quotes", which in GG1 was not the case. We discussed that in some other ticket and decided we would make that change.

Beyond that it should behave like GG1:
- Only one highlight dialog should exist, no duplicate dialogs
- Only highlights within a selection
- Searches (both types) can be case-sensitive or not, controlled with "Match case"
- Toggle Regex mode with checkbox
- Regex should display as red if it won't compile
- Mutually exclusive with "single quote" & "double quote" highlighters; only one can be active at a time
- Clear Highlights button is equivalent to the Remove Highlights menu item
- Restore Selection button should re-select the prior selection
- Regex & Match case checkboxes should persist, including across restarts
- Search history is for this dialog only; not shared with the S/R dialog
- Use same highlight color as "single quote" & "double quote" highlight.
    - Renamed that highlight symbol to MANUAL to group all manually-triggered highlights into one group
- Pressing Return is the same as clicking the Highlight button

## Other notes

I refactored a bit of other stuff for this. For instance the quotes highlighter naively used +1c for highlights, and had to be fixed to work with matches of lengths other than 1. I also renamed the QUOTEMARK highlight to MANUAL.

I added a checkbox "Match Case" that allows the user to control case-sensitivity. This is a divergence from GG1. The default is to match case, which matches the GG1 behavior.

I added the keypress handler for Return, which was not part of the old tool.

I renamed a couple of the buttons from GG1 to be more consistent with menu items (or at least they are consistent in macOS): Select All, Restore Selection

This is a draft for now because it's based on the branch from #556 - but it's ready to test now.