### PR TITLE
Improve HTML Auto-illustration

### DIFF
--- a/src/guiguts/data/html/html_header.txt
+++ b/src/guiguts/data/html/html_header.txt
@@ -161,7 +161,7 @@ em.gesperrt
     font-style: normal;
 }
 
-.caption  {font-weight: bold;}
+figcaption  {font-weight: bold;}
 
 /* Images */
 

--- a/src/guiguts/html_tools.py
+++ b/src/guiguts/html_tools.py
@@ -359,7 +359,7 @@ class HTMLImageDialog(ToplevelDialog):
             return
         maintext().set_insert_index(illo_match_start.rowcol, focus=False)
         # Find end of markup and spotlight it
-        search_start = illo_match_start.rowcol
+        search_start = maintext().rowcol(f"{illo_match_start.rowcol.index()}+12c")
         nested = False
         while True:
             illo_match_end = maintext().find_match(

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -3034,7 +3034,8 @@ class MainText(tk.Text):
 
     def remove_spotlights(self) -> None:
         """Remove active spotlights"""
-        self.tag_remove(HighlightTag.SPOTLIGHT, "1.0", tk.END)
+        if self.winfo_exists():
+            self.tag_remove(HighlightTag.SPOTLIGHT, "1.0", tk.END)
 
     def get_screen_window_coordinates(
         self, viewport: Text, offscreen_lines: int = 5


### PR DESCRIPTION
1. Remove `<p>` markup within caption
2. Remove `class=caption` from caption
3. Change HTML header file to make figcaption bold even without the `class=caption`
4. Remove superfluous trailing newline
5. Remove blank lines at start or end of caption


Fixes #736 