### PR TITLE
Fix Find All highlight priority

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -920,6 +920,7 @@ class CheckerDialog(ToplevelDialog):
             maintext().set_insert_index(
                 IndexRowCol(start), focus=(focus and not is_mac())
             )
+            maintext().clear_selection()
         self.lift()
 
     @classmethod


### PR DESCRIPTION
When Find All was done inside a selection, the spotlight match was hidden by the selection.
Fix by clearing selection when a spotlight is displayed, usually by clicking a message line in a checker dialog, also when the dialog is created.

Fixes #660 