### PR TITLE
Undo case changes in one block

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -2177,6 +2177,7 @@ class MainText(tk.Text):
         """
         if not (ranges := self.selected_ranges()):
             return
+        maintext().undo_block_begin()
         for _range in ranges:
             start = _range.start.index()
             end = _range.end.index()


### PR DESCRIPTION
Note that `undo_block_end` is called automatically when control returns to the user, so there is normally no need to call it in the application code.

Fixes #615 