### PR TITLE
Don't rewrap thought breaks

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -2563,6 +2563,8 @@ class MainText(tk.Text):
             wrap_params: Wrapping parameters.
             wrapper: TextWrapper object to perform the wrapping - re-used for efficiency.
         """
+        if paragraph.startswith("       *" * 5):
+            return
         # Remove leading/trailing space
         paragraph = paragraph.strip()
         # Replace all multiple whitespace with single space


### PR DESCRIPTION
Standard text thought breaks should not be rewrapped, because it turns
`       *       *       *       *       *`
into
`* * * * *`

Fixes #656