### PR TITLE
Simplify use of checker dialogs

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -183,10 +183,8 @@ class CheckerDialog(ToplevelDialog):
             takefocus=False,
         ).grid(row=0, column=4, sticky="NSE", padx=2)
 
-        self.rerun_button = ttk.Button(
-            self.header_frame, text="Re-run", command=rerun_command
-        )
-        self.rerun_button.grid(column=1, row=0, sticky="NSE", padx=20)
+        self.rerun_button = ttk.Button(left_frame, text="Re-run", command=rerun_command)
+        self.rerun_button.grid(row=0, column=5, sticky="NSE", padx=(20, 0))
 
         self.top_frame.rowconfigure(1, weight=1)
         self.text = ScrolledReadOnlyText(

--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -999,13 +999,8 @@ class FootnoteChecker:
     def display_buttons(self) -> None:
         """Helper function to create dialog window for run_check."""
 
-        # Make the fixit_frame that contains all the buttons a direct child
-        # of header_frame that contains the 'Re-run' button. The buttons can
-        # then extend below the 'Re-run' button if columnspan=2 is added to
-        # fixit_frame's grid command. Some padding is required for correct
-        # RH alignment of the 'fixit' buttons with the 'Re-run' button.
-        fixit_frame = ttk.Frame(self.checker_dialog.header_frame, padding=20)
-        fixit_frame.grid(column=0, row=1, columnspan=2, sticky="NSEW")
+        fixit_frame = ttk.Frame(self.checker_dialog.header_frame)
+        fixit_frame.grid(column=0, row=1, sticky="NSEW")
         # Weight only needs setting once for each column, not every row of
         # every column.
         fixit_frame.grid_columnconfigure(0, weight=1)

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -1385,7 +1385,7 @@ class ScannoCheckerDialog(CheckerDialog):
         )
 
         frame = ttk.Frame(self.header_frame)
-        frame.grid(column=0, row=1, sticky="NSEW", columnspan=2, padx=(0, 15))
+        frame.grid(column=0, row=1, sticky="NSEW")
         frame.columnconfigure(1, weight=1)
 
         self.file_combo = Combobox(
@@ -1400,7 +1400,7 @@ class ScannoCheckerDialog(CheckerDialog):
         )
         ttk.Button(
             frame, text="Load File", command=self.choose_file, takefocus=False
-        ).grid(column=2, row=0, sticky="NSEW", padx=5, pady=5)
+        ).grid(column=2, row=0, sticky="NSEW", padx=(5, 0), pady=5)
 
         self.prev_btn = ttk.Button(
             frame,
@@ -1408,7 +1408,7 @@ class ScannoCheckerDialog(CheckerDialog):
             command=lambda: self.prev_next_scanno(prev=True),
             takefocus=False,
         )
-        self.prev_btn.grid(column=0, row=1, sticky="NSEW", padx=5, pady=5)
+        self.prev_btn.grid(column=0, row=1, sticky="NSEW", padx=(0, 5), pady=5)
         self.scanno_textvariable = tk.StringVar(self, "")
         search = ttk.Entry(
             frame,
@@ -1424,7 +1424,7 @@ class ScannoCheckerDialog(CheckerDialog):
             command=lambda: self.prev_next_scanno(prev=False),
             takefocus=False,
         )
-        self.next_btn.grid(column=2, row=1, sticky="NSEW", padx=5, pady=5)
+        self.next_btn.grid(column=2, row=1, sticky="NSEW", padx=(5, 0), pady=5)
 
         self.replacement_textvariable = tk.StringVar(self, "")
         replace = ttk.Entry(
@@ -1437,7 +1437,7 @@ class ScannoCheckerDialog(CheckerDialog):
         replace.grid(column=1, row=2, sticky="NSEW")
         ttk.Button(
             frame, text="Replace", command=self.replace_scanno, takefocus=False
-        ).grid(column=2, row=2, sticky="NSEW", padx=5)
+        ).grid(column=2, row=2, sticky="NSEW", padx=(5, 0))
 
         ttk.Label(
             frame,
@@ -1449,9 +1449,7 @@ class ScannoCheckerDialog(CheckerDialog):
             textvariable=self.hint_textvariable,
             state="readonly",
         )
-        self.hint.grid(
-            column=1, row=3, columnspan=2, sticky="NSEW", padx=(0, 5), pady=5
-        )
+        self.hint.grid(column=1, row=3, sticky="NSEW", pady=5)
 
         self.scanno_list: list[Scanno] = []
         self.whole_word = False
@@ -1808,7 +1806,7 @@ class CurlyQuotesDialog(CheckerDialog):
         )
 
         frame = ttk.Frame(self.header_frame)
-        frame.grid(column=0, row=1, columnspan=2, sticky="NSEW", padx=(0, 20), pady=5)
+        frame.grid(column=0, row=1, sticky="NSEW", pady=5)
         frame.columnconfigure(3, weight=1)
         ttk.Button(
             frame,

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -163,7 +163,7 @@ class SearchDialog(ToplevelDialog):
             text="Match case",
             variable=PersistentBoolean(PrefKey.SEARCHDIALOG_MATCH_CASE),
             takefocus=False,
-        ).grid(row=0, column=1, padx=2, columnspan=2, sticky="NSEW")
+        ).grid(row=0, column=1, padx=2, sticky="NSEW")
         ttk.Checkbutton(
             options_frame,
             text="Regex",

--- a/src/guiguts/spell.py
+++ b/src/guiguts/spell.py
@@ -378,7 +378,7 @@ def spell_check(
         use_pointer_pos=True,
     )
     frame = ttk.Frame(checker_dialog.header_frame)
-    frame.grid(column=0, row=1, columnspan=2, sticky="NSEW")
+    frame.grid(column=0, row=1, sticky="NSEW", pady=5)
     ttk.Label(
         frame,
         text="Threshold ≤ ",

--- a/src/guiguts/tools/jeebies.py
+++ b/src/guiguts/tools/jeebies.py
@@ -71,7 +71,7 @@ class JeebiesChecker:
             process_command=self.process_jeebies,
         )
         frame = ttk.Frame(checker_dialog.header_frame)
-        frame.grid(column=0, row=1, columnspan=2, sticky="NSEW")
+        frame.grid(column=0, row=1, sticky="NSEW")
         ttk.Label(
             frame,
             text="Check Level:",

--- a/src/guiguts/tools/levenshtein.py
+++ b/src/guiguts/tools/levenshtein.py
@@ -653,7 +653,7 @@ class LevenshteinChecker:
             rerun_command=lambda: levenshtein_check(project_dict),
         )
         frame = ttk.Frame(checker_dialog.header_frame)
-        frame.grid(column=0, row=1, columnspan=2, sticky="NSEW")
+        frame.grid(column=0, row=1, sticky="NSEW")
         ttk.Label(
             frame,
             text="Edit Distance:",


### PR DESCRIPTION
Due to the way it developed, the Checkerdialog
base class required tools that used it to set certain padding and columnspan to align. Fix this in the
base dialog instead.

Apart from minor adjustments to alignment, there
should be no behavioral change.