### PR TITLE
Ensure FOOTNOTES heading has correct blank lines

### DIFF
--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -726,7 +726,7 @@ class File:
 
     def remove_page_flags(self) -> None:
         """Remove page flags."""
-        search_range = IndexRange(maintext().start(), maintext().end())
+        search_range = maintext().start_to_end()
         while match := maintext().find_match(
             PAGE_FLAG_REGEX,
             search_range,
@@ -747,11 +747,10 @@ class File:
         Returns:
             True if page marker flags were present.
         """
-        search_range = IndexRange(maintext().start(), maintext().end())
         mark = "1.0"
         flag_matches = maintext().find_matches(
             PAGE_FLAG_REGEX,
-            search_range,
+            maintext().start_to_end(),
             nocase=False,
             regexp=True,
         )
@@ -792,7 +791,7 @@ class File:
         regex = r"^\.bn +(.+?)\.png"
         flag_matches = maintext().find_matches(
             regex,
-            IndexRange(maintext().start(), maintext().end()),
+            maintext().start_to_end(),
             nocase=False,
             regexp=True,
         )
@@ -898,7 +897,7 @@ class File:
     def rewrap_cleanup(self) -> None:
         """Clean up all rewrap markers."""
         match_regex = r"^/[#$*FILPXCR]|^[#$*FILPXCR]/"
-        search_range = IndexRange(maintext().start(), maintext().end())
+        search_range = maintext().start_to_end()
         maintext().undo_block_begin()
         while beg_match := maintext().find_match(
             match_regex, search_range, regexp=True, nocase=True

--- a/src/guiguts/html_convert.py
+++ b/src/guiguts/html_convert.py
@@ -188,7 +188,7 @@ def html_convert_entities() -> None:
     maintext().replace_all("--", "—")
 
     # Find all < and > characters
-    search_range = IndexRange(maintext().start(), maintext().end())
+    search_range = maintext().start_to_end()
     while match := maintext().find_match("(<|>)", search_range, regexp=True):
         match_index = match.rowcol.index()
         match_text = maintext().get(match_index, f"{match_index} lineend")

--- a/src/guiguts/illo_sn_fixup.py
+++ b/src/guiguts/illo_sn_fixup.py
@@ -203,7 +203,7 @@ class IlloSNChecker:
     def run_check(self, tag_type: str) -> None:
         """Run the initial Illustration or Sidenote records check."""
         self.reset()
-        search_range = IndexRange(maintext().start(), maintext().end())
+        search_range = maintext().start_to_end()
         match_regex = (
             r"\[ *illustration" if tag_type == "Illustration" else r"\[ *sidenote"
         )

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1702,6 +1702,10 @@ class MainText(tk.Text):
         because text widget "end" is start of line below last char."""
         return self.rowcol(tk.END + "-1c")
 
+    def start_to_end(self) -> IndexRange:
+        """Return IndexRange from start to end of file."""
+        return IndexRange(self.start(), self.end())
+
     def move_to_selection_start(self, force_line: bool = False) -> str:
         """Set insert position to start of any selection text.
 
@@ -1964,8 +1968,8 @@ class MainText(tk.Text):
         self,
         search_string: str,
         text_range: IndexRange,
-        nocase: bool,
-        regexp: bool,
+        nocase: bool = False,
+        regexp: bool = False,
     ) -> list[FindMatch]:
         """Find all occurrences of string/regex in given range.
 

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -529,7 +529,7 @@ class PageSeparatorDialog(ToplevelDialog):
         """
         match = maintext().find_match(
             PageSeparatorDialog.SEPARATOR_REGEX,
-            IndexRange(maintext().start(), maintext().end()),
+            maintext().start_to_end(),
             nocase=False,
             regexp=True,
             backwards=False,
@@ -718,7 +718,7 @@ def unmatched_curly_quotes() -> None:
         """
         nestable = preferences.get(PrefKey.UNMATCHED_NESTABLE)
         prefix = "Unmatched: "
-        search_range = IndexRange(maintext().start(), maintext().end())
+        search_range = maintext().start_to_end()
         # Find open & close single quotes
         while match := maintext().find_match("[‘’]", search_range, regexp=True):
             quote_type = maintext().get_match_text(match)
@@ -834,7 +834,7 @@ def unmatched_block_markup() -> None:
         Args:
             dialog: UnmatchedCheckerDialog to receive error messages.
         """
-        search_range = IndexRange(maintext().start(), maintext().end())
+        search_range = maintext().start_to_end()
         prefix = "Badly formed markup: "
         while match := maintext().find_match(
             f"(/{ALL_BLOCKS_REG}|{ALL_BLOCKS_REG}/)",
@@ -952,7 +952,7 @@ def unmatched_markup_check(
 
     checker_dialog.reset()
 
-    search_range = IndexRange(maintext().start(), maintext().end())
+    search_range = maintext().start_to_end()
     # Find each piece of markup that matches the regex
     while match := maintext().find_match(
         match_reg, search_range, regexp=True, nocase=True
@@ -1092,7 +1092,7 @@ def fraction_convert(conversion_type: FractionConvertType) -> None:
 
     sel_ranges = maintext().selected_ranges()
     if not sel_ranges:
-        sel_ranges = [IndexRange(maintext().start(), maintext().end())]
+        sel_ranges = [maintext().start_to_end()]
 
     last_match = ""
     frac_slash = "⁄"
@@ -1185,7 +1185,7 @@ def proofer_comment_check() -> None:
 
     matches = maintext().find_matches(
         "[**",
-        IndexRange(maintext().start(), maintext().end()),
+        maintext().start_to_end(),
         nocase=False,
         regexp=False,
     )
@@ -1230,7 +1230,7 @@ def asterisk_check() -> None:
     # Match single or multiple asterisks including when separated by spaces, e.g. thought break
     matches = maintext().find_matches(
         r"\*( *\*)*",
-        IndexRange(maintext().start(), maintext().end()),
+        maintext().start_to_end(),
         nocase=False,
         regexp=True,
     )
@@ -1335,7 +1335,7 @@ class TextMarkupConvertorDialog(ToplevelDialog):
         """
         found = False
         maintext().undo_block_begin()
-        search_range = IndexRange(maintext().start(), maintext().end())
+        search_range = maintext().start_to_end()
         # Find each piece of markup that matches the regex
         while match := maintext().find_match(
             regex, search_range, regexp=True, nocase=True
@@ -1355,7 +1355,7 @@ class TextMarkupConvertorDialog(ToplevelDialog):
         """Convert text marked up with <sc> to ALLCAPS."""
         found = False
         maintext().undo_block_begin()
-        search_range = IndexRange(maintext().start(), maintext().end())
+        search_range = maintext().start_to_end()
         # Find start of each smallcap markup
         while match := maintext().find_match(
             "<sc>", search_range, regexp=False, nocase=True

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -428,7 +428,7 @@ class SearchDialog(ToplevelDialog):
             if self.search_params_have_changed():
                 maintext().remove_search_highlights()
                 for _match in self._find_all(
-                    IndexRange(maintext().start(), maintext().end()),
+                    maintext().start_to_end(),
                     self.search_box.get(),
                 ):
                     maintext().tag_add(
@@ -939,7 +939,7 @@ def get_search_range() -> Tuple[Optional[IndexRange], str]:
     else:
         if preferences.get(PrefKey.SEARCHDIALOG_WRAP):
             range_name = "in entire file"
-            replace_range = IndexRange(maintext().start(), maintext().end())
+            replace_range = maintext().start_to_end()
         elif preferences.get(PrefKey.SEARCHDIALOG_REVERSE):
             range_name = "from start of file to current location"
             replace_range = IndexRange(


### PR DESCRIPTION
After moving footnotes to LZ, code now checks if the FOOTNOTES heading has 4 blank lines before it.
If it does, then make sure it has at least 2 blank lines after it.

Testing note: if you manually edit LZ blank lines in order to test this, you should re-run the footnotes tool to ensure it knows all the locations correctly.

Fixes #691

(Also added a new method to return the range of the whole file, and used it everywhere it previously created a range from
`maintext().start()` to `maintext().end()`. Just a bit of code improvement :) )
