### PR TITLE
Improve behavior if HTML autogen errors

### DIFF
--- a/src/guiguts/html_convert.py
+++ b/src/guiguts/html_convert.py
@@ -140,14 +140,18 @@ def html_autogenerate() -> None:
             icon=messagebox.QUESTION,
         )
         if reload:
-            old_filename = (
-                the_file().filename
-            )  # Save name because load_file will overwrite it
+            # Save name because load_file will overwrite it
+            old_filename = the_file().filename
             the_file().load_file(backup_fn)
-            the_file().filename = old_filename  # Restore original filename
-            the_file().store_recent_file(
-                old_filename
-            )  # Put it at the top of the recent files list
+            # Restore original filename
+            the_file().filename = old_filename
+            # Put it at the top of the recent files list
+            the_file().store_recent_file(old_filename)
+        # Go to error line number if available
+        line_num, is_line_num = re.subn(r"Line (\d+):.*", r"\1", str(exc))
+        if is_line_num:
+            maintext().set_insert_index(IndexRowCol(int(line_num), 0))
+
     Busy.unbusy()
 
 

--- a/src/guiguts/html_convert.py
+++ b/src/guiguts/html_convert.py
@@ -136,7 +136,7 @@ def html_autogenerate() -> None:
         reload = messagebox.askokcancel(
             title="Re-load backup file?",
             message="An error occurred during HTML autogeneration,\nand the file was not completely converted.",
-            detail='Click "OK" to re-load pre-conversion backup file,\nor "Cancel" to explore partially converted file.',
+            detail='Click "OK" to re-load pre-conversion backup file,\nor "Cancel" to explore partially converted file (see manual).',
             icon=messagebox.QUESTION,
         )
         if reload:


### PR DESCRIPTION
1. Output line number of snippet of text in error message to aid user in finding the problem
2. Raise exceptions throughout to give consistent error behavior
3. If an error occurs ask user if they want to load the pre-conversion backup file. If they do, load it but keep the current filename.

Fixes #687 

NTS: Merge after #686