### PR TITLE
VScode debugger to force default settings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,6 +23,14 @@
             "request": "launch",
             "python": "${command:python.interpreterPath}",
             "module": "guiguts.application"
+        },
+        {
+            "name": "Guiguts (use default settings)",
+            "type": "debugpy",
+            "request": "launch",
+            "python": "${command:python.interpreterPath}",
+            "module": "guiguts.application",
+            "args": ["-d", "--nohome"]
         }
     ]
 }


### PR DESCRIPTION
Adds a VScode debugging mode that forces all default settings by calling Guiguts with --nohome in effect.