### PR TITLE
Change "not a valid PrefKey" to a debug message

### DIFF
--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -278,7 +278,7 @@ class Preferences:
                 try:
                     self.dict[PrefKey(key)] = value
                 except ValueError:
-                    logger.warning(f"'{key}' is not a valid PrefKey - ignored")
+                    logger.debug(f"'{key}' is not a valid PrefKey - ignored")
 
     def run_callbacks(self) -> None:
         """Run all defined callbacks, passing value as argument.


### PR DESCRIPTION
Most likely reason is that a later release has removed a PrefKey (or potentially user has edited Prefs file). The previous message just said that the invalid PrefKey was ignored, which caused user concern. So, just output if in debug mode, so only devs see it.

Fixes #659 

Testing notes:
Easiest way is probably to edit the Prefs file and change a key, e.g. `auto_image` to `auto_imagx`. 
In master this will generate a warning. In this branch just a debug message (and nothing at all if not run with `-d` command line option).