### PR TITLE
Fix exception wrapping blank line in index

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -2293,7 +2293,7 @@ class MainText(tk.Text):
 
                     # Find matching close markup within section being wrapped
                     if close_index := self.search(
-                        rf"^{re.escape(block_type)}/\s*$",
+                        rf"^{PAGEMARK_PIN}*{re.escape(block_type)}/\s*$",
                         line_start,
                         stopindex=WRAP_END_MARK,
                         nocase=True,
@@ -2530,6 +2530,10 @@ class MainText(tk.Text):
         while self.compare(line_start, "<", INDEX_END_MARK):
             line_end = self.index(f"{line_start} lineend")
             line = self.get(line_start, line_end).rstrip()
+            # No need to wrap blank lines - just move on to the next l
+            if line == "":
+                line_start = self.index(f"{line_start}+1l")
+                continue
             # Don't include pagemark pins in calculations, since removed after wrapping
             line_no_pin = line.replace(PAGEMARK_PIN, "")
             match = re.match(r"( +)", line_no_pin)

--- a/src/guiguts/utilities.py
+++ b/src/guiguts/utilities.py
@@ -624,6 +624,10 @@ class TextWrapper:
         # Executable section of enclosing function 'fill'.
         ####
 
+        # Empty paragraphs don't need wrapping
+        if paragraph == "":
+            return ""
+
         # Split the passed in paragraph into lines and add them
         # to the global list 'from_lines'.
         paragraph_to_lines(paragraph)


### PR DESCRIPTION
For normal wrapping, the blank line is taken as a paragraph so is not itself wrapped. However, because indexes have been formatted into single whole lines, they are wrapped one line at a time. This accidentally included wrapping the blank lines. The wrapping routine hadn't been written to expect wrapping an empty string.

1. In lower wrapping routine, deal with an empty paragraph without raising an exception.
2. In upper index wrapping routine, only wrap lines that have text

Finally, while testing, I found an independent bug (of mine) which probably wouldn't occur in RL. I made a small index by deleting most of the lines from the example supplied, which left some page marks at the start of the closing `I/` line. It then failed to recognize this as the end of the index, and said "no match for opening `/I`". Fixed.

Fixes #585 