### PR TITLE
Image viewer & next/prev page improvement

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -27,6 +27,7 @@ from guiguts.mainwindow import (
     statusbar,
     ErrorHandler,
     process_accel,
+    mainimage,
 )
 from guiguts.misc_dialogs import (
     PreferencesDialog,
@@ -188,7 +189,10 @@ class Guiguts:
     def auto_image_check(self) -> None:
         """Function called repeatedly to check whether an image needs loading."""
         if preferences.get(PrefKey.AUTO_IMAGE):
-            self.mainwindow.load_image(self.file.get_current_image_path())
+            # Image viewer can temporarily pause auto image viewing,
+            # but still need to schedule another call to this method.
+            if not mainimage().auto_image_paused:
+                self.mainwindow.load_image(self.file.get_current_image_path())
             root().after(200, self.auto_image_check)
 
     def show_image(self) -> None:

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -687,22 +687,20 @@ class File:
         self._next_prev_page(1)
 
     def _next_prev_page(self, direction: Literal[1, -1]) -> None:
-        """Go to the page before/after the current one
+        """Go to the page before/after the current one.
 
-        Always moves backward/forward in file, even if cursor and page mark(s)
-        are coincident or multiple coincident page marks. Will not remain in
-        the same location unless no further page marks are found.
+        Note that cursor may not move if more than one mark is at the same point.
 
         Args:
             direction: +1 to go to next page; -1 for previous page
         """
         insert = maintext().get_insert_index().index()
-        cur_page = maintext().get_current_image_name()
-        mark = page_mark_from_img(cur_page) if cur_page else insert
-        while mark := maintext().page_mark_next_previous(mark, direction):
-            if maintext().compare(mark, "!=", insert):
-                maintext().set_insert_index(maintext().rowcol(mark))
-                return
+        mark = maintext().get_current_page_mark() or insert
+        if mark := maintext().page_mark_next_previous(mark, direction):
+            # Store mark to cope with coincident page marks
+            maintext().store_page_mark(mark)
+            maintext().set_insert_index(maintext().rowcol(mark))
+            return
         sound_bell()
 
     # Note that the following code must match the equivalent code in Guiguts 1

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -371,6 +371,8 @@ class MainImage(tk.Frame):
         self.filename = ""
         self.width = 0
         self.height = 0
+        # May want to pause auto image if user clicks prev/next file buttons
+        self.auto_image_paused = False
 
     def scroll_y(self, *args: Any, **kwargs: Any) -> None:
         """Scroll canvas vertically and redraw the image"""
@@ -561,6 +563,7 @@ class MainImage(tk.Frame):
                 preferences.set(PrefKey.IMAGE_FLOAT_GEOMETRY, tk.Wm.geometry(self))  # type: ignore[call-overload]
             except tk.TclError:
                 pass
+        self.auto_image_paused = False
 
     def next_image(self, reverse: bool = False) -> None:
         """Load the next image alphabetically.
@@ -578,9 +581,6 @@ class MainImage(tk.Frame):
             logger.error(f"Image directory invalid: {current_dir}")
             return
 
-        # Turn off auto-image; we're going to manual control.
-        preferences.set(PrefKey.AUTO_IMAGE, False)
-
         current_basename = os.path.basename(self.filename)
         found = False
         for fn in sorted(os.listdir(current_dir), reverse=reverse):
@@ -590,6 +590,7 @@ class MainImage(tk.Frame):
             # If found on previous time through loop, this is the file we want
             if found:
                 self.load_image(os.path.join(current_dir, fn))
+                self.auto_image_paused = True
                 return
             if fn == current_basename:
                 found = True


### PR DESCRIPTION
Two changes which are independent to improve the interplay between the text window prev/next page and the image viewer prev/next file.

For discussion as to whether either, neither or both of these are improvements:
1. When using prev/next image buttons in status bar (or equivalent buttons in Search-->Goto menu) step back/forward to the next page boundary, even if that means the insert cursor doesn't move. This happens if there are two or more page breaks at the same point in the file, due to full page illo or blank page.
2. Don't turn off Auto Image when prev/next file buttons are used in image viewer. Instead, just pause it until the user moves the mouse out of the image viewer. So the PPer can easily look back/forward a page or two around their current insert location, then when they want to go back to the text to continue editing, auto image will resume. Of course, if the user doesn't want auto image they can always turn it off.