### PR TITLE
Add ruler to display column numbers

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -420,6 +420,10 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         preferences.set_callback(
             PrefKey.HIGHLIGHT_QUOTBRAC, self.highlight_quotbrac_callback
         )
+        preferences.set_default(PrefKey.COLUMN_NUMBERS, False)
+        preferences.set_callback(
+            PrefKey.COLUMN_NUMBERS, lambda value: maintext().show_column_numbers(value)
+        )
 
         # Check all preferences have a default
         for pref_key in PrefKey:
@@ -809,7 +813,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
 
         the_statusbar.add(
             "rowcol",
-            tooltip="Click: Go to line\nShift click: Toggle line numbers",
+            tooltip="Click: Go to line\nShift click: Toggle line numbers\nShift right-click: Toggle column numbers",
             update=rowcol_str,
         )
         the_statusbar.add_binding("rowcol", "ButtonRelease-1", self.file.goto_line)
@@ -817,6 +821,11 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             "rowcol",
             "Shift-ButtonRelease-1",
             lambda: preferences.toggle(PrefKey.LINE_NUMBERS),
+        )
+        the_statusbar.add_binding(
+            "rowcol",
+            "Shift-ButtonRelease-3",
+            lambda: preferences.toggle(PrefKey.COLUMN_NUMBERS),
         )
 
         the_statusbar.add(

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -117,11 +117,16 @@ class PreferencesDialog(ToplevelDialog):
         ).grid(column=0, row=4, sticky="NEW", pady=5)
         ttk.Checkbutton(
             appearance_frame,
+            text="Display Column Numbers",
+            variable=PersistentBoolean(PrefKey.COLUMN_NUMBERS),
+        ).grid(column=0, row=5, sticky="NEW", pady=5)
+        ttk.Checkbutton(
+            appearance_frame,
             text="Show Character Names in Status Bar",
             variable=root().ordinal_names_state,
-        ).grid(column=0, row=5, sticky="NEW", pady=5)
+        ).grid(column=0, row=6, sticky="NEW", pady=5)
         bell_frame = ttk.Frame(appearance_frame)
-        bell_frame.grid(column=0, row=6, sticky="NEW", pady=(5, 0))
+        bell_frame.grid(column=0, row=7, sticky="NEW", pady=(5, 0))
         ttk.Label(bell_frame, text="Warning bell: ").grid(column=0, row=0, sticky="NEW")
         ttk.Checkbutton(
             bell_frame,

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -82,6 +82,7 @@ class PrefKey(StrEnum):
     SCANNOS_FILENAME = auto()
     SCANNOS_HISTORY = auto()
     HIGHLIGHT_QUOTBRAC = auto()
+    COLUMN_NUMBERS = auto()
 
 
 class Preferences:


### PR DESCRIPTION
Adds a ruler along the top of each text view to display column numbers, highlighting current column number.

Adds a user preference to prefs panel (defaulting False) for control of this feature.

Fixes #61

**Testing Notes**

- Turn on column numbers in the preferences pane
- Ruler should scroll horizontally with its text view
    - Using mousewheel / trackpad scroll in text area
    - Using scrollbar
- I suggest testing at narrow and wide widths
- Also suggest testing just at the point where the horizontal scrollbar appears when you narrow the window just enough
- The ruler maxes out at 500 columns
- The ruler is only supposed to be drawn as long as the longest visible line
- UNLESS that line is narrower than the window. Then it pads to the window width.
- Colors should dynamically change in Default theme when OS dark mode changes
- When using split view, the focused view should have highlighted column just like the line numbers; the non-focused view should have the same de-emphasized coloring as the line numbers.

@windymilla when I use the Dark theme the colors are broken. Maybe you can tell me why? I haven't been able to find that one. It does work in Default theme when the OS dark mode is adjusted (at least on Mac). And the Light theme works.