### PR TITLE
Don't write to Search message if no dialog

### DIFF
--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -652,7 +652,8 @@ class SearchDialog(ToplevelDialog):
         Args:
             message: Message to be displayed - clears message if arg omitted
         """
-        self.message["text"] = message
+        if self.message.winfo_exists():
+            self.message["text"] = message
 
 
 def show_search_dialog() -> None:

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -20,6 +20,7 @@ from guiguts.widgets import (
     ToolTip,
     register_focus_widget,
     process_accel,
+    Busy,
 )
 
 logger = logging.getLogger(__package__)
@@ -479,6 +480,7 @@ class SearchDialog(ToplevelDialog):
             "Search Results", rerun_command=self.findall_clicked
         )
         if not checker_dialog.winfo_exists():
+            Busy.unbusy()
             return
         ToolTip(
             checker_dialog.text,
@@ -493,6 +495,7 @@ class SearchDialog(ToplevelDialog):
         )
         checker_dialog.reset()
         if not self.winfo_exists():
+            Busy.unbusy()
             return
         # Construct opening line describing the search
         desc_reg = "regex" if preferences.get(PrefKey.SEARCHDIALOG_REGEX) else "string"

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -478,6 +478,8 @@ class SearchDialog(ToplevelDialog):
         checker_dialog = FindAllCheckerDialog.show_dialog(
             "Search Results", rerun_command=self.findall_clicked
         )
+        if not checker_dialog.winfo_exists():
+            return
         ToolTip(
             checker_dialog.text,
             "\n".join(
@@ -490,6 +492,8 @@ class SearchDialog(ToplevelDialog):
             use_pointer_pos=True,
         )
         checker_dialog.reset()
+        if not self.winfo_exists():
+            return
         # Construct opening line describing the search
         desc_reg = "regex" if preferences.get(PrefKey.SEARCHDIALOG_REGEX) else "string"
         prefix = f'Search for {desc_reg} "'


### PR DESCRIPTION
If user searches and quickly destroys search dialog, it can end up trying to write to the message label. Fixed by checking it exists first.

Fixes #690