### PR TITLE
Column-select scrolling at edge of window

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -3266,27 +3266,20 @@ class MainText(tk.Text):
         if 0 <= widget_x <= width and 0 <= widget_y <= height:
             return
 
-        delay = 50
+        scroll_delay = 100
 
-        # Scroll in the appropriate direction (x or y).  If scrolling
-        # vertically, set the delay before the next loop a little longer.
-        # (Because that "feels right".)
+        # Scroll in the appropriate direction (x or y).
         if widget_y < 0:
             event.widget.yview_scroll(-1, "units")
-            delay = 150
         elif widget_y > height:
             event.widget.yview_scroll(1, "units")
-            delay = 150
         elif widget_x < 0:
             event.widget.xview_scroll(-1, "units")
-            delay = 100
         elif widget_x > width:
             event.widget.xview_scroll(1, "units")
-            delay = 100
 
-        self.after(delay, lambda: callback(event))
         self._on_change()
-        self.after(delay, lambda: self._autoscroll_callback(event))
+        self.after(scroll_delay, lambda: self._autoscroll_callback(event))
 
 
 def img_from_page_mark(mark: str) -> str:

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1584,6 +1584,9 @@ class MainText(tk.Text):
 
         self.do_column_select(IndexRange(self.rowcol(TK_ANCHOR_MARK), cur_rowcol))
 
+        # Handle scrolling past edge of widget
+        self._autoscroll_callback(event)
+
     def column_select_release(self, event: tk.Event) -> None:
         """Callback when column selection is stopped via mouse button release.
 
@@ -1603,10 +1606,12 @@ class MainText(tk.Text):
         """
         self.mark_set(TK_ANCHOR_MARK, anchor.index())
         self.column_selecting = True
+        self._autoscroll_active = True
 
     def column_select_stop(self) -> None:
         """Stop column selection."""
         self.column_selecting = False
+        self._autoscroll_active = False
         self.focus_widget().config(cursor="")
 
     def rowcol(self, index: str) -> IndexRowCol:


### PR DESCRIPTION
Adds support for scrolling past the window edge in column select mode.

It's currently a bit imperfect / visually choppy; possibly that could be improved. But it seems to function properly.

I took the opportunity to simplify the non-column select mode scrolling to use less code. It should work the same as before, except I made the vertical scrolling a bit faster.

As before, the non-column select mode scrolling is only for Mac (because it isn't needed for Win/Linux).

The column select scrolling code is currently active on **all platforms**.
- Mac: because it's needed
- Windows: unknown (to me) - would appreciate feedback as to whether it was needed in the first place
- Linux: scrolling technically functions without this code, but it's **painfully** slow, so I opted to leave it on for Linux to override the normal behavior.

Testing notes:
- Re-test normal selection, going past the window edge, to make sure it still works as expected
- Do the same in column select mode; it should behave similar to normal selections as far as scrolling (literally the same code mostly).

And I'm particularly interested in @windymilla results on Windows with this branch compared to master. I did no testing on Windows.

Fixes #596 