### PR TITLE
Fix blank lines being lost during rewrap

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -2293,7 +2293,7 @@ class MainText(tk.Text):
 
             bq_depth_change = 0
             # Split for non-blank/blank lines
-            if re.search(r"\S", line):
+            if re.search(rf"[^\s{PAGEMARK_PIN}]", line):
                 paragraph_complete = False
                 # Check for various block markup types
                 trimmed = line.lower().rstrip(" \n").replace(PAGEMARK_PIN, "")


### PR DESCRIPTION
The blank lines had invisible characters to mark the page break locations - check for blank line didn't take this into account.

Fixes #600