### PR TITLE
Fix overenthusiastic fraction conversion

### DIFF
--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -1104,11 +1104,16 @@ def fraction_convert(conversion_type: FractionConvertType) -> None:
             elif conversion_type != FractionConvertType.UNICODE:
                 new_frac = f"{gmatch[2].translate(superscripts)}{frac_slash}{gmatch[3].translate(subscripts)}"
             # Only convert if we found one that should be converted. Don't convert strings like
-            # "B1/2" or "C-1/3" - probably a plate/serial number, but not a fraction
+            # "B1/2" or "C-1/3" - probably a plate/serial number, but not a fraction.
+            # Also don't convert ".2/18" - probably "4.2/18.6" and converting the "2/18" would be wrong.
             prefix = maintext().get(
                 f"{match.rowcol.index()} linestart", match.rowcol.index()
             )
-            if new_frac and not re.search(r"\p{L}-?$", prefix):
+            if (
+                new_frac
+                and not re.search(r"\p{L}-?$", prefix)
+                and not prefix.endswith(".")
+            ):
                 len_frac = len(new_frac)
                 maintext().insert(match_index, new_frac)
                 maintext().delete(


### PR DESCRIPTION
Don't convert fraction if preceded by period, e.g. the "2/18" in "4.2/18.6" should not be converted.

Fixes #572 