### PR TITLE
Improve behavior of "R&S"

### DIFF
--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -548,8 +548,12 @@ class SearchDialog(ToplevelDialog):
             start_index = maintext().index(MARK_FOUND_START)
             end_index = maintext().index(MARK_FOUND_END)
         except tk.TclError:
-            sound_bell()
-            self.display_message("No text found to replace")
+            # If Replace & Search, then even if we can't Replace, do a Search
+            if search_again:
+                self.search_clicked(opposite_dir=opposite_dir)
+            else:
+                sound_bell()
+                self.display_message("No text found to replace")
             return "break"
 
         match_text = maintext().get(start_index, end_index)


### PR DESCRIPTION
If unable to do a replace and search, most likely because the user already did a replace, then just do the "search".

Fixes #649

Testing notes: see issue