### PR TITLE
Improve how code is executed on destroying dialog

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -453,9 +453,6 @@ class CheckerDialog(ToplevelDialog):
         """Override method that tidies up when the dialog is destroyed.
 
         Needs to remove the undo_redo callback if there is one.
-
-        Args:
-            event: identifies the widget being destroyed.
         """
         super().on_destroy()
         maintext().remove_undo_redo_callback(self.__class__.__name__)

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -449,19 +449,15 @@ class CheckerDialog(ToplevelDialog):
         if entry_index is not None:
             self.select_entry_by_index(entry_index)
 
-    def tidy_up(self, event: tk.Event) -> None:
-        """Tidy up when the dialog is destroyed.
+    def on_destroy(self) -> None:
+        """Override method that tidies up when the dialog is destroyed.
 
-        Calls the reset method which may be overridden.
+        Needs to remove the undo_redo callback if there is one.
 
         Args:
             event: identifies the widget being destroyed.
         """
-        # Since this method is bound to the "<Destroy>" event on the dialog,
-        # it will also be called for all child widgets - ignore them.
-        if not issubclass(type(event.widget), ToplevelDialog):
-            return
-        super().tidy_up(event)
+        super().on_destroy()
         maintext().remove_undo_redo_callback(self.__class__.__name__)
 
     def new_section(self) -> None:

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -293,10 +293,6 @@ class SearchDialog(ToplevelDialog):
         self.config_width()
         self.allow_geometry_save()
 
-    def reset(self) -> None:
-        """Called when dialog is reset/destroyed - remove search highlights."""
-        maintext().remove_search_highlights()
-
         class SearchParamsState:
             """Ephemeral container to store information about search parameters.
 
@@ -312,6 +308,10 @@ class SearchDialog(ToplevelDialog):
 
         # container to track search parameter state
         self.search_params_state = SearchParamsState()
+
+    def reset(self) -> None:
+        """Called when dialog is reset/destroyed - remove search highlights."""
+        maintext().remove_search_highlights()
 
     def show_multi_replace(self, show: bool, resize: bool = True) -> None:
         """Show or hide the multi-replace buttons.

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -293,10 +293,9 @@ class SearchDialog(ToplevelDialog):
         self.config_width()
         self.allow_geometry_save()
 
-        # Handle tag cleanup when search panel is closed
-        self.top_frame.bind(
-            "<Destroy>", lambda _event: maintext().remove_search_highlights()
-        )
+    def reset(self) -> None:
+        """Called when dialog is reset/destroyed - remove search highlights."""
+        maintext().remove_search_highlights()
 
         class SearchParamsState:
             """Ephemeral container to store information about search parameters.

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -87,7 +87,10 @@ class ToplevelDialog(tk.Toplevel):
         self.wm_deiconify()
 
         self.tooltip_list: list[ToolTip] = []
-        self.bind("<Destroy>", self.tidy_up)
+        # Bind to top_frame being destroyed because if binding is to dialog,
+        # function will be called for every child of dialog due to their
+        # "top level" bind tag
+        self.top_frame.bind("<Destroy>", lambda _: self.on_destroy())
 
         grab_focus(self)
 
@@ -164,18 +167,11 @@ class ToplevelDialog(tk.Toplevel):
         uk = re.sub("[a-z]>?$", lambda m: m.group(0).upper(), key_event)
         self.bind(uk, lambda _: handler())
 
-    def tidy_up(self, event: tk.Event) -> None:
+    def on_destroy(self) -> None:
         """Tidy up when the dialog is destroyed.
 
-        Calls the reset method which may be overridden.
-
-        Args:
-            event: identifies the widget being destroyed.
+        Also calls the reset method.
         """
-        # Since this method is bound to the "<Destroy>" event on the dialog,
-        # it will also be called for all child widgets - ignore them.
-        if not issubclass(type(event.widget), ToplevelDialog):
-            return
         for tooltip in self.tooltip_list:
             tooltip.destroy()
         self.tooltip_list = []

--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -442,7 +442,7 @@ class WordFrequencyDialog(ToplevelDialog):
         """Reset dialog."""
         super().reset()
         self.entries: list[WordFrequencyEntry] = []
-        if not self.winfo_exists():
+        if not self.text.winfo_exists():
             return
         self.text.delete("1.0", tk.END)
         self.message.set("")

--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -442,6 +442,7 @@ class WordFrequencyDialog(ToplevelDialog):
         """Reset dialog."""
         super().reset()
         self.entries: list[WordFrequencyEntry] = []
+        maintext().remove_spotlights()
         if not self.text.winfo_exists():
             return
         self.text.delete("1.0", tk.END)


### PR DESCRIPTION
1. Instead of binding to dialog, bind to `top_frame` so that binding is only called once, instead of for every dialog child.
2. Rename `tidy_up` to the more explicit `on_destroy`.
3. CheckerDialog just overrides `on_destroy`, calling the super method.
4. Search overrides the existing `reset` method instead of using an explicit binding.

Fixes #683 