### PR TITLE
Hide cursor in peer if text is selected

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -903,7 +903,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             """Format current selection range for statusbar.
 
             Returns:
-                "Start-End" for a regualar selection, and "R:rows C:cols" for column selection.
+                "Start-End" for a regular selection, and "R:rows C:cols" for column selection.
             """
             maintext().selection_cursor()
             ranges = maintext().selected_ranges()

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -2860,10 +2860,10 @@ class MainText(tk.Text):
 
     def selection_cursor(self) -> None:
         """Make the insert cursor (in)visible depending on selection."""
-        current = maintext().cget("insertontime")
-        ontime = 0 if maintext().selected_ranges() else 600
+        current = self.focus_widget().cget("insertontime")
+        ontime = 0 if self.selected_ranges() else 600
         if ontime != current:
-            maintext().configure(insertontime=ontime)
+            self.focus_widget().configure(insertontime=ontime)
 
     def is_dark_theme(self) -> bool:
         """Returns True if theme is dark, which is assumed to be the case if


### PR DESCRIPTION
This was already the case in maintext, but hadn't been adapted to work in the peer.

Fixes #692