### PR TITLE
Initialize peer colors at startup

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -513,6 +513,8 @@ class MainText(tk.Text):
         self.peer.bind(
             "<<ThemeChanged>>", lambda _event: theme_set_tk_widget_colors(self.peer)
         )
+        theme_set_tk_widget_colors(self.peer)
+
         self.peer_linenumbers = TextLineNumbers(self.peer_frame, self.peer)
         self.peer_linenumbers.grid(column=0, row=1, sticky="NSEW")
         self.peer_colnumbers = TextColumnNumbers(self.peer_frame, self.peer)


### PR DESCRIPTION
Initialize the peer editor's colors at startup even if peer isn't currently visible. Otherwise in certain conditions, its theme won't match the other editor when the peer is made visible.

Fixes #576