### PR TITLE
Don't create multiple tooltips

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -17,7 +17,7 @@ from guiguts.utilities import (
     is_mac,
     sing_plur,
 )
-from guiguts.widgets import ToplevelDialog, TlDlg, mouse_bind, Busy
+from guiguts.widgets import ToplevelDialog, TlDlg, mouse_bind, Busy, ToolTip
 
 MARK_ENTRY_TO_SELECT = "MarkEntryToSelect"
 HILITE_TAG_NAME = "chk_hilite"
@@ -220,6 +220,7 @@ class CheckerDialog(ToplevelDialog):
         self,
         title: str,
         rerun_command: Callable[[], None],
+        tooltip: str,
         process_command: Optional[Callable[[CheckerEntry], None]] = None,
         sort_key_rowcol: Optional[Callable[[CheckerEntry], tuple]] = None,
         sort_key_alpha: Optional[Callable[[CheckerEntry], tuple]] = None,
@@ -234,6 +235,7 @@ class CheckerDialog(ToplevelDialog):
         Args:
             title: Title for dialog.
             rerun_command: Function to call to re-run the check.
+            tooltip: Tooltip to show in messages text widget.
             process_command: Function to call to "process" the current error, e.g. swap he/be.
             sort_key_rowcol: Function to sort by row & column.
             sort_key_alpha: Function to sort by alpha/type.
@@ -358,6 +360,7 @@ class CheckerDialog(ToplevelDialog):
             font=maintext().font,
         )
         self.text.grid(row=1, column=0, sticky="NSEW")
+        ToolTip(self.text, tooltip, use_pointer_pos=True)
 
         # 3 binary choices:
         #     remove/not_remove (just select) - controlled by button 3 or button 1

--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -19,7 +19,6 @@ from guiguts.utilities import (
     IndexRowCol,
     IndexRange,
 )
-from guiguts.widgets import ToolTip
 
 logger = logging.getLogger(__package__)
 
@@ -1327,6 +1326,13 @@ def footnote_check() -> None:
         rerun_command=footnote_check,
         sort_key_alpha=sort_key_type,
         show_suspects_only=True,
+        tooltip="\n".join(
+            [
+                "Left click: Select & find footnote",
+                "Right click: Remove item from list",
+                "Shift-Right click: Remove all matching items",
+            ]
+        ),
     )
 
     if _the_footnote_checker is None:
@@ -1334,18 +1340,6 @@ def footnote_check() -> None:
     elif not _the_footnote_checker.checker_dialog.winfo_exists():
         _the_footnote_checker.checker_dialog = checker_dialog
     _the_footnote_checker.fns_have_been_moved = False
-
-    ToolTip(
-        checker_dialog.text,
-        "\n".join(
-            [
-                "Left click: Select & find footnote",
-                "Right click: Remove item from list",
-                "Shift-Right click: Remove all matching items",
-            ]
-        ),
-        use_pointer_pos=True,
-    )
 
     _the_footnote_checker.run_check()
     # Order below is important. The display_footnote_entries() function will

--- a/src/guiguts/html_tools.py
+++ b/src/guiguts/html_tools.py
@@ -21,7 +21,7 @@ from guiguts.preferences import (
     preferences,
 )
 from guiguts.utilities import IndexRange, sound_bell, DiacriticRemover, IndexRowCol
-from guiguts.widgets import ToplevelDialog, ToolTip
+from guiguts.widgets import ToplevelDialog
 
 logger = logging.getLogger(__package__)
 
@@ -547,17 +547,14 @@ def html_validator_check() -> None:
         manual_page = "HTML_Menu#HTML_Validator"
 
     checker_dialog = HTMLValidatorDialog.show_dialog(
-        "HTML Validator Results", rerun_command=html_validator_check
-    )
-    ToolTip(
-        checker_dialog.text,
-        "\n".join(
+        "HTML Validator Results",
+        rerun_command=html_validator_check,
+        tooltip="\n".join(
             [
                 "Left click: Select & find comment",
                 "Right click: Remove comment from this list",
             ]
         ),
-        use_pointer_pos=True,
     )
 
     do_validator_check(checker_dialog)

--- a/src/guiguts/illo_sn_fixup.py
+++ b/src/guiguts/illo_sn_fixup.py
@@ -14,7 +14,6 @@ from guiguts.utilities import (
     IndexRowCol,
     IndexRange,
 )
-from guiguts.widgets import ToolTip
 
 logger = logging.getLogger(__package__)
 
@@ -603,6 +602,13 @@ def illosn_check(tag_type: str) -> None:
         rerun_command=lambda: illosn_check(tag_type),
         show_suspects_only=True,
         clear_on_undo_redo=True,
+        tooltip="\n".join(
+            [
+                f"Left click: Select & find {tag_type} tag",
+                "Right click: Remove item from list",
+                "Shift-Right click: Remove all matching items",
+            ]
+        ),
     )
     if tag_type == "Illustration":
         if _the_illo_checker is None:
@@ -616,18 +622,6 @@ def illosn_check(tag_type: str) -> None:
         elif not _the_sn_checker.checker_dialog.winfo_exists():
             _the_sn_checker.checker_dialog = checker_dialog
         the_checker = _the_sn_checker
-
-    ToolTip(
-        checker_dialog.text,
-        "\n".join(
-            [
-                f"Left click: Select & find {tag_type} tag",
-                "Right click: Remove item from list",
-                "Shift-Right click: Remove all matching items",
-            ]
-        ),
-        use_pointer_pos=True,
-    )
 
     frame = ttk.Frame(checker_dialog.header_frame)
     frame.grid(column=0, row=1, sticky="NSEW")

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -30,7 +30,7 @@ from guiguts.utilities import (
     sound_bell,
     load_dict_from_json,
 )
-from guiguts.widgets import ToolTip, ToplevelDialog, Combobox, insert_in_focus_widget
+from guiguts.widgets import ToplevelDialog, Combobox, insert_in_focus_widget
 
 logger = logging.getLogger(__package__)
 
@@ -145,10 +145,7 @@ def basic_fixup_check() -> None:
         rerun_command=basic_fixup_check,
         process_command=process_fixup,
         sort_key_alpha=sort_key_type,
-    )
-    ToolTip(
-        checker_dialog.text,
-        "\n".join(
+        tooltip="\n".join(
             [
                 "Left click: Select & find issue",
                 "Right click: Remove issue from list",
@@ -156,7 +153,6 @@ def basic_fixup_check() -> None:
                 "With Shift key: Also remove/fix matching issues",
             ]
         ),
-        use_pointer_pos=True,
     )
     checker_dialog.reset()
 
@@ -996,17 +992,13 @@ def unmatched_markup_check(
         title,
         rerun_command=rerun_command,
         sort_key_alpha=sort_key_alpha,
-    )
-    ToolTip(
-        checker_dialog.text,
-        "\n".join(
+        tooltip="\n".join(
             [
                 "Left click: Select & find issue",
                 "Right click: Remove issue from list",
                 "Shift-Right click: Remove all matching issues",
             ]
         ),
-        use_pointer_pos=True,
     )
     # User can control nestability of some unmatched check types
     if nest_reg is None:
@@ -1280,17 +1272,14 @@ def proofer_comment_check() -> None:
         manual_page = "Navigation#Find_Proofer_Comments_(_[**notes]_)"
 
     checker_dialog = ProoferCommentCheckerDialog.show_dialog(
-        "Proofer Comments", rerun_command=proofer_comment_check
-    )
-    ToolTip(
-        checker_dialog.text,
-        "\n".join(
+        "Proofer Comments",
+        rerun_command=proofer_comment_check,
+        tooltip="\n".join(
             [
                 "Left click: Select & find comment",
                 "Right click: Remove comment from this list",
             ]
         ),
-        use_pointer_pos=True,
     )
     checker_dialog.reset()
     for match in matches:
@@ -1319,17 +1308,14 @@ def asterisk_check() -> None:
     )
 
     checker_dialog = AsteriskCheckerDialog.show_dialog(
-        "Asterisk Check", rerun_command=asterisk_check
-    )
-    ToolTip(
-        checker_dialog.text,
-        "\n".join(
+        "Asterisk Check",
+        rerun_command=asterisk_check,
+        tooltip="\n".join(
             [
                 "Left click: Select & find occurrence of asterisk",
                 "Right click: Remove occurrence from this list",
             ]
         ),
-        use_pointer_pos=True,
     )
     checker_dialog.reset()
     for match in matches:
@@ -1484,19 +1470,17 @@ class ScannoCheckerDialog(CheckerDialog):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize scanno checker dialog."""
-        super().__init__(*args, **kwargs)
-
-        ToolTip(
-            self.text,
-            "\n".join(
-                [
-                    "Left click: Select & find occurrence of scanno",
-                    "Right click: Remove occurrence of scanno from list",
-                    f"With {cmd_ctrl_string()} key: Also fix this occurrence",
-                    "With Shift key: Also remove/fix matching occurrences",
-                ]
-            ),
-            use_pointer_pos=True,
+        kwargs["tooltip"] = "\n".join(
+            [
+                "Left click: Select & find occurrence of scanno",
+                "Right click: Remove occurrence of scanno from list",
+                f"With {cmd_ctrl_string()} key: Also fix this occurrence",
+                "With Shift key: Also remove/fix matching occurrences",
+            ]
+        )
+        super().__init__(
+            *args,
+            **kwargs,
         )
 
         frame = ttk.Frame(self.header_frame)
@@ -1883,18 +1867,16 @@ class CurlyQuotesDialog(CheckerDialog):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize curly quotes checker dialog."""
-        super().__init__(*args, **kwargs)
-
-        ToolTip(
-            self.text,
-            "\n".join(
-                [
-                    "Left click: Select & find curly quote warning",
-                    "Right click: Remove warning from list",
-                    f"With {cmd_ctrl_string()} key: Convert straight to curly, or swap open⇔close",
-                ]
-            ),
-            use_pointer_pos=True,
+        kwargs["tooltip"] = "\n".join(
+            [
+                "Left click: Select & find curly quote warning",
+                "Right click: Remove warning from list",
+                f"With {cmd_ctrl_string()} key: Convert straight to curly, or swap open⇔close",
+            ]
+        )
+        super().__init__(
+            *args,
+            **kwargs,
         )
 
         frame = ttk.Frame(self.header_frame)

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -17,7 +17,6 @@ from guiguts.widgets import (
     ToplevelDialog,
     Combobox,
     mouse_bind,
-    ToolTip,
     register_focus_widget,
     process_accel,
     Busy,
@@ -449,22 +448,19 @@ class SearchDialog(ToplevelDialog):
             manual_page = "Searching#Find_All"
 
         checker_dialog = FindAllCheckerDialog.show_dialog(
-            "Search Results", rerun_command=self.findall_clicked
-        )
-        if not checker_dialog.winfo_exists():
-            Busy.unbusy()
-            return
-        ToolTip(
-            checker_dialog.text,
-            "\n".join(
+            "Search Results",
+            rerun_command=self.findall_clicked,
+            tooltip="\n".join(
                 [
                     "Left click: Select & find string",
                     "Right click: Remove string from this list",
                     "Shift Right click: Remove all occurrences of string from this list",
                 ]
             ),
-            use_pointer_pos=True,
         )
+        if not checker_dialog.winfo_exists():
+            Busy.unbusy()
+            return
         checker_dialog.reset()
         if not self.winfo_exists():
             Busy.unbusy()

--- a/src/guiguts/spell.py
+++ b/src/guiguts/spell.py
@@ -370,10 +370,7 @@ def spell_check(
             project_dict, add_project_word_callback, add_global_word_callback
         ),
         process_command=process_spelling,
-    )
-    ToolTip(
-        checker_dialog.text,
-        "\n".join(
+        tooltip="\n".join(
             [
                 "Left click: Select & find spelling error",
                 "Right click: Remove spelling error from list",
@@ -381,7 +378,6 @@ def spell_check(
                 f"With {cmd_ctrl_string()} key: Also add spelling to project dictionary",
             ]
         ),
-        use_pointer_pos=True,
     )
     frame = ttk.Frame(checker_dialog.header_frame)
     frame.grid(column=0, row=1, sticky="NSEW", pady=5)

--- a/src/guiguts/tools/bookloupe.py
+++ b/src/guiguts/tools/bookloupe.py
@@ -13,7 +13,6 @@ from guiguts.checkers import CheckerDialog, CheckerViewOptionsDialog, CheckerFil
 from guiguts.maintext import maintext
 from guiguts.misc_tools import tool_save
 from guiguts.utilities import IndexRange, DiacriticRemover
-from guiguts.widgets import ToolTip
 
 logger = logging.getLogger(__package__)
 
@@ -183,17 +182,13 @@ class BookloupeChecker:
             rerun_command=bookloupe_check,
             view_options_dialog_class=BookloupeCheckerViewOptionsDialog,
             view_options_filters=checker_filters,
-        )
-        ToolTip(
-            self.dialog.text,
-            "\n".join(
+            tooltip="\n".join(
                 [
                     "Left click: Select & find issue",
                     "Right click: Remove message from list",
                     "Shift-Right click: Remove all matching messages",
                 ]
             ),
-            use_pointer_pos=True,
         )
         self.dialog.reset()
         self.run_bookloupe()

--- a/src/guiguts/tools/jeebies.py
+++ b/src/guiguts/tools/jeebies.py
@@ -18,7 +18,6 @@ from guiguts.preferences import (
     PrefKey,
 )
 from guiguts.utilities import IndexRowCol, IndexRange
-from guiguts.widgets import ToolTip
 
 logger = logging.getLogger(__package__)
 
@@ -75,6 +74,14 @@ class JeebiesChecker:
             "Jeebies Results",
             rerun_command=jeebies_check,
             process_command=self.process_jeebies,
+            tooltip="\n".join(
+                [
+                    "Left click: Select & find he/be error",
+                    "Right click: Remove he/be error from list",
+                    f"With {cmd_ctrl_string()} key: Also toggle queried he/be",
+                    "Shift Right click: Also remove all matching he/be errors",
+                ]
+            ),
         )
         frame = ttk.Frame(checker_dialog.header_frame)
         frame.grid(column=0, row=1, sticky="NSEW")
@@ -103,18 +110,6 @@ class JeebiesChecker:
             value=JeebiesParanoiaLevel.TOLERANT,
             takefocus=False,
         ).grid(row=0, column=4, sticky="NSE", padx=2)
-        ToolTip(
-            checker_dialog.text,
-            "\n".join(
-                [
-                    "Left click: Select & find he/be error",
-                    "Right click: Remove he/be error from list",
-                    f"With {cmd_ctrl_string()} key: Also toggle queried he/be",
-                    "Shift Right click: Also remove all matching he/be errors",
-                ]
-            ),
-            use_pointer_pos=True,
-        )
         checker_dialog.reset()
 
         # Check level used last time Jeebies was run or default if first run.

--- a/src/guiguts/tools/levenshtein.py
+++ b/src/guiguts/tools/levenshtein.py
@@ -23,7 +23,6 @@ from guiguts.preferences import (
     PrefKey,
 )
 from guiguts.utilities import IndexRowCol, IndexRange
-from guiguts.widgets import ToolTip
 
 logger = logging.getLogger(__package__)
 
@@ -657,6 +656,13 @@ class LevenshteinChecker:
         checker_dialog = LevenshteinCheckerDialog.show_dialog(
             "Levenshtein Edit Distance Check",
             rerun_command=lambda: levenshtein_check(project_dict),
+            tooltip="\n".join(
+                [
+                    "Left click: Select & find highlighted word in file",
+                    "Right click: Remove line with highlighted word from list",
+                    "Shift Right click: Also remove all matching lines from list",
+                ]
+            ),
         )
         frame = ttk.Frame(checker_dialog.header_frame)
         frame.grid(column=0, row=1, sticky="NSEW")
@@ -678,18 +684,6 @@ class LevenshteinChecker:
             value=LevenshteinEditDistance.TWO,
             takefocus=False,
         ).grid(row=0, column=3, sticky="NSE", padx=2)
-
-        ToolTip(
-            checker_dialog.text,
-            "\n".join(
-                [
-                    "Left click: Select & find highlighted word in file",
-                    "Right click: Remove line with highlighted word from list",
-                    "Shift Right click: Also remove all matching lines from list",
-                ]
-            ),
-            use_pointer_pos=True,
-        )
 
         checker_dialog.reset()
 

--- a/src/guiguts/tools/pptxt.py
+++ b/src/guiguts/tools/pptxt.py
@@ -8,7 +8,6 @@ from guiguts.file import ProjectDict
 from guiguts.maintext import maintext
 from guiguts.misc_tools import tool_save
 from guiguts.utilities import IndexRowCol, IndexRange
-from guiguts.widgets import ToolTip
 
 
 class PPtxtCheckerDialog(CheckerDialog):
@@ -2522,18 +2521,15 @@ def pptxt(project_dict: ProjectDict) -> None:
 
     # Create the checker dialog to show results
     checker_dialog = PPtxtCheckerDialog.show_dialog(
-        "PPtxt Results", rerun_command=lambda: pptxt(project_dict)
-    )
-    ToolTip(
-        checker_dialog.text,
-        "\n".join(
+        "PPtxt Results",
+        rerun_command=lambda: pptxt(project_dict),
+        tooltip="\n".join(
             [
                 "Left click: Select & find issue",
                 "Right click: Remove issue from list",
                 "Shift Right click: Remove all matching issues",
             ]
         ),
-        use_pointer_pos=True,
     )
     checker_dialog.reset()
 

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -112,7 +112,6 @@ class ToplevelDialog(tk.Toplevel):
         Args:
             title: Dialog title.
             destroy: True (default is False) if dialog should be destroyed & re-created, rather than re-used
-            args: Optional args to pass to dialog constructor.
             kwargs: Optional kwargs to pass to dialog constructor.
         """
         # If dialog exists, either destroy it or deiconify


### PR DESCRIPTION
Each time some of the tools were re-run, a new tooltip object was created. So, although not visible (because all the tooltips appeared on top of each other) after
several re-runs, each time the cursor entered the list of messages, several tooltips were displayed.

Fixes #730

Testing notes:
Should be nothing noticeable. Check tooltips work in some checker dialogs, Find All, Spelling, WF, etc.