### PR TITLE
Fix exception in HTML autogen from bad footnote

### DIFF
--- a/src/guiguts/html_convert.py
+++ b/src/guiguts/html_convert.py
@@ -1118,6 +1118,12 @@ def html_convert_footnotes() -> None:
     ):
         # Find end of footnote
         fn_end = maintext().search(r"]</p>$", fn_start, tk.END, regexp=True)
+        if not fn_end:
+            logger.error(
+                f"No paragraph break at footnote end: {maintext().get(f'{fn_start}+3c', f'{fn_start} lineend')}"
+            )
+            fn_end = f"{fn_start}+1l"
+            continue
         # Extract label for footnote
         fn_label_end = maintext().search(":", fn_start, tk.END)
         fn_label = maintext().get(f"{fn_start}+13c", fn_label_end)


### PR DESCRIPTION
If the last footnote in the file doesn't have a blank line after it, the search for ]</p> fails, and a bad index is used further down.

Output an error message instead.