### PR TITLE
Fix exception from Search when main window closed

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -3351,7 +3351,8 @@ class MainText(tk.Text):
 
     def remove_highlights_search(self) -> None:
         """Remove highlights for search."""
-        self.tag_remove(HighlightTag.SEARCH, "1.0", tk.END)
+        if self.winfo_exists():
+            self.tag_remove(HighlightTag.SEARCH, "1.0", tk.END)
 
     def highlight_search_deactivate(self) -> None:
         """Turn off the highlight-matches mode."""


### PR DESCRIPTION
If Search dialog was open when program was closed, it generated an exception trying to clear search highlights.

Fixes #735