### PR TITLE
Fix exception if WF is up when program quits

### DIFF
--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -442,7 +442,8 @@ class WordFrequencyDialog(ToplevelDialog):
         """Reset dialog."""
         super().reset()
         self.entries: list[WordFrequencyEntry] = []
-        maintext().remove_spotlights()
+        if maintext().winfo_exists():
+            maintext().remove_spotlights()
         if not self.text.winfo_exists():
             return
         self.text.delete("1.0", tk.END)


### PR DESCRIPTION
Fixes #720

Testing notes:
Run Tools->WF, then quit the program without closing the WF dialog first. 