### PR TITLE
Lower priority of SPOTLIGHT highlight tag

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -3218,10 +3218,10 @@ class MainText(tk.Text):
         # ** THE ORDER MATTERS HERE **
         #
         for tag, colors in (
-            (HighlightTag.SPOTLIGHT, HighlightColors.SPOTLIGHT),
             (HighlightTag.QUOTEMARK, HighlightColors.QUOTEMARK),
             # "sel" is for active selections - don't override the default color
             ("sel", None),
+            (HighlightTag.SPOTLIGHT, HighlightColors.SPOTLIGHT),
             (HighlightTag.PAREN, HighlightColors.PAREN),
             (HighlightTag.CURLY_BRACKET, HighlightColors.CURLY_BRACKET),
             (HighlightTag.SQUARE_BRACKET, HighlightColors.SQUARE_BRACKET),


### PR DESCRIPTION
Testing notes:

Load a file and run a WF check, e.g. hyphens (as noted in the original ticket). Clicking on a match will take you to that text in the file and highlight with SPOTLIGHT (e.g. orange background in light theme). Select one or more characters in the text. On the master branch, the cursor disappears and you can't see what's selected. On this branch, you can see what you've selected. (Should be the same if you select with keyboard or mouse.)

Fixes #631 