### PR TITLE
Add checker dialog undo update mechanism

### DIFF
--- a/src/guiguts/illo_sn_fixup.py
+++ b/src/guiguts/illo_sn_fixup.py
@@ -616,6 +616,13 @@ def illosn_check(tag_type: str) -> None:
             _the_sn_checker.checker_dialog = checker_dialog
         the_checker = _the_sn_checker
 
+    # A move can happen via and undo/redo operation, in which case call update method
+    checker_dialog.add_undo_redo_callback(
+        lambda: the_checker.update_after_move(
+            tag_type, the_checker.get_selected_illosn_index()
+        ),
+    )
+
     ToolTip(
         checker_dialog.text,
         "\n".join(

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -935,12 +935,11 @@ class MainText(tk.Text):
         """Remove callback function from a list of functions to be called when
         <<Undo>> or <<Redo>> virtual events happen.
 
-        Should only be called if callback was added earlier.
+        OK if called for a dialog that didn't set up a callback.
 
         Args:
             key: Key to identify the caller, e.g. dialog class name
         """
-        assert key in self.undo_redo_callbacks
         if key in self.undo_redo_callbacks:
             del self.undo_redo_callbacks[key]
 

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -460,6 +460,15 @@ class MainText(tk.Text):
             "<<Modified>>", lambda _event: self.modify_flag_changed_callback()
         )
 
+        # Set up callbacks when Undo/Redo is executed
+        self.undo_redo_callbacks: dict[str, Callable[[], None]] = {}
+        self.bind_event(
+            "<<Undo>>", lambda _event: self._call_undo_redo_callbacks(), add=True
+        )
+        self.bind_event(
+            "<<Redo>>", lambda _event: self._call_undo_redo_callbacks(), add=True
+        )
+
         self.bind_event("<<Cut>>", lambda _event: self.smart_cut(), force_break=False)
         self.bind_event("<<Copy>>", lambda _event: self.smart_copy(), force_break=False)
         self.bind_event(
@@ -910,6 +919,37 @@ class MainText(tk.Text):
             self.colnumbers.redraw()
             self.peer_colnumbers.redraw()
 
+    def add_undo_redo_callback(self, key: str, func: Callable[[], None]) -> None:
+        """Add callback function to a list of functions to be called when
+        <<Undo>> or <<Redo>> virtual events happen.
+
+        Calling routine has responsibility to remove callback when no longer needed.
+
+        Args:
+            key: Key to identify the caller, e.g. dialog class name
+            func: Callback function to be added to list.
+        """
+        self.undo_redo_callbacks[key] = func
+
+    def remove_undo_redo_callback(self, key: str) -> None:
+        """Remove callback function from a list of functions to be called when
+        <<Undo>> or <<Redo>> virtual events happen.
+
+        Should only be called if callback was added earlier.
+
+        Args:
+            key: Key to identify the caller, e.g. dialog class name
+        """
+        assert key in self.undo_redo_callbacks
+        if key in self.undo_redo_callbacks:
+            del self.undo_redo_callbacks[key]
+
+    def _call_undo_redo_callbacks(self) -> None:
+        """Causes all functions registered via `add_undo_redo_callback`
+        to be called after idle."""
+        for func in self.undo_redo_callbacks.values():
+            self.after_idle(func)
+
     def add_config_callback(self, func: Callable[[], None]) -> None:
         """Add callback function to a list of functions to be called when
         widget's configuration changes (e.g. width or height).
@@ -920,7 +960,7 @@ class MainText(tk.Text):
         self.config_callbacks.append(func)
 
     def _call_config_callbacks(self) -> None:
-        """Causes all functions registered via ``add_config_callback`` to be called."""
+        """Causes all functions registered via `add_config_callback` to be called."""
         for func in self.config_callbacks:
             func()
 


### PR DESCRIPTION
If a checker dialog makes a change, e.g. moving an illustration down to a paragraph break, it may re-run the tool. However, if the user does Undo or Redo, there was no way to flag that the tool needed re-running again.

This commit adds such a mechanism. The mechanism is based within maintext, since that is where Undo/Redo occur, but convenience functions have been added to CheckerDialog because it is probably checkers that will want to take advantage of it.

The checker dialog, e.g. Illo & sidenote fixup, registers a function to be called on undo/redo. The base checker class handles registering that with maintext and removing it when the dialog is deleted.

Implemented for Illo/SN fixups, as an example of what could be done for any checker tool - it isn't needed for all checkers.

Note that if you have both the Illo and the SN dialog popped at the same time, when you do an undo, it will undo the most recent change and will update both the illo and SN checker dialogs, which might mean that the one you were not using becomes the focus one. The moral of that tale is, probably best not to work simultaneously on illos and SNs and then use Undo/Redo - unlikely that a PPer would do that anyway. Similarly, if you have the Illo dialog visible, then go and make some other manual edit to the text, then undo it, there's (currently) no way for the code to know that the change wasn't via the illo dialog, so it will update the illo dialog and select the illo message that was current at the point of undoing.

It's possible that further work could be done to make this cleverer, but it would be getting rather complex and prone to error IMO, so not doing it for now.

Another possible solution to the whole issue would be to disable the illo (and/or SN) dialog list if the user does an undo/redo until such time as they re-run the tool manually. This would possibly be safer, but not as convenient. Your thoughts are welcome. (See #669 for this type of solution)

Fixes #655 