### PR TITLE
Use normal mouse pointer arrow in checkers

### DIFF
--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -647,6 +647,8 @@ class ScrolledReadOnlyText(tk.Text):
             foreground="#000000",
         )
 
+        self["cursor"] = "arrow"
+
         # Since Text widgets don't normally listen to theme changes,
         # need to do it explicitly here.
         super().bind(


### PR DESCRIPTION
In checker dialogs such as bookloupe, use a regular arrow rather than the vertical bar insert cursor.

Fixes #702 - this makes sense for the reasons given in the issue.

Testing notes, move mouse over the list of bookloupe or WF messages.