### PR TITLE
Fix a couple column selection bugs

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1521,7 +1521,7 @@ class MainText(tk.Text):
         return "break"  # Skip default behavior
 
     def column_select_click_action(self, start: IndexRowCol) -> None:
-        """Do that needs to be done when the user clicks to start column selection.
+        """Do what needs to be done when the user clicks to start column selection.
         Since user can click first then press modifier key, or hold modifier while
         clicking, there are two routes into this point.
 


### PR DESCRIPTION
1. Exception on non-Mac platforms when using column select for first time due to non-initialized variable
2. Beginning drag before pressing modifier key didn't initialize everything that was needed, so when you dragged outside the window it reverted to slow
continuous scroll (mac-only)