### PR TITLE
Scroll speedup

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -3276,7 +3276,36 @@ class MainText(tk.Text):
         if 0 <= widget_x <= width and 0 <= widget_y <= height:
             return
 
-        scroll_delay = 100
+        out_of_bounds_distance = 0
+        out_of_bounds_direction = ""
+
+        if widget_x < 0:
+            out_of_bounds_distance = abs(widget_x)
+            out_of_bounds_direction = "left"
+        elif widget_x > width:
+            out_of_bounds_distance = abs(widget_x - width)
+            out_of_bounds_direction = "right"
+        elif widget_y < 0:
+            out_of_bounds_distance = abs(widget_y)
+            out_of_bounds_direction = "up"
+        elif widget_y > height:
+            out_of_bounds_distance = abs(widget_y - height)
+            out_of_bounds_direction = "down"
+
+        # Attempt to "smooth scroll" by basing the delay on math rather than
+        # choosing some arbitrary boundaries. Enforce a minimum and maximum
+        # value, otherwise we start at about 5 seconds and get to ridiculous
+        # minimums.
+        scroll_delay_fastest = 100
+        scroll_delay_slowest = 500
+        scroll_delay = max(
+            scroll_delay_slowest,
+            min(scroll_delay_fastest, (5000 / out_of_bounds_distance)),
+        )
+
+        # Increase speed for horizontal scrolling
+        if out_of_bounds_direction in ("left", "right"):
+            scroll_delay = scroll_delay / 1.5
 
         # Scroll in the appropriate direction (x or y).
         if widget_y < 0:
@@ -3289,7 +3318,7 @@ class MainText(tk.Text):
             event.widget.xview_scroll(1, "units")
 
         self._on_change()
-        self.after(scroll_delay, lambda: self._autoscroll_callback(event))
+        self.after(int(scroll_delay), lambda: self._autoscroll_callback(event))
 
 
 def img_from_page_mark(mark: str) -> str:


### PR DESCRIPTION
Adjust scrolling speed during a drag-select operation based on how far outside the window we've moved.

For column-select mode, this affects all platforms. For linear select mode, it's only relevant on Mac.

Initial attempt:
- For vertical scrolling:
    - Moving outside the boundary triggers a scroll operation every 500ms
    - Moving at least 20 pixels beyond the boundary accelerates to 250ms
    - Moving at least 40 pixels beyond the boundary accelerates to 125ms
- For horizontal scrolling, the delay is cut in half, so 250, 125, and 62ms.

**Edited to add:**

> Later this was changed to use a formula to scroll between 100-500ms (or 66-333ms for horizontal) depending on how far outside the viewport the mouse has moved.

This PoC will print debug info on output showing the current scroll speed (in ms) and how many pixels beyond the boundary the cursor is. Example output below (trimmed for brevity; the real output streams by quickly):

```
scroll=500 out of bounds 1 by 16
scroll=500 out of bounds 1 by 17
scroll=500 out of bounds 1 by 18
scroll=250 out of bounds 1 by 20
scroll=250 out of bounds 1 by 22
```

Aside from making sure scrolling continues to work properly, I'm soliciting feedback on the speed and how it ought to be adjusted.