### PR TITLE
Move mark prefix getter into TopLevelDialog

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -570,9 +570,7 @@ class CheckerDialog(ToplevelDialog):
         if self.text.winfo_exists():
             self.text.delete("1.0", tk.END)
         if maintext().winfo_exists():
-            for mark in maintext().mark_names():
-                if mark.startswith(self.get_mark_prefix()):
-                    maintext().mark_unset(mark)
+            maintext().clear_marks(self.get_mark_prefix())
             maintext().remove_spotlights()
 
     def select_entry_after_undo_redo(self) -> None:

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -1157,8 +1157,3 @@ class CheckerDialog(ToplevelDialog):
             Name for mark, e.g. "Checker123.45"
         """
         return f"{cls.get_mark_prefix()}{rowcol.index()}"
-
-    @classmethod
-    def get_mark_prefix(cls) -> str:
-        """Use reduced dialog name for common part of mark names"""
-        return cls.__name__.removesuffix("Dialog")

--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -272,18 +272,6 @@ class FootnoteChecker:
         end_of_file = maintext().end().index()
         self.set_lz(end_of_file)
 
-    def clear_marks(self, mark_prefix: str) -> None:
-        """Clear marks of type 'mark_prefix'.
-
-        Used to unset marks with names such as "FootnoteCheckerShadow3.15".
-
-        Arg:
-            mark_prefix: Prefix of marks to be cleared.
-        """
-        for mark in maintext().mark_names():
-            if mark.startswith(mark_prefix):
-                maintext().mark_unset(mark)
-
     def add_blank_line_at_eof(self) -> None:
         """Add a blank line at end of the file.
 

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1247,6 +1247,16 @@ class MainText(tk.Text):
         self.mark_set(mark, position.index())
         self.mark_gravity(mark, gravity)
 
+    def clear_marks(self, mark_prefix: str) -> None:
+        """Clear marks with given prefix.
+
+        Arg:
+            mark_prefix: Prefix of marks to be cleared.
+        """
+        for mark in self.mark_names():
+            if mark.startswith(mark_prefix):
+                self.mark_unset(mark)
+
     def get_text(self) -> str:
         """Return all the text from the text widget.
 

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -144,6 +144,14 @@ class ToplevelDialog(tk.Toplevel):
             return ToplevelDialog._toplevel_dialogs[dlg_name]  # type: ignore[return-value]
         return None
 
+    @classmethod
+    def get_mark_prefix(cls) -> str:
+        """Use reduced dialog name for common part of mark names.
+        This ensures each dialog uses unique mark names and does not clash
+        with another dialog.
+        """
+        return cls.__name__.removesuffix("Dialog")
+
     def register_tooltip(self, tooltip: "ToolTip") -> None:
         """Register a tooltip as being attached to a widget in this
         TopleveDialog so it can be destroyed when the dialog is destroyed.


### PR DESCRIPTION
All dialogs can now get a unique prefix or any marks they create. Checker dialogs automatically remove
all such marks when reset/closed. Other dialog types need to remove their own marks.

Fixes #742 

Testing notes: Try a couple of checker dialogs, especially Footnotes, and especially move FNs to paragraphs. Should be no discernible change in behavior.
