### PR TITLE
Playing around with highlight colors.

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -292,17 +292,17 @@ class HighlightColors:
     # Must be a definition for each available theme
     QUOTEMARK = {
         "Light": {"bg": "#a08dfc", "fg": "black"},
-        "Dark": {"bg": "#a08dfc", "fg": "white"},
+        "Dark": {"bg": "darkmagenta", "fg": "white"},
     }
 
     SPOTLIGHT = {
         "Light": {"bg": "orange", "fg": "black"},
-        "Dark": {"bg": "orange", "fg": "white"},
+        "Dark": {"bg": "darkorange", "fg": "white"},
     }
 
     PAREN = {
         "Light": {"bg": "violet", "fg": "white"},
-        "Dark": {"bg": "violet", "fg": "white"},
+        "Dark": {"bg": "mediumpurple", "fg": "white"},
     }
 
     CURLY_BRACKET = {
@@ -322,17 +322,17 @@ class HighlightColors:
 
     CURLY_DOUBLE_QUOTE = {
         "Light": {"bg": "limegreen", "fg": "white"},
-        "Dark": {"bg": "limegreen", "fg": "white"},
+        "Dark": {"bg": "teal", "fg": "white"},
     }
 
     STRAIGHT_SINGLE_QUOTE = {
         "Light": {"bg": "grey", "fg": "white"},
-        "Dark": {"bg": "grey", "fg": "white"},
+        "Dark": {"bg": "sienna", "fg": "white"},
     }
 
     CURLY_SINGLE_QUOTE = {
         "Light": {"bg": "dodgerblue", "fg": "white"},
-        "Dark": {"bg": "dodgerblue", "fg": "white"},
+        "Dark": {"bg": "#b23e0c", "fg": "white"},
     }
 
     ALIGNCOL = {


### PR DESCRIPTION
The main one I really want to see changed is the spotlight color, from `orange` to `darkorange`, at least for the dark themes -- white text just doesn't show as well on `orange` as it does on the `darkorange`.

The rest is playing around only for the colors for the dark themes to try to get better contrast between text color and background color. Some of what I did was to change the double-quotes to use related but different colors, and the straight quotes, ditto, and make them (for dark theme -- I didn't touch the light theme) a bit more noticeable.

It occurrred to me later that it might be better to have straight quotes' colors be related, and curlies' colors be related, but that can be a talking point.

My feelings will absolutely not be hurt if y'all throw up your hands in horror. 😁 (on everything but the spotlight color change :D ) I'm starting this out as a draft. No big hurry.