### PR TITLE
Add HTML Link Checker

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -16,7 +16,7 @@ from guiguts.data import themes
 from guiguts.file import File, the_file, NUM_RECENT_FILES
 from guiguts.footnotes import footnote_check, FootnoteIndexStyle
 from guiguts.html_convert import HTMLGeneratorDialog, HTMLMarkupTypes
-from guiguts.html_tools import HTMLImageDialog, html_validator_check
+from guiguts.html_tools import HTMLImageDialog, html_validator_check, html_link_check
 from guiguts.illo_sn_fixup import illosn_check
 from guiguts.maintext import maintext
 from guiguts.mainwindow import (
@@ -791,6 +791,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         )
         html_menu.add_button("~Unmatched HTML Tags...", unmatched_html_markup)
         html_menu.add_button("HTML5 ~Validator (online)...", html_validator_check)
+        html_menu.add_button("HTML ~Link Checker...", html_link_check)
 
     def init_view_menu(self) -> None:
         """Create the View menu."""


### PR DESCRIPTION
In HTML menu.
Reports similar things to GG1:
1. Broken internal links, where anchor for an href does not exist.
2. Broken file links, where href or src points to a file that does not exist (usually an image file)
3. Links that are "external", i.e. begin with "http"
4. Links that are empty, e.g. `href=""`
5. Similar to the above for CSS url function, e.g. `style="background-image: url("images/a1.jpg")`.
Note that there can be more than one url function in one style attribute value.
6. Files in the image folder that are nor referenced
7. Files in the image folder that have uppercase letters in the filename.
8. Reports a summary of statistics
9. Reports as INFO messages any anchors that are not referenced

Note: to see the last 2 in GG1, you have to check the verbose flag. Also note that the url check didn't work for me in GG1 :shrug: