### PR TITLE
Add default extension during File-->Save As

### DIFF
--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -294,10 +294,29 @@ class File:
         Returns:
             Chosen filename or None if save is cancelled
         """
+        # If no current extension, or ".txt" extension, set extension to ".html"
+        # if it's an HTML file. Similarly for text files, otherwise leave alone.
+        cur_ext = os.path.splitext(self.filename)[1]
+        html_file = maintext().get("1.0", "1.end") == "<!DOCTYPE html>"
+        if html_file and cur_ext in ("", ".txt", ".html"):
+            extension = ".html"
+        elif not html_file and cur_ext in ("", ".txt"):
+            extension = ".txt"
+        else:
+            extension = cur_ext
+        match extension:
+            case ".html":
+                file_type = "HTML files"
+            case ".txt":
+                file_type = "Text files"
+            case _:
+                file_type = f"{extension} files"
+        suggested_fn = os.path.splitext(self.filename)[0] + extension
+
         if fn := filedialog.asksaveasfilename(
-            initialfile=os.path.basename(self.filename),
-            initialdir=os.path.dirname(self.filename),
-            filetypes=[("All files", "*")],
+            initialfile=os.path.basename(suggested_fn),
+            initialdir=os.path.dirname(suggested_fn),
+            filetypes=[(file_type, f"*{extension}"), ("All files", "*")],
             title="Save As",
         ):
             self.store_recent_file(fn)

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -313,8 +313,11 @@ class File:
                 file_type = f"{extension} files"
         suggested_fn = os.path.splitext(self.filename)[0] + extension
 
+        initialfile = (
+            os.path.basename(suggested_fn) if self.filename else f"untitled{extension}"
+        )
         if fn := filedialog.asksaveasfilename(
-            initialfile=os.path.basename(suggested_fn),
+            initialfile=initialfile,
             initialdir=os.path.dirname(suggested_fn),
             filetypes=[(file_type, f"*{extension}"), ("All files", "*")],
             title="Save As",


### PR DESCRIPTION
First detect if the file is an HTML file, i.e. has the first line `<!DOCTYPE html>`
Also check if the filename currently has an extension. If no extension, or extension is `.txt`, then suggest `.html` for HTML files.
If no extension suggest `.txt` for non-HTML files. Use the suggested extension when pre-filling the
Save As dialog. User can override and set their own extension if they want to.

Fixes #651