### PR TITLE
Implement F1 key to bring up manual page

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -805,7 +805,9 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
     def init_help_menu(self) -> None:
         """Create the Help menu."""
         menu_help = Menu(menubar(), "~Help")
-        menu_help.add_button("Guiguts ~Manual", self.show_help_manual, "F1")
+        menu_help.add_button(
+            "Guiguts ~Manual", self.show_help_manual, "F1", force_main_only=True
+        )
         menu_help.add_button("About ~Guiguts", self.help_about)
         menu_help.add_button("~Regex Quick Reference", self.show_help_regex)
         menu_help.add_button(

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -805,7 +805,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
     def init_help_menu(self) -> None:
         """Create the Help menu."""
         menu_help = Menu(menubar(), "~Help")
-        menu_help.add_button("Guiguts ~Manual", self.show_help_manual)
+        menu_help.add_button("Guiguts ~Manual", self.show_help_manual, "F1")
         menu_help.add_button("About ~Guiguts", self.help_about)
         menu_help.add_button("~Regex Quick Reference", self.show_help_regex)
         menu_help.add_button(

--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -102,6 +102,8 @@ class FootnoteRecord:
 class FootnoteCheckerDialog(CheckerDialog):
     """Minimal class to identify dialog type."""
 
+    manual_page = "Tools_Menu#Footnote_Fixup"
+
 
 class FootnoteChecker:
     """Find, check & record footnotes."""

--- a/src/guiguts/html_convert.py
+++ b/src/guiguts/html_convert.py
@@ -53,6 +53,7 @@ class HTMLMarkupTypes(StrEnum):
 class HTMLGeneratorDialog(ToplevelDialog):
     """Dialog for converting text file to HTML."""
 
+    manual_page = "HTML_Menu#HTML_Generator"
     book_title = None
 
     def __init__(self) -> None:

--- a/src/guiguts/illo_sn_fixup.py
+++ b/src/guiguts/illo_sn_fixup.py
@@ -67,9 +67,13 @@ class IlloSNCheckerDialog(CheckerDialog):
 class IlloCheckerDialog(IlloSNCheckerDialog):
     """Minimal class to identify dialog type."""
 
+    manual_page = "Tools_Menu#Illustration_Fixup"
+
 
 class SNCheckerDialog(IlloSNCheckerDialog):
     """Minimal class to identify dialog type."""
+
+    manual_page = "Tools_Menu#Sidenote_Fixup"
 
 
 class IlloSNChecker:

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -66,7 +66,11 @@ class Menu(tk.Menu):
             parent.add_cascade(command_args)
 
     def add_button(
-        self, label: str, handler: str | Callable[[], Any], accel: str = ""
+        self,
+        label: str,
+        handler: str | Callable[[], Any],
+        accel: str = "",
+        force_main_only: bool = False,
     ) -> None:
         """Add a button to the menu.
 
@@ -80,6 +84,7 @@ class Menu(tk.Menu):
               on the button, and will be bound to the same action as the menu
               button. "Cmd/Ctrl" means `Cmd` key on Mac; `Ctrl` key on
               Windows/Linux.
+            force_main_only: True to only bind to the main window, not other dialogs
         """
         (label_tilde, label_txt) = process_label(label)
         (accel, key_event) = process_accel(accel)
@@ -97,6 +102,9 @@ class Menu(tk.Menu):
             bind_all = True
             # Handler is function, so may need key binding
             command = handler
+
+        if force_main_only:
+            bind_all = False
 
         # If key binding given, then bind it
         if accel:

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -689,6 +689,8 @@ class ScrolledReadOnlyText(tk.Text):
 class MessageLogDialog(ToplevelDialog):
     """A dialog that displays error/info messages."""
 
+    manual_page = "View_Menu#Message_Log"
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize messagelog dialog."""
         super().__init__("Message Log", *args, **kwargs)

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -33,6 +33,8 @@ COMBO_SEPARATOR = "―" * 20
 class PreferencesDialog(ToplevelDialog):
     """A dialog that displays settings/preferences."""
 
+    manual_page = "Edit_Menu#Preferences"
+
     def __init__(self) -> None:
         """Initialize preferences dialog."""
         super().__init__("Settings", resize_x=False, resize_y=False)
@@ -225,6 +227,8 @@ class ComposeSequenceDialog(OkApplyCancelDialog):
     Attributes:
         dict: Dictionary mapping sequence of keystrokes to character.
     """
+
+    manual_page = "Tools_Menu#Compose_Sequence"
 
     def __init__(self) -> None:
         """Initialize compose sequence dialog."""
@@ -577,6 +581,8 @@ def init_greek_breathing(char: str, base: str, uiota: str = "") -> None:
 class ComposeHelpDialog(ToplevelDialog):
     """A dialog to show the compose sequences."""
 
+    manual_page = "Tools_Menu#Compose_Sequence"
+
     def __init__(self) -> None:
         """Initialize class members from page details."""
         super().__init__("List of Compose Sequences")
@@ -738,6 +744,7 @@ class UnicodeBlockDialog(ToplevelDialog):
     """A dialog that displays a block of Unicode characters, and allows
     the user to click on them to insert them into text window."""
 
+    manual_page = "Tools_Menu#Unicode_Blocks"
     commonly_used_characters_name = "Commonly Used Characters"
 
     def __init__(self) -> None:
@@ -840,6 +847,7 @@ class UnicodeSearchDialog(ToplevelDialog):
     given partial name match or Unicode ordinal, and allows
     the user to insert it into text window."""
 
+    manual_page = "Tools_Menu#Unicode_Search/Entry"
     CHAR_COL_ID = "#1"
     CHAR_COL_HEAD = "Char"
     CHAR_COL_WIDTH = 50

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -46,13 +46,19 @@ DEFAULT_STEALTH_SCANNOS = "en-common.json"
 class BasicFixupCheckerDialog(CheckerDialog):
     """Minimal class to identify dialog type."""
 
+    manual_page = "Tools_Menu#Basic_Fixup"
+
 
 class UnmatchedCheckerDialog(CheckerDialog):
     """Minimal class to identify dialog type."""
 
+    manual_page = 'Tools_Menu#"Unmatched"_Submenu'
+
 
 class AsteriskCheckerDialog(CheckerDialog):
     """Minimal class to identify dialog type."""
+
+    manual_page = "Navigation#Find_Asterisks_w/o_Slash"
 
 
 def tool_save() -> bool:
@@ -240,6 +246,7 @@ class PageSepAutoType(StrEnum):
 class PageSeparatorDialog(ToplevelDialog):
     """Dialog for fixing page separators."""
 
+    manual_page = "Tools_Menu#Page_Separator_Fixup"
     SEPARATOR_REGEX = r"^-----File: .+"
     BTN_WIDTH = 16
 
@@ -1187,6 +1194,8 @@ def proofer_comment_check() -> None:
         """Minimal class to identify dialog type so that it can exist
         simultaneously with other checker dialogs."""
 
+        manual_page = "Navigation#Find_Proofer_Comments_(_[**notes]_)"
+
     checker_dialog = ProoferCommentCheckerDialog.show_dialog(
         "Proofer Comments", rerun_command=proofer_comment_check
     )
@@ -1262,6 +1271,8 @@ def asterisk_check() -> None:
 
 class TextMarkupConvertorDialog(ToplevelDialog):
     """Dialog for converting DP markup to text markup."""
+
+    manual_page = "Text_Menu#Convert_Markup"
 
     def __init__(self) -> None:
         """Initialize text markup convertor dialog."""
@@ -1385,6 +1396,8 @@ class Scanno(dict):
 
 class ScannoCheckerDialog(CheckerDialog):
     """Dialog to handle stealth scanno checks."""
+
+    manual_page = "Tools_Menu#Stealth_Scannos"
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize scanno checker dialog."""
@@ -1814,6 +1827,8 @@ def convert_to_curly_quotes() -> None:
 
 class CurlyQuotesDialog(CheckerDialog):
     """Dialog to handle curly quotes checks."""
+
+    manual_page = "Tools_Menu#Convert_to_Curly_Quotes"
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize curly quotes checker dialog."""

--- a/src/guiguts/page_details.py
+++ b/src/guiguts/page_details.py
@@ -107,6 +107,8 @@ class PageDetailsDialog(OkApplyCancelDialog):
         changed: True if any changes have been made in dialog.
     """
 
+    manual_page = "File_Menu#Configure_Page_Markers_and_Page_Labels"
+
     def __init__(self, page_details: PageDetails) -> None:
         """Initialize class members from page details."""
         super().__init__("Configure Page Labels")

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -42,6 +42,7 @@ class SearchDialog(ToplevelDialog):
         selection: True to restrict counting, replacing, etc., to selected text.
     """
 
+    manual_page = "Searching"
     # Cannot be initialized here, since Tk root may not be created yet
     selection: tk.BooleanVar
 
@@ -471,6 +472,8 @@ class SearchDialog(ToplevelDialog):
 
         class FindAllCheckerDialog(CheckerDialog):
             """Minimal class to identify dialog typepylint."""
+
+            manual_page = "Searching#Find_All"
 
         checker_dialog = FindAllCheckerDialog.show_dialog(
             "Search Results", rerun_command=self.findall_clicked

--- a/src/guiguts/spell.py
+++ b/src/guiguts/spell.py
@@ -61,6 +61,8 @@ class SpellingError(FindMatch):
 class SpellCheckerDialog(CheckerDialog):
     """Minimal class to identify dialog type."""
 
+    manual_page = "Tools_Menu#Spelling"
+
 
 class SpellChecker:
     """Provides spell check functionality."""

--- a/src/guiguts/tools/jeebies.py
+++ b/src/guiguts/tools/jeebies.py
@@ -55,6 +55,8 @@ class DictionaryNotFoundError(Exception):
 class JeebiesCheckerDialog(CheckerDialog):
     """Minimal class to identify dialog type."""
 
+    manual_page = "Tools_Menu#Jeebies"
+
 
 class JeebiesChecker:
     """Provides jeebies check functionality."""

--- a/src/guiguts/tools/levenshtein.py
+++ b/src/guiguts/tools/levenshtein.py
@@ -57,6 +57,8 @@ class LevenshteinEditDistance(StrEnum):
 class LevenshteinCheckerDialog(CheckerDialog):
     """Minimal class to identify dialog type."""
 
+    manual_page = "Tools_Menu#Word_Distance_Check"
+
 
 class LevenshteinChecker:
     """Provide Levenshtein edit distance functionality."""

--- a/src/guiguts/tools/pptxt.py
+++ b/src/guiguts/tools/pptxt.py
@@ -14,6 +14,8 @@ from guiguts.widgets import ToolTip
 class PPtxtCheckerDialog(CheckerDialog):
     """Minimal class to identify dialog type."""
 
+    manual_page = "Tools_Menu#PPtxt"
+
 
 REPORT_LIMIT = 5  # Max number of times to report same issue for some checks
 

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -3,6 +3,7 @@
 import tkinter as tk
 from tkinter import ttk
 from typing import Any, Optional, TypeVar, Callable
+import webbrowser
 
 import regex as re
 
@@ -65,7 +66,11 @@ class ToplevelDialog(tk.Toplevel):
 
         self._do_config()
         self.save_config = False
-        self.bind("<Configure>", self._handle_config)
+        self.bind("<Configure>", self._handle_config)  #
+
+        # Bind help key to open obligatory manual page
+        assert hasattr(self, "manual_page")
+        self.bind("<F1>", lambda event: self.show_manual_page())
 
         self.wm_withdraw()
         self.wm_attributes("-fullscreen", False)
@@ -304,6 +309,15 @@ class ToplevelDialog(tk.Toplevel):
             return config_dict[self.__class__.__name__]
         except KeyError:
             return None
+
+    def show_manual_page(self) -> None:
+        """Show the manual page for the dialog."""
+        try:
+            suffix = type(self).manual_page  # type:ignore[attr-defined]
+        except AttributeError:
+            return
+        prefix = "https://www.pgdp.net/wiki/PPTools/Guiguts/Guiguts_2_Manual/"
+        webbrowser.open(prefix + suffix)
 
 
 class OkApplyCancelDialog(ToplevelDialog):

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -66,7 +66,7 @@ class ToplevelDialog(tk.Toplevel):
 
         self._do_config()
         self.save_config = False
-        self.bind("<Configure>", self._handle_config)  #
+        self.bind("<Configure>", self._handle_config)
 
         # Bind help key to open obligatory manual page
         assert hasattr(self, "manual_page")

--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -171,6 +171,7 @@ class WordFrequencyDialog(ToplevelDialog):
         text: Text widget to contain results.
     """
 
+    manual_page = "Tools_Menu#Word_Frequency"
     CHAR_DISPLAY: dict[str, str] = {
         " ": "*space*",
         "\u00a0": "*nbsp*",


### PR DESCRIPTION
In any dialog (or main window) press F1 function key to bring up a relevant manual page.

Note that if your function keys are set up to perform other actions by default, you may need to press `<fn>+F1`, or something similar.