### PR TITLE
Alternative to #668 (less-smart undo)

### DIFF
--- a/src/guiguts/illo_sn_fixup.py
+++ b/src/guiguts/illo_sn_fixup.py
@@ -602,6 +602,7 @@ def illosn_check(tag_type: str) -> None:
         f"{tag_type} Check Results",
         rerun_command=lambda: illosn_check(tag_type),
         show_suspects_only=True,
+        clear_on_undo_redo=True,
     )
     if tag_type == "Illustration":
         if _the_illo_checker is None:
@@ -642,6 +643,8 @@ def illosn_check(tag_type: str) -> None:
     ).grid(column=1, row=0, sticky="NSW")
     the_checker.run_check(tag_type)
     display_illosn_entries(tag_type)
+    # Reselect correct entry in case this re-run was after an undo/redo
+    checker_dialog.select_entry_after_undo_redo()
 
 
 def display_illosn_entries(tag_type: str) -> None:


### PR DESCRIPTION
See [#668](https://github.com/DistributedProofreaders/guiguts-py/issues/668) for main attempt to solve this issue.

In this commit, if you do an undo/redo, the list of
messages in the illo/SN checkers is removed until you
manually click Re-run.

This is just to see what it's like, and what you think is
best. It would probably be possible (though more
complicated) to gray out the text instead of removing it
and intercept user attempts to click on the messages and
either do nothing or put up a message saying "you need to
re-run the tool".