### PR TITLE
Fix duplicate ellipsis/ double punctuation error from pptext

### DIFF
--- a/src/guiguts/tools/pptxt.py
+++ b/src/guiguts/tools/pptxt.py
@@ -941,7 +941,7 @@ def specials_check(project_dict: ProjectDict) -> None:
         # The following check for double punctuation consists of:
         #
         # GENERAL TEST
-        pattern = r",\.|\.,|,,|(?!<\.)\.\.(?!\.)"
+        pattern = r",\.|\.,|,,|(?<!\.)\.\.(?!\.)"
         if re.search(pattern, line):
             # Here if possible issue.
             #


### PR DESCRIPTION
Typo in regex caused text line `word...` to be reported as a "double punctuation" error.

Testing notes: lots of false positive "double punctuation" occurrences can be seen by running pptext on [the file from the linked issue](https://github.com/user-attachments/files/18286236/pptext.zip)

Fixes #624 