### PR TITLE
Widget duplicates

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -369,7 +369,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             PrefKey.JEEBIES_PARANOIA_LEVEL, JeebiesParanoiaLevel.NORMAL
         )
         preferences.set_default(
-            PrefKey.LEVENSHTEIN_EDIT_DISTANCE, LevenshteinEditDistance.ONE
+            PrefKey.LEVENSHTEIN_DISTANCE, LevenshteinEditDistance.ONE
         )
         preferences.set_default(PrefKey.FOOTNOTE_INDEX_STYLE, FootnoteIndexStyle.NUMBER)
         preferences.set_default(PrefKey.WRAP_LEFT_MARGIN, 0)

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -786,9 +786,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         """Create the HTML menu."""
         html_menu = Menu(menubar(), "HT~ML")
         html_menu.add_button("HTML ~Generator...", HTMLGeneratorDialog.show_dialog)
-        html_menu.add_button(
-            "Auto-~Illustrations...", lambda: HTMLImageDialog.show_dialog(destroy=True)
-        )
+        html_menu.add_button("Auto-~Illustrations...", HTMLImageDialog.show_dialog)
         html_menu.add_button("~Unmatched HTML Tags...", unmatched_html_markup)
         html_menu.add_button("HTML5 ~Validator (online)...", html_validator_check)
         html_menu.add_button("HTML ~Link Checker...", html_link_check)

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -109,16 +109,16 @@ class CheckerViewOptionsDialog(ToplevelDialog):
 
     def __init__(
         self,
-        title: str,
         checker_dialog: "CheckerDialog",
     ) -> None:
         """Create View Options dialog.
 
         Args:
-            title: Title for dialog.
             checker_dialog: The checker dialog that this dialog belongs to.
         """
-        super().__init__(title, resize_x=False, resize_y=False)
+        super().__init__(
+            f"{checker_dialog.title()} - View Options", resize_x=False, resize_y=False
+        )
         self.checker_dialog = checker_dialog
 
         self.flags: list[tk.BooleanVar] = []
@@ -342,7 +342,7 @@ class CheckerDialog(ToplevelDialog):
             """Show the view options dialog."""
             assert view_options_dialog_class is not None
             self.view_options_dialog = view_options_dialog_class.show_dialog(
-                title + " - View Options", checker_dialog=self
+                checker_dialog=self
             )
 
         if view_options_dialog_class is not None:
@@ -465,20 +465,17 @@ class CheckerDialog(ToplevelDialog):
     @classmethod
     def show_dialog(
         cls: type[TlDlg],
-        title: Optional[str] = None,
-        destroy: bool = False,
         **kwargs: Any,
     ) -> TlDlg:
         """Show the instance of this dialog class, or create it if it doesn't exist.
 
         Args:
             title: Dialog title.
-            destroy: Set to True if dialog should be destroyed & re-created, rather than re-used
             args: Optional args to pass to dialog constructor.
             kwargs: Optional kwargs to pass to dialog constructor.
         """
         Busy.busy()
-        return super().show_dialog(title, destroy, **kwargs)
+        return super().show_dialog(**kwargs)
 
     @classmethod
     def sort_key_rowcol(

--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -4,7 +4,7 @@ import logging
 from enum import StrEnum, auto
 import tkinter as tk
 from tkinter import ttk
-from typing import Optional
+from typing import Optional, Any
 import regex as re
 import roman  # type: ignore[import-untyped]
 
@@ -14,6 +14,7 @@ from guiguts.misc_tools import tool_save
 from guiguts.preferences import (
     PersistentString,
     PrefKey,
+    preferences,
 )
 from guiguts.utilities import (
     IndexRowCol,
@@ -97,21 +98,14 @@ class FootnoteRecord:
         self.an_index = an_index
 
 
-class FootnoteCheckerDialog(CheckerDialog):
-    """Minimal class to identify dialog type."""
-
-    manual_page = "Tools_Menu#Footnote_Fixup"
-
-
 class FootnoteChecker:
     """Find, check & record footnotes."""
 
-    def __init__(self, checker_dialog: FootnoteCheckerDialog) -> None:
+    def __init__(self, checker_dialog: "FootnoteCheckerDialog") -> None:
         """Initialize footnote checker."""
         self.fn_records: list[FootnoteRecord] = []
         self.an_records: list[AnchorRecord] = []
-        self.checker_dialog: FootnoteCheckerDialog = checker_dialog
-        self.fn_index_style = PersistentString(PrefKey.FOOTNOTE_INDEX_STYLE)
+        self.checker_dialog: "FootnoteCheckerDialog" = checker_dialog
         self.fn_check_errors = False
         self.fns_have_been_moved = False
 
@@ -127,113 +121,6 @@ class FootnoteChecker:
     def get_an_records(self) -> list[AnchorRecord]:
         """Return the list of anchor records."""
         return self.an_records
-
-    def join_to_previous(self) -> None:
-        """Join the selected footnote to the previous one."""
-        maintext().undo_block_begin()
-        fn_index = self.get_selected_fn_index()
-        if fn_index < 0:
-            return  # No selection
-        if fn_index == 0:
-            return  # Can't join first footnote to previous
-        fn_records = self.get_fn_records()
-        fn_record = fn_records[fn_index]
-        fn_cur_start = self.checker_dialog.mark_from_rowcol(fn_record.start)
-        fn_cur_end = self.checker_dialog.mark_from_rowcol(fn_record.end)
-        prev_record = fn_records[fn_index - 1]
-        fn_prev_end = self.checker_dialog.mark_from_rowcol(prev_record.end)
-        continuation_text = maintext().get(fn_cur_start, fn_cur_end)[11:]
-        maintext().delete(
-            f"{fn_cur_start} -1l linestart", f"{fn_cur_end} +1l linestart"
-        )
-        maintext().delete(f"{fn_prev_end} -1c", f"{fn_prev_end} lineend")
-        maintext().insert(fn_prev_end, "\n" + continuation_text)
-        self.checker_dialog.remove_entry_current()
-        # Note index of the record to which we joined the continuation text.
-        saved_prev_rec_index = fn_index - 1
-        self.run_check()
-        display_footnote_entries(auto_select_line=False)
-        fn_records = self.get_fn_records()
-        prev_record = fn_records[saved_prev_rec_index]
-        # Get index into dialog entries for this record.
-        dialog_entry_index = self.map_fn_record_to_dialog_index(prev_record)
-        if dialog_entry_index < 0:
-            logger.error("Unexpected return from 'join_to_previous()'")
-            return
-        # Make it the selected entry in the dialog.
-        self.checker_dialog.select_entry_by_index(dialog_entry_index)
-
-    def autoset_chapter_lz(self) -> None:
-        """Insert a 'FOOTNOTES:' landing zone (LZ) header line before each
-        chapter break.
-
-        If chapters are separated correctly from the next chapter by 4 blank
-        lines then there will always be a LZ header inserted at the end of
-        each chapter, except at the end of the last chapter. Append a header
-        to end of file to catch any footnotes in the last chapter. This means
-        that all footnotes will then have a LZ header below them.
-
-        No LZ headers are inserted before the first anchor to avoid adding
-        them at pseudo chapter breaks in front matter, etc. Unused LZ headers
-        are deleted after footnotes have been moved to LZs - see call to
-        remove_unused_lz_headers() in the function move_footnotes_to_lz().
-        """
-        maintext().undo_block_begin()
-        # If the last line of the file is not a blank line then add one.
-        end_of_file = maintext().end().index()
-        if maintext().get(f"{end_of_file} linestart", f"{end_of_file} lineend") != "":
-            self.add_blank_line_at_eof()
-        # Append LZ header to end of file to catch footnotes in the last chapter
-        self.autoset_end_lz()
-        # Set search range for finding 'chapter breaks'. Look for them from the
-        # start of the first anchor rather than after the first 200 lines as
-        # in GG1.
-        an_records = self.get_an_records()
-        first_an = an_records[0]
-        search_range = IndexRange(first_an.start, maintext().end())
-        # Loop, finding all chapter breaks; i.e. block of 4 blank lines. Method
-        # used is to find next blank line then look ahead for 3 more blank lines.
-        # If present then set a LZ and advance 6 lines and repeat. If look ahead
-        # does not find 3 more blank lines then advance 1 line and repeat. This
-        # is based on GG1 method.
-        match_regex = r"^$"
-        while True:
-            beg_match = maintext().find_match(match_regex, search_range, regexp=True)
-            if not beg_match:
-                break
-            start_index = beg_match.rowcol.index()
-            # If next three lines are also empty, insert a LZ "FOOTNOTES:" header
-            # before the 4-line block.
-            if (
-                maintext().get(
-                    f"{start_index} +1l linestart", f"{start_index} +1l lineend"
-                )
-                == ""
-                and maintext().get(
-                    f"{start_index} +2l linestart", f"{start_index} +2l lineend"
-                )
-                == ""
-                and maintext().get(
-                    f"{start_index} +3l linestart", f"{start_index} +3l lineend"
-                )
-                == ""
-            ):
-                # Insert the LZ header.
-                self.set_lz(start_index)
-                # Advance past inserted LZ.
-                restart_point = maintext().rowcol(f"{start_index} +6l")
-            else:
-                # Advance to avoid finding same blank line again.
-                restart_point = maintext().rowcol(f"{start_index} +1l")
-            search_range = IndexRange(restart_point, maintext().end())
-
-        # The file has changed so rebuild AN/FN records and refresh dialog.
-        self.run_check()
-        # Order below is important. A flag is set in display_footnote_entries()
-        # that will determine which, if any, buttons are disabled when they are
-        # displayed.
-        display_footnote_entries()
-        self.display_buttons()
 
     def set_lz(self, lz_index: str) -> None:
         """Add a 'FOOTNOTES:' LZ header at the given index.
@@ -261,16 +148,6 @@ class FootnoteChecker:
         if line_before[0:11] == "-----File: ":
             lz_index = maintext().rowcol(f"{lz_index} -1l linestart").index()
         maintext().insert(f"{lz_index} -1c", "\n\n\n" + "FOOTNOTES:")
-
-    def autoset_end_lz(self) -> None:
-        """Insert a 'FOOTNOTES:' LZ header line at end of file."""
-        maintext().undo_block_begin()
-        # If the last line of the file is not a blank line then add one.
-        end_of_file = maintext().end().index()
-        if maintext().get(f"{end_of_file} linestart", f"{end_of_file} lineend") != "":
-            self.add_blank_line_at_eof()
-        end_of_file = maintext().end().index()
-        self.set_lz(end_of_file)
 
     def add_blank_line_at_eof(self) -> None:
         """Add a blank line at end of the file.
@@ -351,350 +228,6 @@ class FootnoteChecker:
                         )
                         break
 
-    def move_footnotes_to_paragraphs(self) -> None:
-        """Implements the 'Move FNs to Paragraphs' button.
-
-        Moves footnotes to below the paragraph in which they are anchored. There
-        are no 'FOOTNOTES:' headers.
-
-        It is a three-pass process. In the first pass a named mark for each anchor
-        record is set. The location of each mark is the insertion point to which
-        the corresponding footnote will be moved. There may be many marks at the
-        same location.
-
-        The insertion point for marks is immediately BEFORE the line that separates
-        the end of a paragraph from all that follows. That line is either a blank
-        line that is not followed by a '[Footnote ...' line or is a Page Marker if
-        that immediately precedes such a blank line. In this way care is taken to
-        ensure insertion marks are located on the same page as the paragraph that
-        they follow. Special action is required for blank lines that separate
-        paragraphs in a multi-paragraph footnote.
-
-        The second pass simply iterates through the footnote record array copying
-        the text of each footnote before deleting the original and then inserting
-        the unchanged footnote text at its named insertion mark from the first pass.
-
-        The third pass iterates through footnote records in reverse order removing
-        any blank lines left behind when footnotes are deleted.
-        """
-        maintext().undo_block_begin()
-        # Check for any duplicate footnote labels and warn user that they should
-        # reindex footnotes before attempting to move them to paragraphs or LZ(s).
-        if not self.ok_to_move_fns():
-            logger.error(
-                "Duplicate labels - reindex footnotes before moving them to paragraphs"
-            )
-            return
-        # Flip the gravity of all Checker marks at the end of each FN to tk.LEFT.
-        # Can now reliably place insertion marks after the Checker mark so that
-        # they maintain the required ordering. We'll flip the gravity back again
-        # at the end of this function.
-        self.change_gravity_right_to_left()
-        an_records = self.get_an_records()
-        # If the last line of the file is not a blank line then add one. If the
-        # last line of the file is a footnote then because its end Checker mark
-        # is currently tk.LEFT the newline will be correctly placed after the
-        # Checker mark. Dont' have to call self.add_blank_line_at_eof() to do this
-        file_end = maintext().end().index()
-        if maintext().get(f"{file_end} linestart", f"{file_end} lineend") != "":
-            maintext().insert(file_end, "\n")
-        file_end = maintext().end().index()
-
-        # First pass.
-
-        # Set marks at the start of the blank line that separates a paragraph from the start
-        # of the next paragraph. If that blank line is preceded by a Page Marker, set marks
-        # at the start of the Page Marker. Those two locations are the same.
-
-        mark_prefix = self.checker_dialog.get_mark_prefix() + INSERTION_MARK_PREFIX
-        file_end = maintext().end().index()
-        match_regex = r"^$"
-        for an_record_index, an_record in enumerate(an_records):
-            # Find the end of the paragraph in which the footnote anchor is located.
-            # Start searching from the line containing the anchor.
-            search_range = IndexRange(
-                an_record.start, maintext().rowcol(f"{file_end} + 1l linestart")
-            )
-            while blank_line_match := maintext().find_match(
-                match_regex, search_range, regexp=True
-            ):
-                # Found the first blank line after the paragraph.
-                blank_line_start = blank_line_match.rowcol.index()
-                # It might separate paragraph text from a footnote at the bottom of the page
-                # with the paragraph continuing at the top of the next page.
-                line_after_text = maintext().get(
-                    f"{blank_line_start} +1l linestart",
-                    f"{blank_line_start} +1l lineend",
-                )
-                if line_after_text[0:10] == "[Footnote ":
-                    # Ignore this blank line and continue searching. However there is a problem
-                    # if the footnote is a multi-paragraph one since there will be one or more
-                    # blank lines within the footnote. We need to skip past these to the end of
-                    # the footnote before restarting the 'paragraph separator' search.
-                    #
-                    # Find closing square bracket - allow open/close bracket within footnote.
-                    # Start of line beginning '[Footnote ...'.
-                    start = maintext().rowcol(f"{blank_line_start} +1l linestart")
-                    # One character on from the above.
-                    end_point = maintext().rowcol(f"{blank_line_start} +1l +1c")
-                    end_match = None
-                    nested = False
-                    while True:
-                        end_match = maintext().find_match(
-                            "[][]", IndexRange(end_point, maintext().end()), regexp=True
-                        )
-                        if end_match is None:
-                            break
-                        end_point = maintext().rowcol(f"{end_match.rowcol.index()}+1c")
-                        if maintext().get_match_text(end_match) == "]":
-                            if not nested:
-                                break  # Found the one we want
-                            nested = False  # Closing nesting
-                        else:
-                            if nested:
-                                end_match = (
-                                    None  # Not attempting to handle double nesting
-                                )
-                                break
-                            nested = True  # Opening nesting
-
-                    # If closing [ not found, use end of line
-                    if end_match is None:
-                        end_point = maintext().rowcol(f"{start.row}.end")
-                    # We have the end point of the footnote. Restart blank line search
-                    # from there.
-                    search_range = IndexRange(
-                        end_point,
-                        maintext().rowcol(f"{file_end} + 1l linestart"),
-                    )
-                    continue
-                # If preceded by a Page Marker, position at the start of the Page Marker line.
-                line_before_text = maintext().get(
-                    f"{blank_line_start} -1l linestart",
-                    f"{blank_line_start} -1l lineend",
-                )
-                if line_before_text[0:11] == "-----File: ":
-                    blank_line_start = (
-                        maintext().rowcol(f"{blank_line_start} -1l linestart").index()
-                    )
-                # 'blank_line_start' is now same location whether paragraph is followed by a blank
-                # line or followed by a Page Marker then a blank line. Make sure mark point is on
-                # the same page as the paragraph it follows. Note that we may end up with more than
-                # one named mark at this location; that is, when there is more than one anchor
-                # in the paragraph there will be more than one footnote following the paragraph.
-                mark_point = maintext().rowcol(f"{blank_line_start} -1c")
-                maintext().set_mark_position(
-                    f"{mark_prefix}{an_record_index}",
-                    mark_point,
-                    gravity=tk.RIGHT,
-                )
-                break  # and repeat 'while' loop for the next anchor record
-
-        # Second pass.
-
-        # Iterate through the footnote record array copying the text of each footnote
-        # before deleting the original and then inserting the unchanged footnote text
-        # at its named insertion mark from the first pass.
-
-        fn_records = self.get_fn_records()
-        for fn_record_index, fn_record in enumerate(fn_records):
-            fn_cur_start = self.checker_dialog.mark_from_rowcol(fn_record.start)
-            fn_cur_end = self.checker_dialog.mark_from_rowcol(fn_record.end)
-            fn_lines = maintext().get(fn_cur_start, fn_cur_end)
-            mark_name = fn_cur_end
-            fn_is_deleted = False
-            # If the FN is followed on same line by an insertion mark, DON'T delete the
-            # terminating newline. Insertion marks are placed before the newline so if
-            # the latter is deleted then any footnotes moved to those insertion marks
-            # will be located on the wrong page; i.e. they will end up at the start of
-            # the following page.
-            while mark_name := maintext().mark_next(mark_name):  # type: ignore[assignment]
-                if mark_name.startswith(mark_prefix):
-                    # On same line?
-                    if maintext().compare(fn_cur_end, "==", mark_name):
-                        maintext().delete(
-                            f"{fn_cur_start} -1l linestart", f"{fn_cur_end}"
-                        )
-                        maintext().insert(
-                            f"{mark_prefix}{fn_record_index}",
-                            "\n\n" + fn_lines,
-                        )
-                        fn_is_deleted = True
-                    break
-            if not fn_is_deleted:
-                # FN is not followed by an insertion mark. Delete it and its preceding
-                # blank line so the space is closed up; e.g. in the case of a mid-paragrph
-                # FN where the paragraph continues on the next page. There is a bug in GG1
-                # which leaves a blank line mid-paragraph when a FN is deleted from that
-                # location.
-                maintext().delete(
-                    f"{fn_cur_start} -1l linestart", f"{fn_cur_end} +1l linestart"
-                )
-                maintext().insert(f"{mark_prefix}{fn_record_index}", "\n\n" + fn_lines)
-        # Third pass
-
-        # Iterate through the footnote records in reverse order removing blank lines
-        # left behind when FNs are deleted between the end of a paragraph and the
-        # insertion mark after the last FN in a list of FNs that followed it.
-
-        # Restore RIGHT gravity to the Checker mark at the end of each footnote.
-        self.change_gravity_left_to_right()
-        # Rebuild FN and AN record arrays.
-        self.run_check()
-        # Get FN records in reverse order. It is necessary that the 'for' loop below
-        # works backwards from the last footnote to the first footnote so that the
-        # location of each footnote that is processed is not affected by the deletion
-        # of blank lines below it in the file.
-        fn_records = self.get_fn_records()
-        fn_records_reversed = fn_records.copy()
-        fn_records_reversed.reverse()
-        for fn_record in fn_records_reversed:
-            fn_cur_start = fn_record.start.index()
-            fn_cur_end = fn_record.end.index()
-            fn_lines = maintext().get(fn_cur_start, fn_cur_end)
-            # Replace each block of TWO blank lines above a relocated footnote by ONE
-            # blank line until a single blank line remains.
-            while True:
-                text_to_match = maintext().get(
-                    f"{fn_cur_start} -2l linestart", f"{fn_cur_start} linestart"
-                )
-                if re.match(r"^\s+?$", text_to_match):
-                    maintext().delete(
-                        f"{fn_cur_start} -1l linestart", f"{fn_cur_start} linestart"
-                    )
-                    fn_cur_start = f"{fn_cur_start} -1l linestart"
-                else:
-                    # No longer two or more blank lines above the footnote.
-                    break
-
-        # End of final pass over footnotes.
-
-        # Footnotes have been moved. Rebuild anchor and footnote record arrays
-        # to reflect the changes.
-        self.run_check()
-        # Set flag to disable buttons after dialog refreshed so that user
-        # cannot execute a second FN move that might corrupt the file.
-        self.fns_have_been_moved = True
-        # Maintain the order of function calls below.
-        display_footnote_entries()
-        self.display_buttons()
-
-    def move_footnotes_to_lz(self) -> None:
-        """Implements the 'Move FNs to LZs' button.
-
-        There will either be a single LZ 'FOOTNOTES:' header at the end of the
-        file or multiple LZ 'FOOTNOTES:' headers, each one inserted before every
-        4-line chapter break and an added one at end of file. This means that all
-        footnotes have a LZ below them.
-        """
-        maintext().undo_block_begin()
-        # Check for any duplicate footnote labels and warn user that they should
-        # reindex footnotes before attempting to move them to paragraphs or LZ(s).
-        if not self.ok_to_move_fns():
-            logger.error(
-                "Duplicate labels - reindex footnotes before moving them to LZ(s)"
-            )
-            return
-
-        # Footnotes are always moved downward to a landing zone on a higher-numbered
-        # line. Even if a footnote sits immediately below a landing zone, it will be
-        # moved to the next one down in the file. There is always a 'next one down'
-        # landing zone if 'end LZ' or 'chapter LZ' specified but may not be if 'set
-        # LZ at cursor' used. We will add a LZ at file end if necessary as a 'catch
-        # all' to cope with missing LZs.
-        #
-        # Start the moves from the last footnote in the file and work upward to the
-        # first footnote. Each footnote moved is inserted immediately below the LZ
-        # header so pushing down higher-numbered footnotes already moved.
-
-        fn_records = self.get_fn_records()
-        fn_records_reversed = fn_records.copy()
-        fn_records_reversed.reverse()
-        an_records = self.get_an_records()
-        footnotes_header = "FOOTNOTES:"
-        for fn_record in fn_records_reversed:
-            fn_cur_start = self.checker_dialog.mark_from_rowcol(fn_record.start)
-            fn_cur_end = self.checker_dialog.mark_from_rowcol(fn_record.end)
-            fn_lines = maintext().get(fn_cur_start, fn_cur_end)
-            # Get anchor record for this footnote.
-            an_cur = an_records[fn_record.an_index]  # type: ignore[index]
-            an_cur_end = maintext().index(
-                self.checker_dialog.mark_from_rowcol(an_cur.end)
-            )
-            # Is there an LZ below the *anchor* of this footnote?
-            #
-            # NB This corrects a bug found by @sjfoo when chapter breaks occur mid-page
-            #    rather than starting a new page. A footnote at the bottom of the page
-            #    whose anchor is in the previous chapter is incorrectly moved to the LZ
-            #    for the following chapter. Doing the search for the LZ from immediately
-            #    after the anchor of each footnote avoids this pitfall.
-            #
-            # If no LZ, create one and move footnote below it. Otherwise move footnote
-            # below the LZ that was found
-            search_range = IndexRange(an_cur_end, maintext().end())
-            if lz_match := maintext().find_match(footnotes_header, search_range):
-                # There is a LZ below the anchor of the footnote.
-                lz_start = lz_match.rowcol.index()
-                below_lz = f"{lz_start} lineend"
-                # Insert the copy of the footnote line(s) below the LZ.
-                maintext().insert(below_lz, "\n\n" + fn_lines)
-                # Delete the original footnote line(s) along with the
-                # blank line above it.
-                maintext().delete(
-                    f"{fn_cur_start} -1l linestart", f"{fn_cur_end} +1l linestart"
-                )
-            else:
-                # This branch should be entered 0 or 1 times only. Here
-                # with a footnote anchor with no landing zone below.
-                # There are two situations where this can happen:
-                #  1. One or more LZs were added manually with 'set LZ
-                #     at cursor' but were perhaps wrongly placed.
-                #  2. No LZ was specified before clicking the move
-                #     to landing zones button.
-                #
-                # Insert a LZ after the last line of the file
-                # and move the footnote below it. Other footnotes
-                # with a lower index may be inserted immediately
-                # above it but that will be done in the 'then'
-                # branch above because there is now a LZ below
-                # those footnotes.
-                self.autoset_end_lz()
-                below_lz = maintext().end().index()
-                # Insert the copy of the footnote line(s) below the new LZ.
-                maintext().insert(below_lz, "\n" + fn_lines)
-                # Delete the original footnote line(s) along with the blank
-                # line above it.
-                maintext().delete(
-                    f"{fn_cur_start} -1l linestart", f"{fn_cur_end} +1l linestart"
-                )
-                # The last line of the file will be (the last line of) a
-                # footnote. Add a blank line after it.
-                self.add_blank_line_at_eof()
-        # Remove unused LZ headers ('FOOTNOTES:'). Only needed when moving to
-        # chapter end LZs but will be invoked for end LZ too. It does no harm
-        # in this latter case and saves setting/testing flags to make it apply
-        # only when moving FNs to chapter end LZs.
-        self.remove_unused_lz_headers()
-        # Ensure correct number of lines after 'FOOTNOTES:' header. If 4 blank
-        # lines before, then add extra blank line after to make 2 blank lines.
-        matches = maintext().find_matches(footnotes_header, maintext().start_to_end())
-        for match in reversed(matches):
-            match_idx = match.rowcol.index()
-            if (
-                maintext().get(f"{match_idx}-4l", match_idx) == "\n" * 4
-                and maintext().get(f"{match_idx}+1l", f"{match_idx}+3l") != "\n" * 2
-            ):
-                maintext().insert(f"{match_idx}+1l", "\n")
-        # Footnotes have been moved. Rebuild anchor and footnote record arrays
-        # to reflect the changes.
-        self.run_check()
-        # Set flag to disable buttons when dialog refreshed so that user cannot
-        # execute a second footnote move that might corrupt the file.
-        self.fns_have_been_moved = True
-        # Maintain order of function calls below.
-        display_footnote_entries()
-        self.display_buttons()
-
     def remove_unused_lz_headers(self) -> None:
         """Remove unused LZs and up to two preceding blank lines."""
         search_range = maintext().start_to_end()
@@ -750,31 +283,6 @@ class FootnoteChecker:
             labels_dict[fn_label] = fn_label
         return True
 
-    def tidy_footnotes(self) -> None:
-        """Tidy footnotes after they have been moved.
-
-        Copies and deletes the original footnote then reinserts edited
-        version at the same place.
-        """
-        maintext().undo_block_begin()
-        fn_records = self.get_fn_records()
-        for fn_record in fn_records:
-            fn_cur_start = self.checker_dialog.mark_from_rowcol(fn_record.start)
-            fn_cur_end = self.checker_dialog.mark_from_rowcol(fn_record.end)
-            fn_label_and_text_part = maintext().get(
-                f"{fn_cur_start} +10c", f"{fn_cur_end} -1c"
-            )
-            fn_label_and_text_part = re.sub(r"(^.+?):", r"[\1]", fn_label_and_text_part)
-            maintext().delete(fn_cur_start, fn_cur_end)
-            maintext().insert(fn_cur_start, fn_label_and_text_part)
-        # As there are no longer any '[Footnote ...' style records in the file
-        # the effect of invoking run_check() here will be to clear the dialog
-        # as there are no footnotes to report.
-        self.run_check()
-        # Maintain order of function calls below.
-        display_footnote_entries()
-        self.display_buttons()
-
     def get_anchor_hilite_columns_from_marks(self, an_record: AnchorRecord) -> tuple:
         """Get hilite start/end columns of an anchor from its start/end mark positions.
 
@@ -821,147 +329,6 @@ class FootnoteChecker:
         double_ch = (chr(65 + _double)) if label >= 26 else ""
         triple_ch = (chr(65 + _triple)) if label >= (676 + 26) else ""
         return triple_ch + double_ch + single_ch
-
-    def set_anchor(self) -> None:
-        """Insert anchor using label of selected footnote."""
-        maintext().undo_block_begin()
-        insert_index = maintext().get_insert_index().index()
-        # Get label to use  for anchor from the selected FN.
-        fn_index = self.get_selected_fn_index()
-        if fn_index < 0:
-            logger.error("No footnote selected")  # No selection
-            return
-        fn_records = self.get_fn_records()
-        fn_record = fn_records[fn_index]
-        fn_line_text = fn_record.text
-        fn_label_start = 10
-        fn_label_end = fn_line_text.find(":")
-        fn_label = fn_line_text[fn_label_start:fn_label_end]
-        maintext().insert(f"{insert_index}", f"[{fn_label}]")
-        # Update AN and FN record arrays then refresh the dialog.
-        self.run_check()
-        display_footnote_entries(auto_select_line=False)
-        # Make new anchor the selected entry in the dialog.
-        fn_records = self.get_fn_records()
-        # Get the footnote we previously selected.
-        fn_record = fn_records[fn_index]
-        # From that we can get the start index of the new anchor we created.
-        an_records = self.get_an_records()
-        an_record = an_records[fn_record.an_index]  # type: ignore[index]
-        # Get index into dialog entries for this record.
-        dialog_entry_index = self.map_an_record_to_dialog_index(an_record)
-        if dialog_entry_index < 0:
-            logger.error("Unexpected return from 'set_anchor()'")
-            return
-        # Make it the selected entry in the dialog.
-        self.checker_dialog.select_entry_by_index(dialog_entry_index)
-
-    def set_lz_at_cursor(self) -> None:
-        """Insert FOOTNOTES: header at cursor."""
-        maintext().undo_block_begin()
-        insert_index = maintext().get_insert_index().index()
-        insert_rowcol = maintext().get_insert_index()
-        # Place LZ 'FOOTNOTES:' header at cursor; normally the header
-        # is spaced two lines down from chapter end or end of book but
-        # if user is manually inserting LZs it is assumed they will
-        # add spacing as appropriate.
-        maintext().insert(f"{insert_index}", "FOOTNOTES:")
-        # The file has changed so rebuild AN/FN records and refresh dialog.
-        self.run_check()
-        # Order below is important. A flag is set in display_footnote_entries()
-        # that will determine which, if any, buttons are disabled when they are
-        # displayed.
-        display_footnote_entries()
-        self.display_buttons()
-        # Reposition main text window to display the inserted header in the midle of the window.
-        maintext().set_insert_index(insert_rowcol)
-
-    def reindex(self) -> None:
-        """Reindex all footnotes to fn_index_style.
-
-        Three radio buttons set fn_index_style. It is persistent
-        across runs so style chosen last time will be the current
-        labelling style until a different radio button clicked.
-
-        fn_index_style values are 'number', 'letter' or 'roman'.
-        """
-        maintext().undo_block_begin()
-        # Check index style used last time Footnotes Fixup was run or default if first run.
-        index_style = self.fn_index_style.get()
-        an_records = self.get_an_records()
-        fn_records = self.get_fn_records()
-        for index in range(1, len(an_records) + 1):
-            if index_style == "number":
-                label = index
-            elif index_style == "roman":
-                label = roman.toRoman(index)
-                label = label + "."  # type: ignore[operator]
-            elif index_style == "letter":
-                label = self.alpha(index)  # type: ignore[assignment]
-            else:
-                # Default
-                label = index
-            an_record = an_records[index - 1]
-            an_line_text = maintext().get(
-                f"{an_record.start.index()} linestart",
-                f"{an_record.start.index()} lineend",
-            )
-            hl_start, hl_end = self.get_anchor_hilite_columns_from_marks(an_record)
-            replacement_text = (
-                f"{an_line_text[0:hl_start]}[{label}]{an_line_text[hl_end:]}"
-            )
-            an_start = f"{an_record.start.index()} linestart"
-            maintext().delete(f"{an_start}", f"{an_start} lineend")
-            maintext().insert(f"{an_start}", replacement_text)
-            #
-            fn_record = fn_records[index - 1]
-            fn_line_text = fn_record.text
-            hl_start = fn_record.hilite_start
-            hl_end = fn_record.hilite_end
-            fn_line_text = (
-                f"{fn_line_text[0:hl_start + 9]}{label}{fn_line_text[hl_end:]}"
-            )
-            fn_start = f"{fn_record.start.index()} linestart"
-            # Replace (first line of) footnote using new label value.
-            maintext().delete(f"{fn_start}", f"{fn_start} lineend")
-            maintext().insert(f"{fn_start}", fn_line_text)
-        # AN/FN file entries have changed. Update AN/FN records.
-        self.run_check()
-        # Maintain the order of function calls below.
-        display_footnote_entries()
-        self.display_buttons()
-
-    def next_footnote(self, direction: str) -> None:
-        """Jump from the selected FN to next/previous FN.
-
-        The next/previous FN becomes the selected FN.
-
-        Args:
-            direction: "back" to previous FN or "forward" to next FN.
-        """
-        cur_fn_index = self.get_selected_fn_index()
-        if cur_fn_index < 0:
-            logger.error("No footnote selected")  # No selection
-            return
-        fn_records = self.get_fn_records()
-        if cur_fn_index == 0 and direction == "back":
-            # Can't move behind first footnote.
-            fn_record = fn_records[cur_fn_index]
-        elif cur_fn_index == len(fn_records) - 1 and direction == "forward":
-            # Can't move beyond last footnote.
-            fn_record = fn_records[cur_fn_index]
-        elif direction == "forward":
-            fn_record = fn_records[cur_fn_index + 1]
-        else:
-            # direction must be "back".
-            fn_record = fn_records[cur_fn_index - 1]
-        # Get index into dialog entries for the footnote we've moved to.
-        dialog_entry_index = self.map_fn_record_to_dialog_index(fn_record)
-        if dialog_entry_index < 0:
-            logger.error("Unexpected return from 'next_footnote()'")
-            return
-        # Make it the selected entry in the dialog.
-        self.checker_dialog.select_entry_by_index(dialog_entry_index)
 
     def map_fn_record_to_dialog_index(self, fn_record: FootnoteRecord) -> int:
         """Get the footnote's index in the dialog entries.
@@ -1015,159 +382,42 @@ class FootnoteChecker:
                 return fn_index
         return -1
 
-    def display_buttons(self) -> None:
-        """Helper function to create dialog window for run_check."""
-
-        fixit_frame = ttk.Frame(self.checker_dialog.header_frame)
-        fixit_frame.grid(column=0, row=1, sticky="NSEW")
-        # Weight only needs setting once for each column, not every row of
-        # every column.
-        fixit_frame.grid_columnconfigure(0, weight=1)
-        fixit_frame.grid_columnconfigure(1, weight=1)
-        fixit_frame.grid_columnconfigure(2, weight=1)
-        fixit_frame.grid_columnconfigure(3, weight=1)
-        # --
-        join_button = ttk.Button(
-            fixit_frame,
-            text="Join Selected FN to Previous",
-            command=self.join_to_previous,
-        )
-        join_button.grid(column=0, row=0, pady=2, sticky="NSEW")
-        # --
-        prev_fn_button = ttk.Button(
-            fixit_frame,
-            text="<-- Prev. FN",
-            command=lambda: self.next_footnote("back"),
-        )
-        prev_fn_button.grid(column=1, row=0, pady=2, sticky="NSEW")
-        # --
-        next_fn_button = ttk.Button(
-            fixit_frame,
-            text="Next FN -->",
-            command=lambda: self.next_footnote("forward"),
-        )
-        next_fn_button.grid(column=2, row=0, pady=2, sticky="NSEW")
-        # --
-        anchor_button = ttk.Button(
-            fixit_frame,
-            text="Set Anchor for Selected FN",
-            command=self.set_anchor,
-        )
-        anchor_button.grid(column=3, row=0, pady=2, sticky="NSEW")
-
-        # Reindexing Footnotes
-
-        all_to_num = ttk.Radiobutton(
-            fixit_frame,
-            text="All to Number",
-            variable=self.fn_index_style,
-            value=FootnoteIndexStyle.NUMBER,
-            takefocus=False,
-        )
-        all_to_num.grid(column=0, row=1, pady=2, sticky="NSEW")
-        # --
-        all_to_let = ttk.Radiobutton(
-            fixit_frame,
-            text="All to Letter",
-            variable=self.fn_index_style,
-            value=FootnoteIndexStyle.LETTER,
-            takefocus=False,
-        )
-        all_to_let.grid(column=1, row=1, pady=2, sticky="NSEW")
-        # --
-        all_to_rom = ttk.Radiobutton(
-            fixit_frame,
-            text="All to Roman",
-            variable=self.fn_index_style,
-            value=FootnoteIndexStyle.ROMAN,
-            takefocus=False,
-        )
-        all_to_rom.grid(column=2, row=1, pady=2, sticky="NSEW")
-        # --
-        reindex_button = ttk.Button(
-            fixit_frame,
-            text="Reindex",
-            command=self.reindex,
-        )
-        reindex_button.grid(column=3, row=1, pady=2, sticky="NSEW")
-
-        # Setting LZs, moving FNs, tidying FNs.
-
-        lz_set_at_cursor_button = ttk.Button(
-            fixit_frame,
-            text="Set LZ @ Cursor",
-            command=self.set_lz_at_cursor,
-        )
-        lz_set_at_cursor_button.grid(column=0, row=2, pady=2, sticky="NSEW")
-        # --
-        lz_set_at_end_button = ttk.Button(
-            fixit_frame,
-            text="Autoset End LZ",
-            command=self.autoset_end_lz,
-        )
-        lz_set_at_end_button.grid(column=1, row=2, pady=2, sticky="NSEW")
-        # --
-        lz_set_at_chapter_button = ttk.Button(
-            fixit_frame,
-            text="Autoset Chap. LZ",
-            command=self.autoset_chapter_lz,
-        )
-        lz_set_at_chapter_button.grid(column=2, row=2, pady=2, sticky="NSEW")
-        # --
-        move_to_lz_button = ttk.Button(
-            fixit_frame,
-            text="Move FNs to Landing Zone(s)",
-            command=self.move_footnotes_to_lz,
-        )
-        move_to_lz_button.grid(column=3, row=2, pady=2, sticky="NSEW")
-        # --
-        move_to_para_button = ttk.Button(
-            fixit_frame,
-            text="Move FNs to Paragraphs",
-            command=self.move_footnotes_to_paragraphs,
-        )
-        move_to_para_button.grid(column=0, row=3, pady=2, sticky="NSEW")
-        # --
-        fn_tidy_button = ttk.Button(
-            fixit_frame,
-            text="Tidy Footnotes",
-            command=self.tidy_footnotes,
-        )
-        fn_tidy_button.grid(column=3, row=3, pady=2, sticky="NSEW")
+    def enable_disable_buttons(self) -> None:
+        """Helper function to enable/disable buttons."""
 
         # Some buttons are disabled if their operation could corrupt the file.
 
         # The following flag is set once and never unset.
         if self.fns_have_been_moved:
-            lz_set_at_cursor_button.config(state="disable")
-            lz_set_at_chapter_button.config(state="disable")
-            lz_set_at_end_button.config(state="disable")
-            move_to_lz_button.config(state="disable")
-            move_to_para_button.config(state="disable")
-            reindex_button.config(state="disable")
-            join_button.config(state="disable")
-            anchor_button.config(state="disable")
+            self.checker_dialog.lz_set_at_cursor_button.config(state="disable")
+            self.checker_dialog.lz_set_at_chapter_button.config(state="disable")
+            self.checker_dialog.lz_set_at_end_button.config(state="disable")
+            self.checker_dialog.move_to_lz_button.config(state="disable")
+            self.checker_dialog.move_to_para_button.config(state="disable")
+            self.checker_dialog.reindex_button.config(state="disable")
+            self.checker_dialog.join_button.config(state="disable")
+            self.checker_dialog.anchor_button.config(state="disable")
         # The following flag is set if FN check errors and unset if
         # there are no errors.
         if self.fn_check_errors:
-            lz_set_at_cursor_button.config(state="disable")
-            lz_set_at_chapter_button.config(state="disable")
-            lz_set_at_end_button.config(state="disable")
-            move_to_lz_button.config(state="disable")
-            move_to_para_button.config(state="disable")
-            reindex_button.config(state="disable")
-            fn_tidy_button.config(state="disable")
+            self.checker_dialog.lz_set_at_cursor_button.config(state="disable")
+            self.checker_dialog.lz_set_at_chapter_button.config(state="disable")
+            self.checker_dialog.lz_set_at_end_button.config(state="disable")
+            self.checker_dialog.move_to_lz_button.config(state="disable")
+            self.checker_dialog.move_to_para_button.config(state="disable")
+            self.checker_dialog.reindex_button.config(state="disable")
+            self.checker_dialog.fn_tidy_button.config(state="disable")
         # Enable all buttons if neither of the 'disable' flags are True.
         if not (self.fn_check_errors or self.fns_have_been_moved):
-            join_button.config(state="normal")
-            anchor_button.config(state="normal")
-            reindex_button.config(state="normal")
-            lz_set_at_cursor_button.config(state="normal")
-            lz_set_at_chapter_button.config(state="normal")
-            lz_set_at_end_button.config(state="normal")
-            move_to_lz_button.config(state="normal")
-            move_to_para_button.config(state="normal")
-            fn_tidy_button.config(state="normal")
+            self.checker_dialog.join_button.config(state="normal")
+            self.checker_dialog.anchor_button.config(state="normal")
+            self.checker_dialog.reindex_button.config(state="normal")
+            self.checker_dialog.lz_set_at_cursor_button.config(state="normal")
+            self.checker_dialog.lz_set_at_chapter_button.config(state="normal")
+            self.checker_dialog.lz_set_at_end_button.config(state="normal")
+            self.checker_dialog.move_to_lz_button.config(state="normal")
+            self.checker_dialog.move_to_para_button.config(state="normal")
+            self.checker_dialog.fn_tidy_button.config(state="normal")
 
     def run_check(self) -> None:
         """Run the initial footnote check."""
@@ -1282,6 +532,797 @@ def sort_key_type(
     )
 
 
+def join_to_previous() -> None:
+    """Join the selected footnote to the previous one."""
+    assert _the_footnote_checker is not None
+    maintext().undo_block_begin()
+    fn_index = _the_footnote_checker.get_selected_fn_index()
+    if fn_index < 0:
+        return  # No selection
+    if fn_index == 0:
+        return  # Can't join first footnote to previous
+    fn_records = _the_footnote_checker.get_fn_records()
+    fn_record = fn_records[fn_index]
+    fn_cur_start = _the_footnote_checker.checker_dialog.mark_from_rowcol(
+        fn_record.start
+    )
+    fn_cur_end = _the_footnote_checker.checker_dialog.mark_from_rowcol(fn_record.end)
+    prev_record = fn_records[fn_index - 1]
+    fn_prev_end = _the_footnote_checker.checker_dialog.mark_from_rowcol(prev_record.end)
+    continuation_text = maintext().get(fn_cur_start, fn_cur_end)[11:]
+    maintext().delete(f"{fn_cur_start} -1l linestart", f"{fn_cur_end} +1l linestart")
+    maintext().delete(f"{fn_prev_end} -1c", f"{fn_prev_end} lineend")
+    maintext().insert(fn_prev_end, "\n" + continuation_text)
+    _the_footnote_checker.checker_dialog.remove_entry_current()
+    # Note index of the record to which we joined the continuation text.
+    saved_prev_rec_index = fn_index - 1
+    _the_footnote_checker.run_check()
+    display_footnote_entries(auto_select_line=False)
+    fn_records = _the_footnote_checker.get_fn_records()
+    prev_record = fn_records[saved_prev_rec_index]
+    # Get index into dialog entries for this record.
+    dialog_entry_index = _the_footnote_checker.map_fn_record_to_dialog_index(
+        prev_record
+    )
+    if dialog_entry_index < 0:
+        logger.error("Unexpected return from 'join_to_previous()'")
+        return
+    # Make it the selected entry in the dialog.
+    _the_footnote_checker.checker_dialog.select_entry_by_index(dialog_entry_index)
+
+
+def next_footnote(direction: str) -> None:
+    """Jump from the selected FN to next/previous FN.
+
+    The next/previous FN becomes the selected FN.
+
+    Args:
+        direction: "back" to previous FN or "forward" to next FN.
+    """
+    assert _the_footnote_checker is not None
+    cur_fn_index = _the_footnote_checker.get_selected_fn_index()
+    if cur_fn_index < 0:
+        logger.error("No footnote selected")  # No selection
+        return
+    fn_records = _the_footnote_checker.get_fn_records()
+    if cur_fn_index == 0 and direction == "back":
+        # Can't move behind first footnote.
+        fn_record = fn_records[cur_fn_index]
+    elif cur_fn_index == len(fn_records) - 1 and direction == "forward":
+        # Can't move beyond last footnote.
+        fn_record = fn_records[cur_fn_index]
+    elif direction == "forward":
+        fn_record = fn_records[cur_fn_index + 1]
+    else:
+        # direction must be "back".
+        fn_record = fn_records[cur_fn_index - 1]
+    # Get index into dialog entries for the footnote we've moved to.
+    dialog_entry_index = _the_footnote_checker.map_fn_record_to_dialog_index(fn_record)
+    if dialog_entry_index < 0:
+        logger.error("Unexpected return from 'next_footnote()'")
+        return
+    # Make it the selected entry in the dialog.
+    _the_footnote_checker.checker_dialog.select_entry_by_index(dialog_entry_index)
+
+
+def set_anchor() -> None:
+    """Insert anchor using label of selected footnote."""
+    assert _the_footnote_checker is not None
+    maintext().undo_block_begin()
+    insert_index = maintext().get_insert_index().index()
+    # Get label to use  for anchor from the selected FN.
+    fn_index = _the_footnote_checker.get_selected_fn_index()
+    if fn_index < 0:
+        logger.error("No footnote selected")  # No selection
+        return
+    fn_records = _the_footnote_checker.get_fn_records()
+    fn_record = fn_records[fn_index]
+    fn_line_text = fn_record.text
+    fn_label_start = 10
+    fn_label_end = fn_line_text.find(":")
+    fn_label = fn_line_text[fn_label_start:fn_label_end]
+    maintext().insert(f"{insert_index}", f"[{fn_label}]")
+    # Update AN and FN record arrays then refresh the dialog.
+    _the_footnote_checker.run_check()
+    display_footnote_entries(auto_select_line=False)
+    # Make new anchor the selected entry in the dialog.
+    fn_records = _the_footnote_checker.get_fn_records()
+    # Get the footnote we previously selected.
+    fn_record = fn_records[fn_index]
+    # From that we can get the start index of the new anchor we created.
+    an_records = _the_footnote_checker.get_an_records()
+    an_record = an_records[fn_record.an_index]  # type: ignore[index]
+    # Get index into dialog entries for this record.
+    dialog_entry_index = _the_footnote_checker.map_an_record_to_dialog_index(an_record)
+    if dialog_entry_index < 0:
+        logger.error("Unexpected return from 'set_anchor()'")
+        return
+    # Make it the selected entry in the dialog.
+    _the_footnote_checker.checker_dialog.select_entry_by_index(dialog_entry_index)
+
+
+def set_lz_at_cursor() -> None:
+    """Insert FOOTNOTES: header at cursor."""
+    assert _the_footnote_checker is not None
+    maintext().undo_block_begin()
+    insert_index = maintext().get_insert_index().index()
+    insert_rowcol = maintext().get_insert_index()
+    # Place LZ 'FOOTNOTES:' header at cursor; normally the header
+    # is spaced two lines down from chapter end or end of book but
+    # if user is manually inserting LZs it is assumed they will
+    # add spacing as appropriate.
+    maintext().insert(f"{insert_index}", "FOOTNOTES:")
+    # The file has changed so rebuild AN/FN records and refresh dialog.
+    _the_footnote_checker.run_check()
+    # Order below is important. A flag is set in display_footnote_entries()
+    # that will determine which, if any, buttons are disabled when they are
+    # displayed.
+    display_footnote_entries()
+    _the_footnote_checker.enable_disable_buttons()
+    # Reposition main text window to display the inserted header in the midle of the window.
+    maintext().set_insert_index(insert_rowcol)
+
+
+def reindex() -> None:
+    """Reindex all footnotes to FOOTNOTE_INDEX_STYLE.
+
+    Three radio buttons control FOOTNOTE_INDEX_STYLE. It is persistent
+    across runs so style chosen last time will be the current
+    labelling style until a different radio button clicked.
+
+    FOOTNOTE_INDEX_STYLE values are 'number', 'letter' or 'roman'.
+    """
+    assert _the_footnote_checker is not None
+    maintext().undo_block_begin()
+    # Check index style used last time Footnotes Fixup was run or default if first run.
+    index_style = preferences.get(PrefKey.FOOTNOTE_INDEX_STYLE)
+    an_records = _the_footnote_checker.get_an_records()
+    fn_records = _the_footnote_checker.get_fn_records()
+    for index in range(1, len(an_records) + 1):
+        if index_style == "number":
+            label = index
+        elif index_style == "roman":
+            label = roman.toRoman(index)
+            label = label + "."  # type: ignore[operator]
+        elif index_style == "letter":
+            label = _the_footnote_checker.alpha(index)  # type: ignore[assignment]
+        else:
+            # Default
+            label = index
+        an_record = an_records[index - 1]
+        an_line_text = maintext().get(
+            f"{an_record.start.index()} linestart",
+            f"{an_record.start.index()} lineend",
+        )
+        hl_start, hl_end = _the_footnote_checker.get_anchor_hilite_columns_from_marks(
+            an_record
+        )
+        replacement_text = f"{an_line_text[0:hl_start]}[{label}]{an_line_text[hl_end:]}"
+        an_start = f"{an_record.start.index()} linestart"
+        maintext().delete(f"{an_start}", f"{an_start} lineend")
+        maintext().insert(f"{an_start}", replacement_text)
+        #
+        fn_record = fn_records[index - 1]
+        fn_line_text = fn_record.text
+        hl_start = fn_record.hilite_start
+        hl_end = fn_record.hilite_end
+        fn_line_text = f"{fn_line_text[0:hl_start + 9]}{label}{fn_line_text[hl_end:]}"
+        fn_start = f"{fn_record.start.index()} linestart"
+        # Replace (first line of) footnote using new label value.
+        maintext().delete(f"{fn_start}", f"{fn_start} lineend")
+        maintext().insert(f"{fn_start}", fn_line_text)
+    # AN/FN file entries have changed. Update AN/FN records.
+    _the_footnote_checker.run_check()
+    # Maintain the order of function calls below.
+    display_footnote_entries()
+    _the_footnote_checker.enable_disable_buttons()
+
+
+def autoset_end_lz() -> None:
+    """Insert a 'FOOTNOTES:' LZ header line at end of file."""
+    assert _the_footnote_checker is not None
+    maintext().undo_block_begin()
+    # If the last line of the file is not a blank line then add one.
+    end_of_file = maintext().end().index()
+    if maintext().get(f"{end_of_file} linestart", f"{end_of_file} lineend") != "":
+        _the_footnote_checker.add_blank_line_at_eof()
+    end_of_file = maintext().end().index()
+    _the_footnote_checker.set_lz(end_of_file)
+
+
+def autoset_chapter_lz() -> None:
+    """Insert a 'FOOTNOTES:' landing zone (LZ) header line before each
+    chapter break.
+
+    If chapters are separated correctly from the next chapter by 4 blank
+    lines then there will always be a LZ header inserted at the end of
+    each chapter, except at the end of the last chapter. Append a header
+    to end of file to catch any footnotes in the last chapter. This means
+    that all footnotes will then have a LZ header below them.
+
+    No LZ headers are inserted before the first anchor to avoid adding
+    them at pseudo chapter breaks in front matter, etc. Unused LZ headers
+    are deleted after footnotes have been moved to LZs - see call to
+    remove_unused_lz_headers() in the function move_footnotes_to_lz().
+    """
+    assert _the_footnote_checker is not None
+    maintext().undo_block_begin()
+    # If the last line of the file is not a blank line then add one.
+    end_of_file = maintext().end().index()
+    if maintext().get(f"{end_of_file} linestart", f"{end_of_file} lineend") != "":
+        _the_footnote_checker.add_blank_line_at_eof()
+    # Append LZ header to end of file to catch footnotes in the last chapter
+    autoset_end_lz()
+    # Set search range for finding 'chapter breaks'. Look for them from the
+    # start of the first anchor rather than after the first 200 lines as
+    # in GG1.
+    an_records = _the_footnote_checker.get_an_records()
+    first_an = an_records[0]
+    search_range = IndexRange(first_an.start, maintext().end())
+    # Loop, finding all chapter breaks; i.e. block of 4 blank lines. Method
+    # used is to find next blank line then look ahead for 3 more blank lines.
+    # If present then set a LZ and advance 6 lines and repeat. If look ahead
+    # does not find 3 more blank lines then advance 1 line and repeat. This
+    # is based on GG1 method.
+    match_regex = r"^$"
+    while True:
+        beg_match = maintext().find_match(match_regex, search_range, regexp=True)
+        if not beg_match:
+            break
+        start_index = beg_match.rowcol.index()
+        # If next three lines are also empty, insert a LZ "FOOTNOTES:" header
+        # before the 4-line block.
+        if (
+            maintext().get(f"{start_index} +1l linestart", f"{start_index} +1l lineend")
+            == ""
+            and maintext().get(
+                f"{start_index} +2l linestart", f"{start_index} +2l lineend"
+            )
+            == ""
+            and maintext().get(
+                f"{start_index} +3l linestart", f"{start_index} +3l lineend"
+            )
+            == ""
+        ):
+            # Insert the LZ header.
+            _the_footnote_checker.set_lz(start_index)
+            # Advance past inserted LZ.
+            restart_point = maintext().rowcol(f"{start_index} +6l")
+        else:
+            # Advance to avoid finding same blank line again.
+            restart_point = maintext().rowcol(f"{start_index} +1l")
+        search_range = IndexRange(restart_point, maintext().end())
+
+        # The file has changed so rebuild AN/FN records and refresh dialog.
+        _the_footnote_checker.run_check()
+        # Order below is important. A flag is set in display_footnote_entries()
+        # that will determine which, if any, buttons are disabled when they are
+        # displayed.
+        display_footnote_entries()
+        _the_footnote_checker.enable_disable_buttons()
+
+
+def move_footnotes_to_paragraphs() -> None:
+    """Implements the 'Move FNs to Paragraphs' button.
+
+    Moves footnotes to below the paragraph in which they are anchored. There
+    are no 'FOOTNOTES:' headers.
+
+    It is a three-pass process. In the first pass a named mark for each anchor
+    record is set. The location of each mark is the insertion point to which
+    the corresponding footnote will be moved. There may be many marks at the
+    same location.
+
+    The insertion point for marks is immediately BEFORE the line that separates
+    the end of a paragraph from all that follows. That line is either a blank
+    line that is not followed by a '[Footnote ...' line or is a Page Marker if
+    that immediately precedes such a blank line. In this way care is taken to
+    ensure insertion marks are located on the same page as the paragraph that
+    they follow. Special action is required for blank lines that separate
+    paragraphs in a multi-paragraph footnote.
+
+    The second pass simply iterates through the footnote record array copying
+    the text of each footnote before deleting the original and then inserting
+    the unchanged footnote text at its named insertion mark from the first pass.
+
+    The third pass iterates through footnote records in reverse order removing
+    any blank lines left behind when footnotes are deleted.
+    """
+    assert _the_footnote_checker is not None
+    maintext().undo_block_begin()
+    # Check for any duplicate footnote labels and warn user that they should
+    # reindex footnotes before attempting to move them to paragraphs or LZ(s).
+    if not _the_footnote_checker.ok_to_move_fns():
+        logger.error(
+            "Duplicate labels - reindex footnotes before moving them to paragraphs"
+        )
+        return
+    # Flip the gravity of all Checker marks at the end of each FN to tk.LEFT.
+    # Can now reliably place insertion marks after the Checker mark so that
+    # they maintain the required ordering. We'll flip the gravity back again
+    # at the end of this function.
+    _the_footnote_checker.change_gravity_right_to_left()
+    an_records = _the_footnote_checker.get_an_records()
+    # If the last line of the file is not a blank line then add one. If the
+    # last line of the file is a footnote then because its end Checker mark
+    # is currently tk.LEFT the newline will be correctly placed after the
+    # Checker mark. Dont' have to call self.add_blank_line_at_eof() to do this
+    file_end = maintext().end().index()
+    if maintext().get(f"{file_end} linestart", f"{file_end} lineend") != "":
+        maintext().insert(file_end, "\n")
+    file_end = maintext().end().index()
+
+    # First pass.
+
+    # Set marks at the start of the blank line that separates a paragraph from the start
+    # of the next paragraph. If that blank line is preceded by a Page Marker, set marks
+    # at the start of the Page Marker. Those two locations are the same.
+
+    mark_prefix = (
+        _the_footnote_checker.checker_dialog.get_mark_prefix() + INSERTION_MARK_PREFIX
+    )
+    file_end = maintext().end().index()
+    match_regex = r"^$"
+    for an_record_index, an_record in enumerate(an_records):
+        # Find the end of the paragraph in which the footnote anchor is located.
+        # Start searching from the line containing the anchor.
+        search_range = IndexRange(
+            an_record.start, maintext().rowcol(f"{file_end} + 1l linestart")
+        )
+        while blank_line_match := maintext().find_match(
+            match_regex, search_range, regexp=True
+        ):
+            # Found the first blank line after the paragraph.
+            blank_line_start = blank_line_match.rowcol.index()
+            # It might separate paragraph text from a footnote at the bottom of the page
+            # with the paragraph continuing at the top of the next page.
+            line_after_text = maintext().get(
+                f"{blank_line_start} +1l linestart",
+                f"{blank_line_start} +1l lineend",
+            )
+            if line_after_text[0:10] == "[Footnote ":
+                # Ignore this blank line and continue searching. However there is a problem
+                # if the footnote is a multi-paragraph one since there will be one or more
+                # blank lines within the footnote. We need to skip past these to the end of
+                # the footnote before restarting the 'paragraph separator' search.
+                #
+                # Find closing square bracket - allow open/close bracket within footnote.
+                # Start of line beginning '[Footnote ...'.
+                start = maintext().rowcol(f"{blank_line_start} +1l linestart")
+                # One character on from the above.
+                end_point = maintext().rowcol(f"{blank_line_start} +1l +1c")
+                end_match = None
+                nested = False
+                while True:
+                    end_match = maintext().find_match(
+                        "[][]", IndexRange(end_point, maintext().end()), regexp=True
+                    )
+                    if end_match is None:
+                        break
+                    end_point = maintext().rowcol(f"{end_match.rowcol.index()}+1c")
+                    if maintext().get_match_text(end_match) == "]":
+                        if not nested:
+                            break  # Found the one we want
+                        nested = False  # Closing nesting
+                    else:
+                        if nested:
+                            end_match = None  # Not attempting to handle double nesting
+                            break
+                        nested = True  # Opening nesting
+
+                # If closing [ not found, use end of line
+                if end_match is None:
+                    end_point = maintext().rowcol(f"{start.row}.end")
+                # We have the end point of the footnote. Restart blank line search
+                # from there.
+                search_range = IndexRange(
+                    end_point,
+                    maintext().rowcol(f"{file_end} + 1l linestart"),
+                )
+                continue
+            # If preceded by a Page Marker, position at the start of the Page Marker line.
+            line_before_text = maintext().get(
+                f"{blank_line_start} -1l linestart",
+                f"{blank_line_start} -1l lineend",
+            )
+            if line_before_text[0:11] == "-----File: ":
+                blank_line_start = (
+                    maintext().rowcol(f"{blank_line_start} -1l linestart").index()
+                )
+            # 'blank_line_start' is now same location whether paragraph is followed by a blank
+            # line or followed by a Page Marker then a blank line. Make sure mark point is on
+            # the same page as the paragraph it follows. Note that we may end up with more than
+            # one named mark at this location; that is, when there is more than one anchor
+            # in the paragraph there will be more than one footnote following the paragraph.
+            mark_point = maintext().rowcol(f"{blank_line_start} -1c")
+            maintext().set_mark_position(
+                f"{mark_prefix}{an_record_index}",
+                mark_point,
+                gravity=tk.RIGHT,
+            )
+            break  # and repeat 'while' loop for the next anchor record
+
+    # Second pass.
+
+    # Iterate through the footnote record array copying the text of each footnote
+    # before deleting the original and then inserting the unchanged footnote text
+    # at its named insertion mark from the first pass.
+
+    fn_records = _the_footnote_checker.get_fn_records()
+    for fn_record_index, fn_record in enumerate(fn_records):
+        fn_cur_start = _the_footnote_checker.checker_dialog.mark_from_rowcol(
+            fn_record.start
+        )
+        fn_cur_end = _the_footnote_checker.checker_dialog.mark_from_rowcol(
+            fn_record.end
+        )
+        fn_lines = maintext().get(fn_cur_start, fn_cur_end)
+        mark_name = fn_cur_end
+        fn_is_deleted = False
+        # If the FN is followed on same line by an insertion mark, DON'T delete the
+        # terminating newline. Insertion marks are placed before the newline so if
+        # the latter is deleted then any footnotes moved to those insertion marks
+        # will be located on the wrong page; i.e. they will end up at the start of
+        # the following page.
+        while mark_name := maintext().mark_next(mark_name):  # type: ignore[assignment]
+            if mark_name.startswith(mark_prefix):
+                # On same line?
+                if maintext().compare(fn_cur_end, "==", mark_name):
+                    maintext().delete(f"{fn_cur_start} -1l linestart", f"{fn_cur_end}")
+                    maintext().insert(
+                        f"{mark_prefix}{fn_record_index}",
+                        "\n\n" + fn_lines,
+                    )
+                    fn_is_deleted = True
+                break
+        if not fn_is_deleted:
+            # FN is not followed by an insertion mark. Delete it and its preceding
+            # blank line so the space is closed up; e.g. in the case of a mid-paragrph
+            # FN where the paragraph continues on the next page. There is a bug in GG1
+            # which leaves a blank line mid-paragraph when a FN is deleted from that
+            # location.
+            maintext().delete(
+                f"{fn_cur_start} -1l linestart", f"{fn_cur_end} +1l linestart"
+            )
+            maintext().insert(f"{mark_prefix}{fn_record_index}", "\n\n" + fn_lines)
+    # Third pass
+
+    # Iterate through the footnote records in reverse order removing blank lines
+    # left behind when FNs are deleted between the end of a paragraph and the
+    # insertion mark after the last FN in a list of FNs that followed it.
+
+    # Restore RIGHT gravity to the Checker mark at the end of each footnote.
+    _the_footnote_checker.change_gravity_left_to_right()
+    # Rebuild FN and AN record arrays.
+    _the_footnote_checker.run_check()
+    # Get FN records in reverse order. It is necessary that the 'for' loop below
+    # works backwards from the last footnote to the first footnote so that the
+    # location of each footnote that is processed is not affected by the deletion
+    # of blank lines below it in the file.
+    fn_records = _the_footnote_checker.get_fn_records()
+    fn_records_reversed = fn_records.copy()
+    fn_records_reversed.reverse()
+    for fn_record in fn_records_reversed:
+        fn_cur_start = fn_record.start.index()
+        fn_cur_end = fn_record.end.index()
+        fn_lines = maintext().get(fn_cur_start, fn_cur_end)
+        # Replace each block of TWO blank lines above a relocated footnote by ONE
+        # blank line until a single blank line remains.
+        while True:
+            text_to_match = maintext().get(
+                f"{fn_cur_start} -2l linestart", f"{fn_cur_start} linestart"
+            )
+            if re.match(r"^\s+?$", text_to_match):
+                maintext().delete(
+                    f"{fn_cur_start} -1l linestart", f"{fn_cur_start} linestart"
+                )
+                fn_cur_start = f"{fn_cur_start} -1l linestart"
+            else:
+                # No longer two or more blank lines above the footnote.
+                break
+
+    # End of final pass over footnotes.
+
+    # Footnotes have been moved. Rebuild anchor and footnote record arrays
+    # to reflect the changes.
+    _the_footnote_checker.run_check()
+    # Set flag to disable buttons after dialog refreshed so that user
+    # cannot execute a second FN move that might corrupt the file.
+    _the_footnote_checker.fns_have_been_moved = True
+    # Maintain the order of function calls below.
+    display_footnote_entries()
+    _the_footnote_checker.enable_disable_buttons()
+
+
+def move_footnotes_to_lz() -> None:
+    """Implements the 'Move FNs to LZs' button.
+
+    There will either be a single LZ 'FOOTNOTES:' header at the end of the
+    file or multiple LZ 'FOOTNOTES:' headers, each one inserted before every
+    4-line chapter break and an added one at end of file. This means that all
+    footnotes have a LZ below them.
+    """
+    assert _the_footnote_checker is not None
+    maintext().undo_block_begin()
+    # Check for any duplicate footnote labels and warn user that they should
+    # reindex footnotes before attempting to move them to paragraphs or LZ(s).
+    if not _the_footnote_checker.ok_to_move_fns():
+        logger.error("Duplicate labels - reindex footnotes before moving them to LZ(s)")
+        return
+
+    # Footnotes are always moved downward to a landing zone on a higher-numbered
+    # line. Even if a footnote sits immediately below a landing zone, it will be
+    # moved to the next one down in the file. There is always a 'next one down'
+    # landing zone if 'end LZ' or 'chapter LZ' specified but may not be if 'set
+    # LZ at cursor' used. We will add a LZ at file end if necessary as a 'catch
+    # all' to cope with missing LZs.
+    #
+    # Start the moves from the last footnote in the file and work upward to the
+    # first footnote. Each footnote moved is inserted immediately below the LZ
+    # header so pushing down higher-numbered footnotes already moved.
+
+    fn_records = _the_footnote_checker.get_fn_records()
+    fn_records_reversed = fn_records.copy()
+    fn_records_reversed.reverse()
+    an_records = _the_footnote_checker.get_an_records()
+    footnotes_header = "FOOTNOTES:"
+    for fn_record in fn_records_reversed:
+        fn_cur_start = _the_footnote_checker.checker_dialog.mark_from_rowcol(
+            fn_record.start
+        )
+        fn_cur_end = _the_footnote_checker.checker_dialog.mark_from_rowcol(
+            fn_record.end
+        )
+        fn_lines = maintext().get(fn_cur_start, fn_cur_end)
+        # Get anchor record for this footnote.
+        an_cur = an_records[fn_record.an_index]  # type: ignore[index]
+        an_cur_end = maintext().index(
+            _the_footnote_checker.checker_dialog.mark_from_rowcol(an_cur.end)
+        )
+        # Is there an LZ below the *anchor* of this footnote?
+        #
+        # NB This corrects a bug found by @sjfoo when chapter breaks occur mid-page
+        #    rather than starting a new page. A footnote at the bottom of the page
+        #    whose anchor is in the previous chapter is incorrectly moved to the LZ
+        #    for the following chapter. Doing the search for the LZ from immediately
+        #    after the anchor of each footnote avoids this pitfall.
+        #
+        # If no LZ, create one and move footnote below it. Otherwise move footnote
+        # below the LZ that was found
+        search_range = IndexRange(an_cur_end, maintext().end())
+        if lz_match := maintext().find_match(footnotes_header, search_range):
+            # There is a LZ below the anchor of the footnote.
+            lz_start = lz_match.rowcol.index()
+            below_lz = f"{lz_start} lineend"
+            # Insert the copy of the footnote line(s) below the LZ.
+            maintext().insert(below_lz, "\n\n" + fn_lines)
+            # Delete the original footnote line(s) along with the
+            # blank line above it.
+            maintext().delete(
+                f"{fn_cur_start} -1l linestart", f"{fn_cur_end} +1l linestart"
+            )
+        else:
+            # This branch should be entered 0 or 1 times only. Here
+            # with a footnote anchor with no landing zone below.
+            # There are two situations where this can happen:
+            #  1. One or more LZs were added manually with 'set LZ
+            #     at cursor' but were perhaps wrongly placed.
+            #  2. No LZ was specified before clicking the move
+            #     to landing zones button.
+            #
+            # Insert a LZ after the last line of the file
+            # and move the footnote below it. Other footnotes
+            # with a lower index may be inserted immediately
+            # above it but that will be done in the 'then'
+            # branch above because there is now a LZ below
+            # those footnotes.
+            autoset_end_lz()
+            below_lz = maintext().end().index()
+            # Insert the copy of the footnote line(s) below the new LZ.
+            maintext().insert(below_lz, "\n" + fn_lines)
+            # Delete the original footnote line(s) along with the blank
+            # line above it.
+            maintext().delete(
+                f"{fn_cur_start} -1l linestart", f"{fn_cur_end} +1l linestart"
+            )
+            # The last line of the file will be (the last line of) a
+            # footnote. Add a blank line after it.
+            _the_footnote_checker.add_blank_line_at_eof()
+    # Remove unused LZ headers ('FOOTNOTES:'). Only needed when moving to
+    # chapter end LZs but will be invoked for end LZ too. It does no harm
+    # in this latter case and saves setting/testing flags to make it apply
+    # only when moving FNs to chapter end LZs.
+    _the_footnote_checker.remove_unused_lz_headers()
+    # Ensure correct number of lines after 'FOOTNOTES:' header. If 4 blank
+    # lines before, then add extra blank line after to make 2 blank lines.
+    matches = maintext().find_matches(footnotes_header, maintext().start_to_end())
+    for match in reversed(matches):
+        match_idx = match.rowcol.index()
+        if (
+            maintext().get(f"{match_idx}-4l", match_idx) == "\n" * 4
+            and maintext().get(f"{match_idx}+1l", f"{match_idx}+3l") != "\n" * 2
+        ):
+            maintext().insert(f"{match_idx}+1l", "\n")
+    # Footnotes have been moved. Rebuild anchor and footnote record arrays
+    # to reflect the changes.
+    _the_footnote_checker.run_check()
+    # Set flag to disable buttons when dialog refreshed so that user cannot
+    # execute a second footnote move that might corrupt the file.
+    _the_footnote_checker.fns_have_been_moved = True
+    # Maintain order of function calls below.
+    display_footnote_entries()
+    _the_footnote_checker.enable_disable_buttons()
+
+
+def tidy_footnotes() -> None:
+    """Tidy footnotes after they have been moved.
+
+    Copies and deletes the original footnote then reinserts edited
+    version at the same place.
+    """
+    assert _the_footnote_checker is not None
+    maintext().undo_block_begin()
+    fn_records = _the_footnote_checker.get_fn_records()
+    for fn_record in fn_records:
+        fn_cur_start = _the_footnote_checker.checker_dialog.mark_from_rowcol(
+            fn_record.start
+        )
+        fn_cur_end = _the_footnote_checker.checker_dialog.mark_from_rowcol(
+            fn_record.end
+        )
+        fn_label_and_text_part = maintext().get(
+            f"{fn_cur_start} +10c", f"{fn_cur_end} -1c"
+        )
+        fn_label_and_text_part = re.sub(r"(^.+?):", r"[\1]", fn_label_and_text_part)
+        maintext().delete(fn_cur_start, fn_cur_end)
+        maintext().insert(fn_cur_start, fn_label_and_text_part)
+    # As there are no longer any '[Footnote ...' style records in the file
+    # the effect of invoking run_check() here will be to clear the dialog
+    # as there are no footnotes to report.
+    _the_footnote_checker.run_check()
+    # Maintain order of function calls below.
+    display_footnote_entries()
+    _the_footnote_checker.enable_disable_buttons()
+
+
+class FootnoteCheckerDialog(CheckerDialog):
+    """Footnote Fixup dialog."""
+
+    manual_page = "Tools_Menu#Footnote_Fixup"
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize Footnote Fixup dialog."""
+
+        super().__init__(
+            "Footnote Check Results",
+            tooltip="\n".join(
+                [
+                    "Left click: Select & find footnote",
+                    "Right click: Remove item from list",
+                    "Shift-Right click: Remove all matching items",
+                ]
+            ),
+            **kwargs,
+        )
+
+        fixit_frame = ttk.Frame(self.header_frame)
+        fixit_frame.grid(column=0, row=1, sticky="NSEW")
+        # Weight only needs setting once for each column, not every row of
+        # every column.
+        fixit_frame.grid_columnconfigure(0, weight=1)
+        fixit_frame.grid_columnconfigure(1, weight=1)
+        fixit_frame.grid_columnconfigure(2, weight=1)
+        fixit_frame.grid_columnconfigure(3, weight=1)
+        # --
+        self.join_button = ttk.Button(
+            fixit_frame,
+            text="Join Selected FN to Previous",
+            command=join_to_previous,
+        )
+        self.join_button.grid(column=0, row=0, pady=2, sticky="NSEW")
+        # --
+        self.prev_fn_button = ttk.Button(
+            fixit_frame,
+            text="<-- Prev. FN",
+            command=lambda: next_footnote("back"),
+        )
+        self.prev_fn_button.grid(column=1, row=0, pady=2, sticky="NSEW")
+        # --
+        self.next_fn_button = ttk.Button(
+            fixit_frame,
+            text="Next FN -->",
+            command=lambda: next_footnote("forward"),
+        )
+        self.next_fn_button.grid(column=2, row=0, pady=2, sticky="NSEW")
+        # --
+        self.anchor_button = ttk.Button(
+            fixit_frame,
+            text="Set Anchor for Selected FN",
+            command=set_anchor,
+        )
+        self.anchor_button.grid(column=3, row=0, pady=2, sticky="NSEW")
+
+        # Reindexing Footnotes
+        fn_index_style = PersistentString(PrefKey.FOOTNOTE_INDEX_STYLE)
+        self.all_to_num = ttk.Radiobutton(
+            fixit_frame,
+            text="All to Number",
+            variable=fn_index_style,
+            value=FootnoteIndexStyle.NUMBER,
+            takefocus=False,
+        )
+        self.all_to_num.grid(column=0, row=1, pady=2, sticky="NSEW")
+        # --
+        self.all_to_let = ttk.Radiobutton(
+            fixit_frame,
+            text="All to Letter",
+            variable=fn_index_style,
+            value=FootnoteIndexStyle.LETTER,
+            takefocus=False,
+        )
+        self.all_to_let.grid(column=1, row=1, pady=2, sticky="NSEW")
+        # --
+        self.all_to_rom = ttk.Radiobutton(
+            fixit_frame,
+            text="All to Roman",
+            variable=fn_index_style,
+            value=FootnoteIndexStyle.ROMAN,
+            takefocus=False,
+        )
+        self.all_to_rom.grid(column=2, row=1, pady=2, sticky="NSEW")
+        # --
+        self.reindex_button = ttk.Button(
+            fixit_frame,
+            text="Reindex",
+            command=reindex,
+        )
+        self.reindex_button.grid(column=3, row=1, pady=2, sticky="NSEW")
+
+        # Setting LZs, moving FNs, tidying FNs.
+
+        self.lz_set_at_cursor_button = ttk.Button(
+            fixit_frame,
+            text="Set LZ @ Cursor",
+            command=set_lz_at_cursor,
+        )
+        self.lz_set_at_cursor_button.grid(column=0, row=2, pady=2, sticky="NSEW")
+        # --
+        self.lz_set_at_end_button = ttk.Button(
+            fixit_frame,
+            text="Autoset End LZ",
+            command=autoset_end_lz,
+        )
+        self.lz_set_at_end_button.grid(column=1, row=2, pady=2, sticky="NSEW")
+        # --
+        self.lz_set_at_chapter_button = ttk.Button(
+            fixit_frame,
+            text="Autoset Chap. LZ",
+            command=autoset_chapter_lz,
+        )
+        self.lz_set_at_chapter_button.grid(column=2, row=2, pady=2, sticky="NSEW")
+        # --
+        self.move_to_lz_button = ttk.Button(
+            fixit_frame,
+            text="Move FNs to Landing Zone(s)",
+            command=move_footnotes_to_lz,
+        )
+        self.move_to_lz_button.grid(column=3, row=2, pady=2, sticky="NSEW")
+        # --
+        self.move_to_para_button = ttk.Button(
+            fixit_frame,
+            text="Move FNs to Paragraphs",
+            command=move_footnotes_to_paragraphs,
+        )
+        self.move_to_para_button.grid(column=0, row=3, pady=2, sticky="NSEW")
+        # --
+        self.fn_tidy_button = ttk.Button(
+            fixit_frame,
+            text="Tidy Footnotes",
+            command=tidy_footnotes,
+        )
+        self.fn_tidy_button.grid(column=3, row=3, pady=2, sticky="NSEW")
+
+
 def footnote_check() -> None:
     """Check footnotes in the currently loaded file."""
     global _the_footnote_checker
@@ -1290,17 +1331,9 @@ def footnote_check() -> None:
         return
 
     checker_dialog = FootnoteCheckerDialog.show_dialog(
-        "Footnote Check Results",
         rerun_command=footnote_check,
         sort_key_alpha=sort_key_type,
         show_suspects_only=True,
-        tooltip="\n".join(
-            [
-                "Left click: Select & find footnote",
-                "Right click: Remove item from list",
-                "Shift-Right click: Remove all matching items",
-            ]
-        ),
     )
 
     if _the_footnote_checker is None:
@@ -1315,7 +1348,7 @@ def footnote_check() -> None:
     # checked in display_buttons() and will determine which, if any, buttons
     # are disabled when they are displayed.
     display_footnote_entries()
-    _the_footnote_checker.display_buttons()
+    _the_footnote_checker.enable_disable_buttons()
 
 
 def check_fn_string(fn_record: FootnoteRecord) -> str:
@@ -1436,4 +1469,4 @@ def display_footnote_entries(auto_select_line: bool = True) -> None:
             an_record.hilite_end,
         )
     checker_dialog.display_entries(auto_select_line)
-    _the_footnote_checker.display_buttons()
+    _the_footnote_checker.enable_disable_buttons()

--- a/src/guiguts/html_tools.py
+++ b/src/guiguts/html_tools.py
@@ -6,7 +6,7 @@ import logging
 import os.path
 import tkinter as tk
 from tkinter import ttk, filedialog
-from typing import Optional
+from typing import Optional, Any
 
 from PIL import Image, ImageTk, UnidentifiedImageError
 import regex as re
@@ -556,18 +556,23 @@ def html_validator_check() -> None:
         """Minimal class to identify dialog type so that it can exist
         simultaneously with other checker dialogs."""
 
-        manual_page = "HTML_Menu#HTML_Validator"
+        manual_page = "HTML_Menu#HTML_Link_Checker"
 
-    checker_dialog = HTMLValidatorDialog.show_dialog(
-        "HTML Validator Results",
-        rerun_command=html_validator_check,
-        tooltip="\n".join(
-            [
-                "Left click: Select & find validation error",
-                "Right click: Remove validation error from this list",
-            ]
-        ),
-    )
+        def __init__(self, **kwargs: Any) -> None:
+            """Initialize HTML Validator dialog."""
+
+            super().__init__(
+                "HTML Validator Results",
+                tooltip="\n".join(
+                    [
+                        "Left click: Select & find validation error",
+                        "Right click: Remove validation error from this list",
+                    ]
+                ),
+                **kwargs,
+            )
+
+    checker_dialog = HTMLValidatorDialog.show_dialog(rerun_command=html_validator_check)
 
     do_validator_check(checker_dialog)
 
@@ -677,22 +682,25 @@ def html_link_check() -> None:
     """Validate the current HTML file."""
 
     class HTMLLinkCheckerDialog(CheckerDialog):
-        """Minimal class to identify dialog type so that it can exist
-        simultaneously with other checker dialogs."""
+        """HTML Link Checker dialog."""
 
         manual_page = "HTML_Menu#HTML_Link_Checker"
 
-    checker_dialog = HTMLLinkCheckerDialog.show_dialog(
-        "HTML Link Checker Results",
-        rerun_command=html_link_check,
-        tooltip="\n".join(
-            [
-                "Left click: Select & find issue",
-                "Right click: Remove issue from this list",
-            ]
-        ),
-    )
-    checker_dialog.reset()
+        def __init__(self, **kwargs: Any) -> None:
+            """Initialize HTML Link Checker dialog."""
+
+            super().__init__(
+                "HTML Link Checker Results",
+                tooltip="\n".join(
+                    [
+                        "Left click: Select & find issue",
+                        "Right click: Remove issue from this list",
+                    ]
+                ),
+                **kwargs,
+            )
+
+    checker_dialog = HTMLLinkCheckerDialog.show_dialog(rerun_command=html_link_check)
 
     do_link_check(checker_dialog)
 
@@ -806,7 +814,12 @@ def do_link_check(checker_dialog: CheckerDialog) -> None:
     # Get list of image files to check if they are referenced
     cur_dir = os.path.dirname(the_file().filename)
     images_used: dict[str, bool] = {}
-    for fn in os.listdir(os.path.join(cur_dir, "images")):
+    images_dir = os.path.join(cur_dir, "images")
+    if not os.path.isdir(images_dir):
+        logger.error(f"Directory {images_dir} does not exist")
+        checker_dialog.display_entries()
+        return
+    for fn in os.listdir(images_dir):
         # Force forward slash (unlike os.join) so it matches attribute value
         images_used[f"images/{fn}"] = False
 

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -48,7 +48,7 @@ class PrefKey(StrEnum):
     ROOT_GEOMETRY_STATE = auto()
     DEFAULT_LANGUAGES = auto()
     JEEBIES_PARANOIA_LEVEL = auto()
-    LEVENSHTEIN_EDIT_DISTANCE = auto()
+    LEVENSHTEIN_DISTANCE = auto()
     FOOTNOTE_INDEX_STYLE = auto()
     WRAP_LEFT_MARGIN = auto()
     WRAP_RIGHT_MARGIN = auto()

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -449,28 +449,32 @@ class SearchDialog(ToplevelDialog):
             return
 
         class FindAllCheckerDialog(CheckerDialog):
-            """Minimal class to identify dialog typepylint."""
+            """Find All dialog."""
 
             manual_page = "Searching#Find_All"
 
+            def __init__(self, **kwargs: Any) -> None:
+                """Initialize Find All dialog."""
+
+                super().__init__(
+                    "Search Results",
+                    tooltip="\n".join(
+                        [
+                            "Left click: Select & find string",
+                            "Right click: Remove string from this list",
+                            "Shift Right click: Remove all occurrences of string from this list",
+                        ]
+                    ),
+                    **kwargs,
+                )
+
         checker_dialog = FindAllCheckerDialog.show_dialog(
-            "Search Results",
             rerun_command=self.findall_clicked,
-            tooltip="\n".join(
-                [
-                    "Left click: Select & find string",
-                    "Right click: Remove string from this list",
-                    "Shift Right click: Remove all occurrences of string from this list",
-                ]
-            ),
         )
-        if not checker_dialog.winfo_exists():
+        if not checker_dialog.winfo_exists() or not self.winfo_exists():
             Busy.unbusy()
             return
-        checker_dialog.reset()
-        if not self.winfo_exists():
-            Busy.unbusy()
-            return
+
         # Construct opening line describing the search
         desc_reg = "regex" if preferences.get(PrefKey.SEARCHDIALOG_REGEX) else "string"
         prefix = f'Search for {desc_reg} "'

--- a/src/guiguts/spell.py
+++ b/src/guiguts/spell.py
@@ -4,7 +4,7 @@ import importlib.resources
 import logging
 from pathlib import Path
 from tkinter import ttk
-from typing import Callable, Optional
+from typing import Callable, Optional, Any
 import regex as re
 
 from guiguts.data import dictionaries
@@ -60,9 +60,122 @@ class SpellingError(FindMatch):
 
 
 class SpellCheckerDialog(CheckerDialog):
-    """Minimal class to identify dialog type."""
+    """Spell Checker dialog."""
 
     manual_page = "Tools_Menu#Spelling"
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize Spell Checker dialog."""
+        assert "add_global_word_callback" in kwargs
+        self.add_global_word_callback = kwargs["add_global_word_callback"]
+        del kwargs["add_global_word_callback"]
+        super().__init__(
+            "Spelling Check Results",
+            tooltip="\n".join(
+                [
+                    "Left click: Select & find spelling error",
+                    "Right click: Remove spelling error from list",
+                    "Shift Right click: Remove all occurrences of spelling error from list",
+                    f"With {cmd_ctrl_string()} key: Also add spelling to project dictionary",
+                ]
+            ),
+            **kwargs,
+        )
+        frame = ttk.Frame(self.header_frame)
+        frame.grid(column=0, row=1, sticky="NSEW", pady=5)
+        ttk.Label(
+            frame,
+            text="Threshold ≤ ",
+        ).grid(column=0, row=0, sticky="NSW")
+        threshold_spinbox = ttk.Spinbox(
+            frame,
+            textvariable=PersistentInt(PrefKey.SPELL_THRESHOLD),
+            from_=1,
+            to=999,
+            width=4,
+        )
+        threshold_spinbox.grid(column=1, row=0, sticky="NW", padx=(0, 10))
+        ToolTip(
+            threshold_spinbox,
+            "Do not show errors that appear more than this number of times",
+        )
+
+        def invoke_and_break(button: ttk.Button) -> str:
+            """Invoke a button and return "break" to avoid further callbacks."""
+            button.invoke()
+            return "break"
+
+        def add_to_global_dict() -> None:
+            """Add current word to global dictionary."""
+            current_index = self.current_entry_index()
+            if current_index is None:
+                return
+            checker_entry = self.entries[current_index]
+            if checker_entry.text_range:
+                word = checker_entry.text.split(maxsplit=1)[0]
+                self.add_global_word_callback(word)
+                checker = get_spell_checker()
+                assert checker is not None
+                checker.dictionary[word] = True
+            self.remove_entry_current(all_matching=True)
+
+        lang = maintext().get_language_list()[0]
+        global_dict_button = ttk.Button(
+            frame,
+            text=f"Add to Global Dict ({lang})",
+            command=add_to_global_dict,
+        )
+        global_dict_button.grid(column=2, row=0, sticky="NSW")
+        for accel in ("Cmd/Ctrl+a", "Cmd/Ctrl+A"):
+            _, key_event = process_accel(accel)
+            self.bind(key_event, lambda _: invoke_and_break(global_dict_button))
+        ToolTip(
+            global_dict_button,
+            f"{cmd_ctrl_string()}+A",
+            use_pointer_pos=True,
+        )
+        project_dict_button = ttk.Button(
+            frame,
+            text="Add to Project Dict",
+            command=lambda: self.process_remove_entry_current(all_matching=True),
+        )
+        project_dict_button.grid(column=3, row=0, sticky="NSW")
+        for accel in ("Cmd/Ctrl+p", "Cmd/Ctrl+P"):
+            _, key_event = process_accel(accel)
+            self.bind(key_event, lambda _: invoke_and_break(project_dict_button))
+        ToolTip(
+            project_dict_button,
+            f"{cmd_ctrl_string()}+P",
+            use_pointer_pos=True,
+        )
+        skip_button = ttk.Button(
+            frame,
+            text="Skip",
+            command=lambda: self.remove_entry_current(all_matching=False),
+        )
+        skip_button.grid(column=4, row=0, sticky="NSW")
+        for accel in ("Cmd/Ctrl+s", "Cmd/Ctrl+S"):
+            _, key_event = process_accel(accel)
+            self.bind(key_event, lambda _: invoke_and_break(skip_button))
+        ToolTip(
+            skip_button,
+            f"{cmd_ctrl_string()}+S",
+            use_pointer_pos=True,
+        )
+        skip_all_button = ttk.Button(
+            frame,
+            text="Skip All",
+            command=lambda: self.remove_entry_current(all_matching=True),
+        )
+        skip_all_button.grid(column=5, row=0, sticky="NSW")
+        for accel in ("Cmd/Ctrl+i", "Cmd/Ctrl+I"):
+            _, key_event = process_accel(accel)
+            self.bind(key_event, lambda _: invoke_and_break(skip_all_button))
+        ToolTip(
+            skip_all_button,
+            f"{cmd_ctrl_string()}+I",
+            use_pointer_pos=True,
+        )
 
 
 class SpellChecker:
@@ -366,116 +479,16 @@ def spell_check(
             add_project_word_callback(checker_entry.text.split(maxsplit=1)[0])
 
     checker_dialog = SpellCheckerDialog.show_dialog(
-        "Spelling Check Results",
         rerun_command=lambda: spell_check(
-            project_dict, add_project_word_callback, add_global_word_callback
+            project_dict,
+            add_project_word_callback,
+            add_global_word_callback,
         ),
         process_command=process_spelling,
-        tooltip="\n".join(
-            [
-                "Left click: Select & find spelling error",
-                "Right click: Remove spelling error from list",
-                "Shift Right click: Remove all occurrences of spelling error from list",
-                f"With {cmd_ctrl_string()} key: Also add spelling to project dictionary",
-            ]
-        ),
         switch_focus_when_clicked=False,
-    )
-    frame = ttk.Frame(checker_dialog.header_frame)
-    frame.grid(column=0, row=1, sticky="NSEW", pady=5)
-    ttk.Label(
-        frame,
-        text="Threshold ≤ ",
-    ).grid(column=0, row=0, sticky="NSW")
-    threshold_spinbox = ttk.Spinbox(
-        frame,
-        textvariable=PersistentInt(PrefKey.SPELL_THRESHOLD),
-        from_=1,
-        to=999,
-        width=4,
-    )
-    threshold_spinbox.grid(column=1, row=0, sticky="NW", padx=(0, 10))
-    ToolTip(
-        threshold_spinbox,
-        "Do not show errors that appear more than this number of times",
+        add_global_word_callback=add_global_word_callback,
     )
 
-    def invoke_and_break(button: ttk.Button) -> str:
-        """Invoke a button and return "break" to avoid further callbacks."""
-        button.invoke()
-        return "break"
-
-    def add_to_global_dict() -> None:
-        """Add current word to global dictionary."""
-        current_index = checker_dialog.current_entry_index()
-        if current_index is None:
-            return
-        checker_entry = checker_dialog.entries[current_index]
-        if checker_entry.text_range:
-            word = checker_entry.text.split(maxsplit=1)[0]
-            add_global_word_callback(word)
-            checker.dictionary[word] = True
-        checker_dialog.remove_entry_current(all_matching=True)
-
-    lang = maintext().get_language_list()[0]
-    global_dict_button = ttk.Button(
-        frame,
-        text=f"Add to Global Dict ({lang})",
-        command=add_to_global_dict,
-    )
-    global_dict_button.grid(column=2, row=0, sticky="NSW")
-    for accel in ("Cmd/Ctrl+a", "Cmd/Ctrl+A"):
-        _, key_event = process_accel(accel)
-        checker_dialog.bind(key_event, lambda _: invoke_and_break(global_dict_button))
-    ToolTip(
-        global_dict_button,
-        f"{cmd_ctrl_string()}+A",
-        use_pointer_pos=True,
-    )
-    project_dict_button = ttk.Button(
-        frame,
-        text="Add to Project Dict",
-        command=lambda: checker_dialog.process_remove_entry_current(all_matching=True),
-    )
-    project_dict_button.grid(column=3, row=0, sticky="NSW")
-    for accel in ("Cmd/Ctrl+p", "Cmd/Ctrl+P"):
-        _, key_event = process_accel(accel)
-        checker_dialog.bind(key_event, lambda _: invoke_and_break(project_dict_button))
-    ToolTip(
-        project_dict_button,
-        f"{cmd_ctrl_string()}+P",
-        use_pointer_pos=True,
-    )
-    skip_button = ttk.Button(
-        frame,
-        text="Skip",
-        command=lambda: checker_dialog.remove_entry_current(all_matching=False),
-    )
-    skip_button.grid(column=4, row=0, sticky="NSW")
-    for accel in ("Cmd/Ctrl+s", "Cmd/Ctrl+S"):
-        _, key_event = process_accel(accel)
-        checker_dialog.bind(key_event, lambda _: invoke_and_break(skip_button))
-    ToolTip(
-        skip_button,
-        f"{cmd_ctrl_string()}+S",
-        use_pointer_pos=True,
-    )
-    skip_all_button = ttk.Button(
-        frame,
-        text="Skip All",
-        command=lambda: checker_dialog.remove_entry_current(all_matching=True),
-    )
-    skip_all_button.grid(column=5, row=0, sticky="NSW")
-    for accel in ("Cmd/Ctrl+i", "Cmd/Ctrl+I"):
-        _, key_event = process_accel(accel)
-        checker_dialog.bind(key_event, lambda _: invoke_and_break(skip_all_button))
-    ToolTip(
-        skip_all_button,
-        f"{cmd_ctrl_string()}+I",
-        use_pointer_pos=True,
-    )
-
-    checker_dialog.reset()
     # Construct opening line describing the search
     sel_only = " (selected text only)" if len(maintext().selected_ranges()) > 0 else ""
     checker_dialog.add_header("Start of Spelling Check" + sel_only, "")

--- a/src/guiguts/tools/levenshtein.py
+++ b/src/guiguts/tools/levenshtein.py
@@ -671,7 +671,6 @@ def run_levenshtein_check_on_file(project_dict: ProjectDict) -> None:
         "Levenshtein Edit Distance Check",
         rerun_command=lambda: levenshtein_check(project_dict),
     )
-    checker_dialog.reset()
 
     # Convert to int the edit distance used last time Levenshtein was run or default if first run.
     distance_to_check = (

--- a/src/guiguts/tools/levenshtein.py
+++ b/src/guiguts/tools/levenshtein.py
@@ -1,27 +1,22 @@
 """Levenshtein edit distance check tool"""
 
-import time
+from enum import StrEnum, auto
 import importlib.resources
 import logging
-
-from enum import StrEnum, auto
+import time
+from typing import Any
 from tkinter import ttk
-from Levenshtein import distance
 
+from Levenshtein import distance
 import regex as re
 
 from guiguts.checkers import CheckerDialog
-
-# from guiguts.spell import SpellChecker, DictionaryNotFoundError
-from guiguts.spell import get_spell_checker
 from guiguts.data import dictionaries
 from guiguts.file import ProjectDict
 from guiguts.maintext import maintext
 from guiguts.misc_tools import tool_save
-from guiguts.preferences import (
-    PersistentString,
-    PrefKey,
-)
+from guiguts.preferences import PersistentString, PrefKey, preferences
+from guiguts.spell import get_spell_checker
 from guiguts.utilities import IndexRowCol, IndexRange
 
 logger = logging.getLogger(__package__)
@@ -58,613 +53,23 @@ class LevenshteinCheckerDialog(CheckerDialog):
 
     manual_page = "Tools_Menu#Word_Distance_Check"
 
-
-class LevenshteinChecker:
-    """Provide Levenshtein edit distance functionality."""
-
-    def __init__(self) -> None:
-        """Initialize LevenshteinChecker class."""
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize curly quotes checker dialog."""
+        kwargs["tooltip"] = "\n".join(
+            [
+                "Left click: Select & find highlighted word in file",
+                "Right click: Remove line with highlighted word from list",
+                "Shift Right click: Also remove all matching lines from list",
+            ]
+        )
+        super().__init__(
+            *args,
+            **kwargs,
+        )
 
         self.edit_distance = PersistentString(PrefKey.LEVENSHTEIN_EDIT_DISTANCE)
 
-    def run_levenshtein_check_on_file(self, project_dict: ProjectDict) -> None:
-        """Check Levenshtein edit distance between selected file words."""
-
-        ####
-        # The following are declared and accessed as 'nonlocal' variables
-        # by functions defined within the enclosing scope of this top-most
-        # function definition. The names must exist when first encountered
-        # as they cannot be created by a first assignment in a nested def.
-        ####
-
-        # Each word that is correctly spell-checked is appended to this list,
-        # hence can contain many duplicates of a word in all its case forms.
-        # E.g. ['another', 'Another', 'another', ...]
-        good_words: list[str] = []
-        # Each word that fails the spell check is appended to this list, hence
-        # can contain many duplicates of a word in all its case forms.
-        # E.g. ['anither', 'Anither', 'anither', ...]
-        suspect_words: list[str] = []
-        # Key is a word in whatever case it appears in the text. Maps
-        # the frequency with which that word form appears in the text.
-        all_words_counts: dict[str, int] = {}
-        # Key is a word in whatever case it appears in the text. Maps
-        # the word to the line(s) it appears on using a list of
-        # tuples: (line_number, start_columan_index).
-        # E.g. 'another': [(1, 8), (3, 0), (3, 12)]
-        word_to_lines_map: dict[str, list[tuple]] = {}
-        # A list of tuples, each tuple containing two, lowercase, words.
-        # These are the 'suspect_word/good_word' pairs that differ by the
-        # Levenshtein edit distance specified (1 or 2). E.g. of content:
-        # [('anither', 'another'), ...]
-        distance_check_results: list[tuple] = []
-        # Given a lowercase word as a key, the value of that key is a list
-        # of different case versions of the key that appear in the text.
-        # E.g. 'another': ['Another', 'another', 'ANOTHER']
-        all_words_case_map: dict[str, list[str]] = {}
-
-        def build_header_line(result_tuple: tuple) -> str:
-            """Function to build a header line for display
-
-            It processes a tuple that contains a pair of words that
-            are the required Levenshtein edit distance apart. E.g.
-            ('anither', 'another')
-
-            Args:
-                result_tuple: contains a pair of lowercase words.
-
-            Returns:
-                Formatted string. E.g.
-                  Anither (1), anither (2) <-> ANOTHER (1), Another (3), another (7)
-            """
-
-            # The tuple argument contains two lowercase strings.
-            suspect_word = result_tuple[0]
-            test_word = result_tuple[1]
-
-            # Find any different-case versions of each word. The key
-            # for this map is always the canonical form of the word;
-            # that is, the lowercase version.
-            #
-            # Note that the strings in an 'all_words_case_map[word]' list
-            # are not necessarily in lexicographic order so always sort it.
-            # E.g.:
-            #     ['Another', 'another', 'ANOTHER']
-            # when we want to display
-            #     ['ANOTHER', 'Another', 'another'']
-            list_sorted_sw = sorted(all_words_case_map[suspect_word])
-            list_sorted_gw = sorted(all_words_case_map[test_word])
-
-            # When the same word appears in different cases build a header
-            # line that reflects that. E.g:
-            #
-            #   Anither(1), anither(2) <-> ANOTHER(1), Another(2), another(5)
-            #
-            # Build it in two sections, left and right parts with the
-            # separator between them.
-
-            # NB In the following section the key to the 'all_words_counts'
-            # dictionary can be in any case form; that is, they are not
-            # expected to be in lowercase canonical form.
-
-            # This half displays one or more case versions of the suspect word.
-            left_part = ""
-            for word in list_sorted_sw:
-                left_part += f"{word}({all_words_counts[word]}), "
-            # Chop the trailing ", " characters.
-            left_part = left_part[:-2]
-
-            # This half displays one or more case versions of the test word.
-            right_part = ""
-            for word in list_sorted_gw:
-                right_part += f"{word}({all_words_counts[word]}), "
-            # Chop the trailing ", " characters.
-            right_part = right_part[:-2]
-
-            return f"{left_part} <-> {right_part}"
-
-        def sort_tuples(tuples: list[tuple], key_indx: int) -> list[tuple]:
-            """Utility function to sort a list of tuples
-
-            Args:
-                tuples: a list of two-element tuples
-                key_indx: int 0 or 1 - element of a tuple on which to sort
-
-            Returns:
-                Input list of tuples sorted on key_indx element of each tuple
-            """
-
-            # Define a key function that returns the desired element of each tuple.
-            def key_func(x: tuple) -> int:
-                return x[key_indx]
-
-            # key_func = lambda x: x[key_indx]
-
-            # Use the 'sorted' function to sort the list of tuples using the key function.
-            sorted_tuples = sorted(tuples, key=key_func)
-
-            return sorted_tuples
-
-        def get_sorted_list_of_linecol_tuples(word: str) -> list:
-            """Utility function to sort line_number/column_start_index tuples
-
-            Enables the reporting of every line on which a word occurs (in any of its
-            case forms) by increasing order of line number and column index.
-
-            Arg:
-                word: all line_number/column_start_index tuples for this word will be
-                      collected and sorted.
-
-            Returns:
-                list of sorted tuples.
-            """
-
-            # The 'word' argument is in canonical form. Put the different
-            # case versions of the word into 'word_list'.
-            word_list = all_words_case_map[word]
-
-            # Each case version of the word is mapped to a list of tuples.
-            # Each tuple represents (line_number, column_start_index) as
-            # integers. The list of tuples for each case version represents
-            # the location of every occurrence of that form of the word in
-            # the file.
-            #
-            # Gather together all the tuples of each different case version
-            # of a word and sort that list into start column order within line
-            # number order.
-            tuples = []
-
-            for word_entry in word_list:
-                # The key to the map below is in any case form.
-                tuples_list = word_to_lines_map[word_entry]
-                for tuple_entry in tuples_list:
-                    tuples.append(tuple_entry)
-
-            # First sort the tuples by column_start_index
-            sorted_tuples = sort_tuples(tuples, 1)
-            # Then sort the result by line_number
-            sorted_tuples = sort_tuples(sorted_tuples, 0)
-            # If the original list of tuples was, say
-            #   [(2, 5), (1, 2), (4, 4), (2, 3)]
-            # it should now be
-            #   [(1, 2), (2, 3), (2, 5), (4, 4)]
-
-            return sorted_tuples
-
-        def unpack_and_write_to_dialog(result_tuple: tuple) -> None:
-            """Function for reporting word pair results from distance check
-
-            This function is called once for each pair of words that meet
-            the required Levenshtein edit distance criteria. It calls utility
-            functions to generate the header line and select and highlight all
-            the file lines that make up the report for that word pair. It then
-            calls checker dialog methods to report the header line and all the
-            accompanying file lines.
-
-            Arg:
-                result_tuple: 2-element tuple containing a lowercase 'suspect'
-                              word and a lowercase 'good' word against which
-                              it was tested.
-            """
-
-            # The tuple argument contains two lowercase strings; that is,
-            # they are the canonical form of each word of the pair being
-            # reported.
-            suspect_word = result_tuple[0]
-            test_word = result_tuple[1]
-
-            # In order to build the header line for the report; e.g.
-            #   Anither(1), anither(2) <-> ANOTHER(1), Another(2), another(5)
-            # will need all other case forms (if any) of the two words. Add
-            # the generated header line to the report.
-            checker_dialog.add_header(build_header_line(result_tuple))
-
-            # The header line is first followed by lines that contain the 'suspect'
-            # word in all of it case forms. The number of lines output is limited
-            # to LINES_IN_REPORT_LIMIT, currently set to 4. If there were more lines
-            # to output to the dialog then the lines that are displayed are followed
-            # by a line displaying "...more". The occurrence of the word on each
-            # line is highlighted in the usual way.
-            tuples = get_sorted_list_of_linecol_tuples(suspect_word)
-            lines_output_count = 0
-            for index_tuple in tuples:
-                # Limit the number of 'suspect' word lines reported.
-                if lines_output_count == LINES_IN_REPORT_LIMIT:
-                    lines_output_count = -1
-                    break
-                error_start, error_end = make_into_strings(
-                    index_tuple, len(suspect_word)
-                )
-                start_rowcol = IndexRowCol(error_start)
-                end_rowcol = IndexRowCol(error_end)
-                file_line = maintext().get(
-                    error_start + " linestart", error_end + " lineend"
-                )
-                checker_dialog.add_entry(
-                    file_line,
-                    IndexRange(start_rowcol, end_rowcol),
-                    start_rowcol.col,
-                    end_rowcol.col,
-                )
-                lines_output_count += 1
-
-            if lines_output_count < 0:
-                checker_dialog.add_footer("  ...more")
-
-            # No more lines to output for the suspect word so add a separator.
-            checker_dialog.add_header("----")
-
-            # The separator line is then followed by lines that contain the 'good'
-            # word in all of it case forms. The number of lines output is limited
-            # to LINES_IN_REPORT_LIMIT, currently set to 4. If there were more lines
-            # to output to the dialog then the lines that are displayed are followed
-            # by a line displaying "...more". The occurrence of the word on each
-            # line is highlighted in the usual way.
-            tuples = get_sorted_list_of_linecol_tuples(test_word)
-            lines_output_count = 0
-            for index_tuple in tuples:
-                # Limit the number of 'good' word lines reported.
-                if lines_output_count == LINES_IN_REPORT_LIMIT:
-                    lines_output_count = -1
-                    break
-                error_start, error_end = make_into_strings(index_tuple, len(test_word))
-                start_rowcol = IndexRowCol(error_start)
-                end_rowcol = IndexRowCol(error_end)
-                file_line = maintext().get(
-                    error_start + " linestart", error_end + " lineend"
-                )
-                checker_dialog.add_entry(
-                    file_line,
-                    IndexRange(start_rowcol, end_rowcol),
-                    start_rowcol.col,
-                    end_rowcol.col,
-                )
-                lines_output_count += 1
-
-            if lines_output_count < 0:
-                checker_dialog.add_footer("  ...more")
-
-            # Add a blank line to separate this word-pair report from that of the
-            # next pair.
-            checker_dialog.add_footer("")
-
-        def make_into_strings(
-            index_tuple: tuple, hilite_length: int
-        ) -> tuple[str, str]:
-            """Utility function to generate error_start & error_end strings from int values
-
-            Args:
-                index_tuple: an integer line number and an integer column start index
-                hilite_length: integer length of string to be lighlighted on the line.
-
-            Return:
-                An error_start string (E.g. "18.3" and an error_end string (E.g. "18.9")
-            """
-
-            line_num = str(index_tuple[0])
-            col_indx = str(index_tuple[1])
-            error_start = f"{line_num}.{col_indx}"
-            col_indx = str(index_tuple[1] + hilite_length)
-            error_end = f"{line_num}.{col_indx}"
-
-            return error_start, error_end
-
-        def reject_this(word: str) -> bool:
-            """Helper function that extracts repeated code. Decides whether
-            a word should be added to a list ('good' or 'suspects') and thus
-            will be distance checked. Criteria for rejection includes being
-            too short, a Roman numeral, all digits, etc.
-
-            Args:
-                word: should we add this word to a list or not?
-
-            Return:
-                A boolean. True if answer is 'No'; i.e. it won't be distance checked
-            """
-
-            # Reject single-letter 'words' as they generate spurious report lines
-            if len(word) == 1:
-                return True
-            # Reject if word contains Greek letters; e.g. 5μ, 3π, etc.
-            if re.search(r"\p{Greek}+", word):
-                return True
-            # Reject word if a valid Roman numeral
-            worduc = word.upper()
-            if re.fullmatch(
-                r"(?=[MDCLXVI])M*(C[MD]|D?C{0,3})(X[CL]|L?X{0,3})(I[XV]|V?I{0,3})",
-                worduc,
-            ):
-                return True
-            # Otherwise the length/type of the word looks OK. Keep it so that it's
-            # added to one of the two lists.
-            return False
-
-        def map_words_in_file(project_dict: ProjectDict) -> None:
-            """Spell check the currently loaded file and extract a list of suspect
-            words and a list of good words. Build a map of the line position index(es)
-            of each word and a map of the frequency of each word. In addition, build
-            a map of the case variants of a word that uses the lowercase form of the
-            word as key.
-
-            The two lists of words from which word pairs are generated for possible
-            distance checking are unique collections of words all in lowercase. This
-            is crucial to minimise execution time needed to generate the reported
-            results.
-
-            However when we generate the edit distance report we want to display all
-            the case variants of a word (e.g. 'ANOTHER', 'Another', 'another') hence
-            the role of the 'all_words_case_map' created in this function.
-
-            Outputs into a nonlocal list or dictionary:
-                List of suspect words - each an apparent spelling error.
-                Counts of those words (dictionary).
-                List of good words - each found in an English dictionary.
-                Counts of those words (dictionary).
-                Map of the line index(es) of each word and hilite start index on line
-                  (dictionary).
-                Map of the case variants of a word (dictionary).
-            """
-            assert _the_spell_checker is not None
-
-            # The following must already exist (see enclosing function) before they are
-            # used here. They are the lists and dictionaries into which the results of
-            # this function are 'returned'.
-            nonlocal good_words
-            nonlocal suspect_words
-            nonlocal word_to_lines_map, all_words_counts
-            nonlocal all_words_case_map
-
-            # Do spelling checks below using SpellChecker methods from spell.py
-
-            # The main loop from spell.py with some minor adaptions. It splits each
-            # file line into 'words' and calls SpellChecker.spell_check_word() on each.
-            # Depending on the result, the word is appended either to 'good_words' list
-            # (they are in the spelling dictionary) or 'suspect_words' list (not in the
-            # spelling dictionary). Some variable names changed to avoid pylint flagging
-            # 'duplicate code' with the same block of code in spell.py.
-            for line_text, line_number in maintext().get_lines():
-                words = re.split(r"[^\p{Alnum}\p{Mark}'’]", line_text)
-                next_column = 0
-                for word in words:
-                    column = next_column
-                    next_column = column + len(word) + 1
-                    if word:
-                        # Consider whether 'word' should be added to the 'good' or the
-                        # 'suspects' list. It might not be added to either if it is
-                        # too short or a Roman numeral, etc., so is unsuitable to be
-                        # distance checked.
-                        spell_check_result = _the_spell_checker.spell_check_word(
-                            word, project_dict
-                        )
-                        if spell_check_result == SPELL_CHECK_OK_YES:
-                            # Don't add it to the list if unsuitable for distance checking.
-                            if reject_this(word):
-                                continue
-                            good_words.append(word)
-                            try:
-                                all_words_counts[word] += 1
-                            except KeyError:
-                                all_words_counts[word] = 1
-
-                            try:
-                                word_to_lines_map[word].append((line_number, column))
-                            except KeyError:
-                                word_to_lines_map[word] = [(line_number, column)]
-                            continue
-
-                        # If word has leading straight apostrophe, it might be
-                        # open single quote; trim it and check again
-                        if spell_check_result == SPELL_CHECK_OK_NO and word.startswith(
-                            "'"
-                        ):
-                            word = word[1:]
-                            spell_check_result = _the_spell_checker.spell_check_word(
-                                word, project_dict
-                            )
-                            if spell_check_result == SPELL_CHECK_OK_YES:
-                                # Don't add it to the list if unsuitable for distance checking.
-                                if reject_this(word):
-                                    continue
-                                good_words.append(word)
-                                try:
-                                    all_words_counts[word] += 1
-                                except KeyError:
-                                    all_words_counts[word] = 1
-
-                                try:
-                                    word_to_lines_map[word].append(
-                                        (line_number, column)
-                                    )
-                                except KeyError:
-                                    word_to_lines_map[word] = [(line_number, column)]
-                                continue
-
-                        # If trailing straight/curly apostrophe, it might be
-                        # close single quote; trim it and check again
-                        if spell_check_result == SPELL_CHECK_OK_NO and re.search(
-                            r"['’]$", word
-                        ):
-                            word = word[:-1]
-                            spell_check_result = _the_spell_checker.spell_check_word(
-                                word, project_dict
-                            )
-                            if spell_check_result == SPELL_CHECK_OK_YES:
-                                # Don't add it to the list if unsuitable for distance checking
-                                if reject_this(word):
-                                    continue
-                                good_words.append(word)
-                                try:
-                                    all_words_counts[word] += 1
-                                except KeyError:
-                                    all_words_counts[word] = 1
-
-                                try:
-                                    word_to_lines_map[word].append(
-                                        (line_number, column)
-                                    )
-                                except KeyError:
-                                    word_to_lines_map[word] = [(line_number, column)]
-                                continue
-
-                        # Word not in dictionary. If word is not now empty and not
-                        # consisting only of single quotes, add it to suspect words
-                        # list.
-                        if not re.fullmatch(r"['’]*", word):
-                            # Don't add it to the list if unsuitable for distance checking
-                            if reject_this(word):
-                                continue
-                            suspect_words.append(word)
-                            try:
-                                all_words_counts[word] += 1
-                            except KeyError:
-                                all_words_counts[word] = 1
-
-                            try:
-                                word_to_lines_map[word].append((line_number, column))
-                            except KeyError:
-                                word_to_lines_map[word] = [(line_number, column)]
-
-            # NB The lists of 'good' words and 'suspect' words are not always mutually
-            # exclusive since a lowercase version of a word may not be in the spelling
-            # dictionary used but the uppercase version of the word is in that dictionary.
-            # An example of this is 'kirk' which is not in spelling dictionary but 'Kirk'
-            # is in the dictionary.
-
-            # Build a dictionary, keyed by the lower case version of a word, whose value
-            # will be a list of the same word in the different cases in which it appears
-            # in the file. E.g.
-            #  dict['another'] -> ['ANOTHER', Another', 'another']
-            #
-            # NB Only words that appear in the text will appear in that list. Thus the
-            #    lowercase version of a word that's used as a key will not be in the list
-            #    unless it also appears in the text.
-
-            # As stated in the comments above, 'word' may be a string in any case.
-            for word in good_words:
-                # The lowercase version of the word is the dictionary key.
-                word_lc = word.lower()
-                if word_lc in all_words_case_map:
-                    # There's a dictionary entry keyed by the lowercase form of the word.
-                    # Is 'word' in the entries list? That is, if key is 'another' it is
-                    # asking here whether, say, 'Another' is in the values list for the
-                    # key.
-                    if word not in all_words_case_map[word_lc]:
-                        # Then add it to the list
-                        all_words_case_map[word_lc].append(word)
-                else:
-                    # Create the dictionary entry which is a list.
-                    all_words_case_map[word_lc] = [word]
-
-            # Same comments apply here.
-            for word in suspect_words:
-                word_lc = word.lower()
-                if word_lc in all_words_case_map:
-                    # There's a dictionary entry. Is 'word' in the entries list?
-                    if word not in all_words_case_map[word_lc]:
-                        # Then add it to the list
-                        all_words_case_map[word_lc].append(word)
-                else:
-                    # Create the dictionary entry which is a list.
-                    all_words_case_map[word_lc] = [word]
-
-        def distance_check_words() -> None:
-            """Function to select, and edit distance check, pairs of suspect/good words.
-
-            The process involves taking each lowercase form of a suspect word and doing a
-            Levenshtein edit distance check against the lowercase form of every good word.
-
-            Keeping the lengths of the respective lists of words as short as possible is
-            critical. A book quoting a lot of speech in dialect may have a 'suspect' words
-            list of more than 1,000 entries. If the 'good' words list has 8,000 or 9,000
-            entries then the number of pairs of suspect<->good words to consider will approach
-            10 million. Processing that number of pairs is very demanding of CPU time.
-            """
-
-            nonlocal distance_check_results
-
-            # As a word may appear many times in a text, and in many case forms, for example
-            # 'ANOTHER', 'Another', 'another, each of the two lists is kept as short as
-            # possible by containing just a single lowercase instance of the word: 'another'
-            # in the example above.
-
-            # NB For display purposes a separate dictionary maps each case form of a word to
-            # its line number and column start index for every occurrence in the file. That is
-            # in turn indexed by entries from another dictionary that maps a word in lowercase
-            # to any other case form that appears in the file. E.g.: 'another' -> 'ANOTHER',
-            # 'Another', 'another'.
-            #
-            # These dictionaries are only used when processing for display in the report the
-            # small number of word pairs that meet the required Levenshtein edit distance criteria.
-            # Crucially they free us to do the CPU-intensive word selection and Levenshtein edit
-            # distance calculations on the smallest feasible set of word pairs.
-
-            # First make every word lowercase in a copy of each list.
-            suspect_words_unique = [x.lower() for x in suspect_words]
-            good_words_unique = [x.lower() for x in good_words]
-            # The resulting lists still contain multiple occurrences of a word. Use set() to
-            # create a unique collection of words from each list. Then turn the result back
-            # into a list and sort it.
-            suspect_words_unique = sorted(list(set(suspect_words_unique)))
-            good_words_unique = sorted(list(set(good_words_unique)))
-
-            # For each lowercase form of a suspect word do distance check against the lowercase
-            # form of every good word; i.e. 'test' words. Some obvious filtering of both suspect
-            # and test words is done to eliminate some pairs before the edit distance calculation
-            # check is made.
-            for suspect_wordlc in suspect_words_unique:
-                # Must be five letters or more OR contain an unexpected character.
-                unexpected = re.sub(r"[a-z0-9’'æœ]", "", suspect_wordlc)
-                if len(suspect_wordlc) < 3 and len(unexpected) == 0:
-                    continue
-                for test_wordlc in good_words_unique:
-                    # No point in processing a suspect<->test word pair whose difference in
-                    # length is greater than the edit distance to be used in the check (1 or 2).
-                    if abs(len(suspect_wordlc) - len(test_wordlc)) > distance_to_check:
-                        continue
-                    # Check if they are the same word differing only by capitalisation.
-                    # This check may seem unnecessary since the two lists are supposed
-                    # to contain mutually exclusive collections of words. This may not
-                    # always be so. For example 'kirk', the Scottish word for a church
-                    # is not in the dictionary so would appear in 'suspect_words' while
-                    # the name 'Kirk' IS in the dictionary hence would appear in the
-                    # 'good_words/test_words' list.
-                    if suspect_wordlc == test_wordlc:
-                        continue
-
-                    # Calculate Levenshtein distance
-                    dist = distance(
-                        suspect_wordlc, test_wordlc, score_cutoff=distance_to_check
-                    )
-
-                    if dist == distance_to_check:
-                        distance_check_results.append((suspect_wordlc, test_wordlc))
-
-        ####
-        # Executable section of enclosing function 'run_levenshtein_check_on_file'.
-        ####
-
-        # Start time of prgram execution
-        prog_start = time.time()
-
-        # Set up SpellChecker here before the tool window is opened in
-        # case it cannot find the required dictionaries.
-        _the_spell_checker = get_spell_checker()
-        if _the_spell_checker is None:
-            return
-
-        # Create the checker dialog to show results
-        checker_dialog = LevenshteinCheckerDialog.show_dialog(
-            "Levenshtein Edit Distance Check",
-            rerun_command=lambda: levenshtein_check(project_dict),
-            tooltip="\n".join(
-                [
-                    "Left click: Select & find highlighted word in file",
-                    "Right click: Remove line with highlighted word from list",
-                    "Shift Right click: Also remove all matching lines from list",
-                ]
-            ),
-        )
-        frame = ttk.Frame(checker_dialog.header_frame)
+        frame = ttk.Frame(self.header_frame)
         frame.grid(column=0, row=1, sticky="NSEW")
         ttk.Label(
             frame,
@@ -685,51 +90,628 @@ class LevenshteinChecker:
             takefocus=False,
         ).grid(row=0, column=3, sticky="NSE", padx=2)
 
-        checker_dialog.reset()
 
-        # Convert to int the edit distance used last time Levenshtein was run or default if first run.
-        distance_to_check = 1
-        if self.edit_distance.get() == "two":
-            distance_to_check = 2
+def run_levenshtein_check_on_file(project_dict: ProjectDict) -> None:
+    """Check Levenshtein edit distance between selected file words."""
 
-        # Build maps of the good words and the suspect words in the file.
-        # Ideally should only do this once and not every time the tool is
-        # rerun.
-        map_words_in_file(project_dict)
+    ####
+    # The following are declared and accessed as 'nonlocal' variables
+    # by functions defined within the enclosing scope of this top-most
+    # function definition. The names must exist when first encountered
+    # as they cannot be created by a first assignment in a nested def.
+    ####
 
-        # For each suspect word, check against each good word in turn.
-        # Very compute intensive. Where 90% of the execution time is consumed.
-        distance_check_words()
+    # Each word that is correctly spell-checked is appended to this list,
+    # hence can contain many duplicates of a word in all its case forms.
+    # E.g. ['another', 'Another', 'another', ...]
+    good_words: list[str] = []
+    # Each word that fails the spell check is appended to this list, hence
+    # can contain many duplicates of a word in all its case forms.
+    # E.g. ['anither', 'Anither', 'anither', ...]
+    suspect_words: list[str] = []
+    # Key is a word in whatever case it appears in the text. Maps
+    # the frequency with which that word form appears in the text.
+    all_words_counts: dict[str, int] = {}
+    # Key is a word in whatever case it appears in the text. Maps
+    # the word to the line(s) it appears on using a list of
+    # tuples: (line_number, start_columan_index).
+    # E.g. 'another': [(1, 8), (3, 0), (3, 12)]
+    word_to_lines_map: dict[str, list[tuple]] = {}
+    # A list of tuples, each tuple containing two, lowercase, words.
+    # These are the 'suspect_word/good_word' pairs that differ by the
+    # Levenshtein edit distance specified (1 or 2). E.g. of content:
+    # [('anither', 'another'), ...]
+    distance_check_results: list[tuple] = []
+    # Given a lowercase word as a key, the value of that key is a list
+    # of different case versions of the key that appear in the text.
+    # E.g. 'another': ['Another', 'another', 'ANOTHER']
+    all_words_case_map: dict[str, list[str]] = {}
 
-        # Did distance_check_words() find any word pairs that met
-        # the required Levenshtein criteria?
-        if len(distance_check_results) == 0:
-            # No.
-            checker_dialog.add_entry("No Levenshtein edit distance queries reported")
-            checker_dialog.add_entry("")
-        else:
-            # Yes, so display the results using checker_dialog methods.
-            for result_tuple in distance_check_results:
-                unpack_and_write_to_dialog(result_tuple)
+    def build_header_line(result_tuple: tuple) -> str:
+        """Function to build a header line for display
 
-        # Calculate and display execution time of run.
-        prog_end = time.time()
-        checker_dialog.add_footer(
-            f"Execution time: {(prog_end - prog_start):.2f} seconds"
-        )
+        It processes a tuple that contains a pair of words that
+        are the required Levenshtein edit distance apart. E.g.
+        ('anither', 'another')
 
-        checker_dialog.display_entries()
+        Args:
+            result_tuple: contains a pair of lowercase words.
+
+        Returns:
+            Formatted string. E.g.
+                Anither (1), anither (2) <-> ANOTHER (1), Another (3), another (7)
+        """
+
+        # The tuple argument contains two lowercase strings.
+        suspect_word = result_tuple[0]
+        test_word = result_tuple[1]
+
+        # Find any different-case versions of each word. The key
+        # for this map is always the canonical form of the word;
+        # that is, the lowercase version.
+        #
+        # Note that the strings in an 'all_words_case_map[word]' list
+        # are not necessarily in lexicographic order so always sort it.
+        # E.g.:
+        #     ['Another', 'another', 'ANOTHER']
+        # when we want to display
+        #     ['ANOTHER', 'Another', 'another'']
+        list_sorted_sw = sorted(all_words_case_map[suspect_word])
+        list_sorted_gw = sorted(all_words_case_map[test_word])
+
+        # When the same word appears in different cases build a header
+        # line that reflects that. E.g:
+        #
+        #   Anither(1), anither(2) <-> ANOTHER(1), Another(2), another(5)
+        #
+        # Build it in two sections, left and right parts with the
+        # separator between them.
+
+        # NB In the following section the key to the 'all_words_counts'
+        # dictionary can be in any case form; that is, they are not
+        # expected to be in lowercase canonical form.
+
+        # This half displays one or more case versions of the suspect word.
+        left_part = ""
+        for word in list_sorted_sw:
+            left_part += f"{word}({all_words_counts[word]}), "
+        # Chop the trailing ", " characters.
+        left_part = left_part[:-2]
+
+        # This half displays one or more case versions of the test word.
+        right_part = ""
+        for word in list_sorted_gw:
+            right_part += f"{word}({all_words_counts[word]}), "
+        # Chop the trailing ", " characters.
+        right_part = right_part[:-2]
+
+        return f"{left_part} <-> {right_part}"
+
+    def sort_tuples(tuples: list[tuple], key_indx: int) -> list[tuple]:
+        """Utility function to sort a list of tuples
+
+        Args:
+            tuples: a list of two-element tuples
+            key_indx: int 0 or 1 - element of a tuple on which to sort
+
+        Returns:
+            Input list of tuples sorted on key_indx element of each tuple
+        """
+
+        # Define a key function that returns the desired element of each tuple.
+        def key_func(x: tuple) -> int:
+            return x[key_indx]
+
+        # key_func = lambda x: x[key_indx]
+
+        # Use the 'sorted' function to sort the list of tuples using the key function.
+        sorted_tuples = sorted(tuples, key=key_func)
+
+        return sorted_tuples
+
+    def get_sorted_list_of_linecol_tuples(word: str) -> list:
+        """Utility function to sort line_number/column_start_index tuples
+
+        Enables the reporting of every line on which a word occurs (in any of its
+        case forms) by increasing order of line number and column index.
+
+        Arg:
+            word: all line_number/column_start_index tuples for this word will be
+                    collected and sorted.
+
+        Returns:
+            list of sorted tuples.
+        """
+
+        # The 'word' argument is in canonical form. Put the different
+        # case versions of the word into 'word_list'.
+        word_list = all_words_case_map[word]
+
+        # Each case version of the word is mapped to a list of tuples.
+        # Each tuple represents (line_number, column_start_index) as
+        # integers. The list of tuples for each case version represents
+        # the location of every occurrence of that form of the word in
+        # the file.
+        #
+        # Gather together all the tuples of each different case version
+        # of a word and sort that list into start column order within line
+        # number order.
+        tuples = []
+
+        for word_entry in word_list:
+            # The key to the map below is in any case form.
+            tuples_list = word_to_lines_map[word_entry]
+            for tuple_entry in tuples_list:
+                tuples.append(tuple_entry)
+
+        # First sort the tuples by column_start_index
+        sorted_tuples = sort_tuples(tuples, 1)
+        # Then sort the result by line_number
+        sorted_tuples = sort_tuples(sorted_tuples, 0)
+        # If the original list of tuples was, say
+        #   [(2, 5), (1, 2), (4, 4), (2, 3)]
+        # it should now be
+        #   [(1, 2), (2, 3), (2, 5), (4, 4)]
+
+        return sorted_tuples
+
+    def unpack_and_write_to_dialog(result_tuple: tuple) -> None:
+        """Function for reporting word pair results from distance check
+
+        This function is called once for each pair of words that meet
+        the required Levenshtein edit distance criteria. It calls utility
+        functions to generate the header line and select and highlight all
+        the file lines that make up the report for that word pair. It then
+        calls checker dialog methods to report the header line and all the
+        accompanying file lines.
+
+        Arg:
+            result_tuple: 2-element tuple containing a lowercase 'suspect'
+                            word and a lowercase 'good' word against which
+                            it was tested.
+        """
+
+        # The tuple argument contains two lowercase strings; that is,
+        # they are the canonical form of each word of the pair being
+        # reported.
+        suspect_word = result_tuple[0]
+        test_word = result_tuple[1]
+
+        # In order to build the header line for the report; e.g.
+        #   Anither(1), anither(2) <-> ANOTHER(1), Another(2), another(5)
+        # will need all other case forms (if any) of the two words. Add
+        # the generated header line to the report.
+        checker_dialog.add_header(build_header_line(result_tuple))
+
+        # The header line is first followed by lines that contain the 'suspect'
+        # word in all of it case forms. The number of lines output is limited
+        # to LINES_IN_REPORT_LIMIT, currently set to 4. If there were more lines
+        # to output to the dialog then the lines that are displayed are followed
+        # by a line displaying "...more". The occurrence of the word on each
+        # line is highlighted in the usual way.
+        tuples = get_sorted_list_of_linecol_tuples(suspect_word)
+        lines_output_count = 0
+        for index_tuple in tuples:
+            # Limit the number of 'suspect' word lines reported.
+            if lines_output_count == LINES_IN_REPORT_LIMIT:
+                lines_output_count = -1
+                break
+            error_start, error_end = make_into_strings(index_tuple, len(suspect_word))
+            start_rowcol = IndexRowCol(error_start)
+            end_rowcol = IndexRowCol(error_end)
+            file_line = maintext().get(
+                error_start + " linestart", error_end + " lineend"
+            )
+            checker_dialog.add_entry(
+                file_line,
+                IndexRange(start_rowcol, end_rowcol),
+                start_rowcol.col,
+                end_rowcol.col,
+            )
+            lines_output_count += 1
+
+        if lines_output_count < 0:
+            checker_dialog.add_footer("  ...more")
+
+        # No more lines to output for the suspect word so add a separator.
+        checker_dialog.add_header("----")
+
+        # The separator line is then followed by lines that contain the 'good'
+        # word in all of it case forms. The number of lines output is limited
+        # to LINES_IN_REPORT_LIMIT, currently set to 4. If there were more lines
+        # to output to the dialog then the lines that are displayed are followed
+        # by a line displaying "...more". The occurrence of the word on each
+        # line is highlighted in the usual way.
+        tuples = get_sorted_list_of_linecol_tuples(test_word)
+        lines_output_count = 0
+        for index_tuple in tuples:
+            # Limit the number of 'good' word lines reported.
+            if lines_output_count == LINES_IN_REPORT_LIMIT:
+                lines_output_count = -1
+                break
+            error_start, error_end = make_into_strings(index_tuple, len(test_word))
+            start_rowcol = IndexRowCol(error_start)
+            end_rowcol = IndexRowCol(error_end)
+            file_line = maintext().get(
+                error_start + " linestart", error_end + " lineend"
+            )
+            checker_dialog.add_entry(
+                file_line,
+                IndexRange(start_rowcol, end_rowcol),
+                start_rowcol.col,
+                end_rowcol.col,
+            )
+            lines_output_count += 1
+
+        if lines_output_count < 0:
+            checker_dialog.add_footer("  ...more")
+
+        # Add a blank line to separate this word-pair report from that of the
+        # next pair.
+        checker_dialog.add_footer("")
+
+    def make_into_strings(index_tuple: tuple, hilite_length: int) -> tuple[str, str]:
+        """Utility function to generate error_start & error_end strings from int values
+
+        Args:
+            index_tuple: an integer line number and an integer column start index
+            hilite_length: integer length of string to be lighlighted on the line.
+
+        Return:
+            An error_start string (E.g. "18.3" and an error_end string (E.g. "18.9")
+        """
+
+        line_num = str(index_tuple[0])
+        col_indx = str(index_tuple[1])
+        error_start = f"{line_num}.{col_indx}"
+        col_indx = str(index_tuple[1] + hilite_length)
+        error_end = f"{line_num}.{col_indx}"
+
+        return error_start, error_end
+
+    def reject_this(word: str) -> bool:
+        """Helper function that extracts repeated code. Decides whether
+        a word should be added to a list ('good' or 'suspects') and thus
+        will be distance checked. Criteria for rejection includes being
+        too short, a Roman numeral, all digits, etc.
+
+        Args:
+            word: should we add this word to a list or not?
+
+        Return:
+            A boolean. True if answer is 'No'; i.e. it won't be distance checked
+        """
+
+        # Reject single-letter 'words' as they generate spurious report lines
+        if len(word) == 1:
+            return True
+        # Reject if word contains Greek letters; e.g. 5μ, 3π, etc.
+        if re.search(r"\p{Greek}+", word):
+            return True
+        # Reject word if a valid Roman numeral
+        worduc = word.upper()
+        if re.fullmatch(
+            r"(?=[MDCLXVI])M*(C[MD]|D?C{0,3})(X[CL]|L?X{0,3})(I[XV]|V?I{0,3})",
+            worduc,
+        ):
+            return True
+        # Otherwise the length/type of the word looks OK. Keep it so that it's
+        # added to one of the two lists.
+        return False
+
+    def map_words_in_file(project_dict: ProjectDict) -> None:
+        """Spell check the currently loaded file and extract a list of suspect
+        words and a list of good words. Build a map of the line position index(es)
+        of each word and a map of the frequency of each word. In addition, build
+        a map of the case variants of a word that uses the lowercase form of the
+        word as key.
+
+        The two lists of words from which word pairs are generated for possible
+        distance checking are unique collections of words all in lowercase. This
+        is crucial to minimise execution time needed to generate the reported
+        results.
+
+        However when we generate the edit distance report we want to display all
+        the case variants of a word (e.g. 'ANOTHER', 'Another', 'another') hence
+        the role of the 'all_words_case_map' created in this function.
+
+        Outputs into a nonlocal list or dictionary:
+            List of suspect words - each an apparent spelling error.
+            Counts of those words (dictionary).
+            List of good words - each found in an English dictionary.
+            Counts of those words (dictionary).
+            Map of the line index(es) of each word and hilite start index on line
+                (dictionary).
+            Map of the case variants of a word (dictionary).
+        """
+        assert _the_spell_checker is not None
+
+        # The following must already exist (see enclosing function) before they are
+        # used here. They are the lists and dictionaries into which the results of
+        # this function are 'returned'.
+        nonlocal good_words
+        nonlocal suspect_words
+        nonlocal word_to_lines_map, all_words_counts
+        nonlocal all_words_case_map
+
+        # Do spelling checks below using SpellChecker methods from spell.py
+
+        # The main loop from spell.py with some minor adaptions. It splits each
+        # file line into 'words' and calls SpellChecker.spell_check_word() on each.
+        # Depending on the result, the word is appended either to 'good_words' list
+        # (they are in the spelling dictionary) or 'suspect_words' list (not in the
+        # spelling dictionary). Some variable names changed to avoid pylint flagging
+        # 'duplicate code' with the same block of code in spell.py.
+        for line_text, line_number in maintext().get_lines():
+            words = re.split(r"[^\p{Alnum}\p{Mark}'’]", line_text)
+            next_column = 0
+            for word in words:
+                column = next_column
+                next_column = column + len(word) + 1
+                if word:
+                    # Consider whether 'word' should be added to the 'good' or the
+                    # 'suspects' list. It might not be added to either if it is
+                    # too short or a Roman numeral, etc., so is unsuitable to be
+                    # distance checked.
+                    spell_check_result = _the_spell_checker.spell_check_word(
+                        word, project_dict
+                    )
+                    if spell_check_result == SPELL_CHECK_OK_YES:
+                        # Don't add it to the list if unsuitable for distance checking.
+                        if reject_this(word):
+                            continue
+                        good_words.append(word)
+                        try:
+                            all_words_counts[word] += 1
+                        except KeyError:
+                            all_words_counts[word] = 1
+
+                        try:
+                            word_to_lines_map[word].append((line_number, column))
+                        except KeyError:
+                            word_to_lines_map[word] = [(line_number, column)]
+                        continue
+
+                    # If word has leading straight apostrophe, it might be
+                    # open single quote; trim it and check again
+                    if spell_check_result == SPELL_CHECK_OK_NO and word.startswith("'"):
+                        word = word[1:]
+                        spell_check_result = _the_spell_checker.spell_check_word(
+                            word, project_dict
+                        )
+                        if spell_check_result == SPELL_CHECK_OK_YES:
+                            # Don't add it to the list if unsuitable for distance checking.
+                            if reject_this(word):
+                                continue
+                            good_words.append(word)
+                            try:
+                                all_words_counts[word] += 1
+                            except KeyError:
+                                all_words_counts[word] = 1
+
+                            try:
+                                word_to_lines_map[word].append((line_number, column))
+                            except KeyError:
+                                word_to_lines_map[word] = [(line_number, column)]
+                            continue
+
+                    # If trailing straight/curly apostrophe, it might be
+                    # close single quote; trim it and check again
+                    if spell_check_result == SPELL_CHECK_OK_NO and re.search(
+                        r"['’]$", word
+                    ):
+                        word = word[:-1]
+                        spell_check_result = _the_spell_checker.spell_check_word(
+                            word, project_dict
+                        )
+                        if spell_check_result == SPELL_CHECK_OK_YES:
+                            # Don't add it to the list if unsuitable for distance checking
+                            if reject_this(word):
+                                continue
+                            good_words.append(word)
+                            try:
+                                all_words_counts[word] += 1
+                            except KeyError:
+                                all_words_counts[word] = 1
+
+                            try:
+                                word_to_lines_map[word].append((line_number, column))
+                            except KeyError:
+                                word_to_lines_map[word] = [(line_number, column)]
+                            continue
+
+                    # Word not in dictionary. If word is not now empty and not
+                    # consisting only of single quotes, add it to suspect words
+                    # list.
+                    if not re.fullmatch(r"['’]*", word):
+                        # Don't add it to the list if unsuitable for distance checking
+                        if reject_this(word):
+                            continue
+                        suspect_words.append(word)
+                        try:
+                            all_words_counts[word] += 1
+                        except KeyError:
+                            all_words_counts[word] = 1
+
+                        try:
+                            word_to_lines_map[word].append((line_number, column))
+                        except KeyError:
+                            word_to_lines_map[word] = [(line_number, column)]
+
+        # NB The lists of 'good' words and 'suspect' words are not always mutually
+        # exclusive since a lowercase version of a word may not be in the spelling
+        # dictionary used but the uppercase version of the word is in that dictionary.
+        # An example of this is 'kirk' which is not in spelling dictionary but 'Kirk'
+        # is in the dictionary.
+
+        # Build a dictionary, keyed by the lower case version of a word, whose value
+        # will be a list of the same word in the different cases in which it appears
+        # in the file. E.g.
+        #  dict['another'] -> ['ANOTHER', Another', 'another']
+        #
+        # NB Only words that appear in the text will appear in that list. Thus the
+        #    lowercase version of a word that's used as a key will not be in the list
+        #    unless it also appears in the text.
+
+        # As stated in the comments above, 'word' may be a string in any case.
+        for word in good_words:
+            # The lowercase version of the word is the dictionary key.
+            word_lc = word.lower()
+            if word_lc in all_words_case_map:
+                # There's a dictionary entry keyed by the lowercase form of the word.
+                # Is 'word' in the entries list? That is, if key is 'another' it is
+                # asking here whether, say, 'Another' is in the values list for the
+                # key.
+                if word not in all_words_case_map[word_lc]:
+                    # Then add it to the list
+                    all_words_case_map[word_lc].append(word)
+            else:
+                # Create the dictionary entry which is a list.
+                all_words_case_map[word_lc] = [word]
+
+        # Same comments apply here.
+        for word in suspect_words:
+            word_lc = word.lower()
+            if word_lc in all_words_case_map:
+                # There's a dictionary entry. Is 'word' in the entries list?
+                if word not in all_words_case_map[word_lc]:
+                    # Then add it to the list
+                    all_words_case_map[word_lc].append(word)
+            else:
+                # Create the dictionary entry which is a list.
+                all_words_case_map[word_lc] = [word]
+
+    def distance_check_words() -> None:
+        """Function to select, and edit distance check, pairs of suspect/good words.
+
+        The process involves taking each lowercase form of a suspect word and doing a
+        Levenshtein edit distance check against the lowercase form of every good word.
+
+        Keeping the lengths of the respective lists of words as short as possible is
+        critical. A book quoting a lot of speech in dialect may have a 'suspect' words
+        list of more than 1,000 entries. If the 'good' words list has 8,000 or 9,000
+        entries then the number of pairs of suspect<->good words to consider will approach
+        10 million. Processing that number of pairs is very demanding of CPU time.
+        """
+
+        nonlocal distance_check_results
+
+        # As a word may appear many times in a text, and in many case forms, for example
+        # 'ANOTHER', 'Another', 'another, each of the two lists is kept as short as
+        # possible by containing just a single lowercase instance of the word: 'another'
+        # in the example above.
+
+        # NB For display purposes a separate dictionary maps each case form of a word to
+        # its line number and column start index for every occurrence in the file. That is
+        # in turn indexed by entries from another dictionary that maps a word in lowercase
+        # to any other case form that appears in the file. E.g.: 'another' -> 'ANOTHER',
+        # 'Another', 'another'.
+        #
+        # These dictionaries are only used when processing for display in the report the
+        # small number of word pairs that meet the required Levenshtein edit distance criteria.
+        # Crucially they free us to do the CPU-intensive word selection and Levenshtein edit
+        # distance calculations on the smallest feasible set of word pairs.
+
+        # First make every word lowercase in a copy of each list.
+        suspect_words_unique = [x.lower() for x in suspect_words]
+        good_words_unique = [x.lower() for x in good_words]
+        # The resulting lists still contain multiple occurrences of a word. Use set() to
+        # create a unique collection of words from each list. Then turn the result back
+        # into a list and sort it.
+        suspect_words_unique = sorted(list(set(suspect_words_unique)))
+        good_words_unique = sorted(list(set(good_words_unique)))
+
+        # For each lowercase form of a suspect word do distance check against the lowercase
+        # form of every good word; i.e. 'test' words. Some obvious filtering of both suspect
+        # and test words is done to eliminate some pairs before the edit distance calculation
+        # check is made.
+        for suspect_wordlc in suspect_words_unique:
+            # Must be five letters or more OR contain an unexpected character.
+            unexpected = re.sub(r"[a-z0-9’'æœ]", "", suspect_wordlc)
+            if len(suspect_wordlc) < 3 and len(unexpected) == 0:
+                continue
+            for test_wordlc in good_words_unique:
+                # No point in processing a suspect<->test word pair whose difference in
+                # length is greater than the edit distance to be used in the check (1 or 2).
+                if abs(len(suspect_wordlc) - len(test_wordlc)) > distance_to_check:
+                    continue
+                # Check if they are the same word differing only by capitalisation.
+                # This check may seem unnecessary since the two lists are supposed
+                # to contain mutually exclusive collections of words. This may not
+                # always be so. For example 'kirk', the Scottish word for a church
+                # is not in the dictionary so would appear in 'suspect_words' while
+                # the name 'Kirk' IS in the dictionary hence would appear in the
+                # 'good_words/test_words' list.
+                if suspect_wordlc == test_wordlc:
+                    continue
+
+                # Calculate Levenshtein distance
+                dist = distance(
+                    suspect_wordlc, test_wordlc, score_cutoff=distance_to_check
+                )
+
+                if dist == distance_to_check:
+                    distance_check_results.append((suspect_wordlc, test_wordlc))
+
+    ####
+    # Executable section of enclosing function 'run_levenshtein_check_on_file'.
+    ####
+
+    # Start time of prgram execution
+    prog_start = time.time()
+
+    # Set up SpellChecker here before the tool window is opened in
+    # case it cannot find the required dictionaries.
+    _the_spell_checker = get_spell_checker()
+    if _the_spell_checker is None:
+        return
+
+    # Create the checker dialog to show results
+    checker_dialog = LevenshteinCheckerDialog.show_dialog(
+        "Levenshtein Edit Distance Check",
+        rerun_command=lambda: levenshtein_check(project_dict),
+    )
+    checker_dialog.reset()
+
+    # Convert to int the edit distance used last time Levenshtein was run or default if first run.
+    distance_to_check = (
+        1
+        if preferences.get(PrefKey.LEVENSHTEIN_EDIT_DISTANCE)
+        == LevenshteinEditDistance.ONE
+        else 2
+    )
+
+    # Build maps of the good words and the suspect words in the file.
+    # Ideally should only do this once and not every time the tool is
+    # rerun.
+    map_words_in_file(project_dict)
+
+    # For each suspect word, check against each good word in turn.
+    # Very compute intensive. Where 90% of the execution time is consumed.
+    distance_check_words()
+
+    # Did distance_check_words() find any word pairs that met
+    # the required Levenshtein criteria?
+    if len(distance_check_results) == 0:
+        # No.
+        checker_dialog.add_entry("No Levenshtein edit distance queries reported")
+        checker_dialog.add_entry("")
+    else:
+        # Yes, so display the results using checker_dialog methods.
+        for result_tuple in distance_check_results:
+            unpack_and_write_to_dialog(result_tuple)
+
+    # Calculate and display execution time of run.
+    prog_end = time.time()
+    checker_dialog.add_footer(f"Execution time: {(prog_end - prog_start):.2f} seconds")
+
+    checker_dialog.display_entries()
 
 
 def levenshtein_check(project_dict: ProjectDict) -> None:
     """Do Levenshtein edit distance checks"""
 
-    global _the_levenshtein_checker
-
     if not tool_save():
         return
 
-    if _the_levenshtein_checker is None:
-        _the_levenshtein_checker = LevenshteinChecker()
-
-    _the_levenshtein_checker.run_levenshtein_check_on_file(project_dict)
+    run_levenshtein_check_on_file(project_dict)

--- a/src/guiguts/tools/levenshtein.py
+++ b/src/guiguts/tools/levenshtein.py
@@ -49,21 +49,21 @@ class LevenshteinEditDistance(StrEnum):
 
 
 class LevenshteinCheckerDialog(CheckerDialog):
-    """Minimal class to identify dialog type."""
+    """Levenshtein Checker Dialog."""
 
     manual_page = "Tools_Menu#Word_Distance_Check"
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Initialize curly quotes checker dialog."""
-        kwargs["tooltip"] = "\n".join(
-            [
-                "Left click: Select & find highlighted word in file",
-                "Right click: Remove line with highlighted word from list",
-                "Shift Right click: Also remove all matching lines from list",
-            ]
-        )
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize Levenshtein checker dialog."""
         super().__init__(
-            *args,
+            "Levenshtein Edit Distance Check",
+            tooltip="\n".join(
+                [
+                    "Left click: Select & find highlighted word in file",
+                    "Right click: Remove line with highlighted word from list",
+                    "Shift Right click: Also remove all matching lines from list",
+                ]
+            ),
             **kwargs,
         )
 
@@ -668,7 +668,6 @@ def run_levenshtein_check_on_file(project_dict: ProjectDict) -> None:
 
     # Create the checker dialog to show results
     checker_dialog = LevenshteinCheckerDialog.show_dialog(
-        "Levenshtein Edit Distance Check",
         rerun_command=lambda: levenshtein_check(project_dict),
     )
 

--- a/src/guiguts/tools/levenshtein.py
+++ b/src/guiguts/tools/levenshtein.py
@@ -1,6 +1,6 @@
 """Levenshtein edit distance check tool"""
 
-from enum import StrEnum, auto
+from enum import IntEnum, auto
 import importlib.resources
 import logging
 import time
@@ -15,7 +15,7 @@ from guiguts.data import dictionaries
 from guiguts.file import ProjectDict
 from guiguts.maintext import maintext
 from guiguts.misc_tools import tool_save
-from guiguts.preferences import PersistentString, PrefKey, preferences
+from guiguts.preferences import PersistentInt, PrefKey, preferences
 from guiguts.spell import get_spell_checker
 from guiguts.utilities import IndexRowCol, IndexRange
 
@@ -41,7 +41,7 @@ _the_levenshtein_checker = None  # pylint: disable=invalid-name
 #########################################################
 
 
-class LevenshteinEditDistance(StrEnum):
+class LevenshteinEditDistance(IntEnum):
     """Enum class to store Levenshtein Edit Distance."""
 
     ONE = auto()
@@ -67,7 +67,7 @@ class LevenshteinCheckerDialog(CheckerDialog):
             **kwargs,
         )
 
-        self.edit_distance = PersistentString(PrefKey.LEVENSHTEIN_EDIT_DISTANCE)
+        self.edit_distance = PersistentInt(PrefKey.LEVENSHTEIN_DISTANCE)
 
         frame = ttk.Frame(self.header_frame)
         frame.grid(column=0, row=1, sticky="NSEW")
@@ -671,13 +671,8 @@ def run_levenshtein_check_on_file(project_dict: ProjectDict) -> None:
         rerun_command=lambda: levenshtein_check(project_dict),
     )
 
-    # Convert to int the edit distance used last time Levenshtein was run or default if first run.
-    distance_to_check = (
-        1
-        if preferences.get(PrefKey.LEVENSHTEIN_EDIT_DISTANCE)
-        == LevenshteinEditDistance.ONE
-        else 2
-    )
+    # Get the edit distance used last time Levenshtein was run or default if first run.
+    distance_to_check = preferences.get(PrefKey.LEVENSHTEIN_DISTANCE)
 
     # Build maps of the good words and the suspect words in the file.
     # Ideally should only do this once and not every time the tool is

--- a/src/guiguts/tools/pptxt.py
+++ b/src/guiguts/tools/pptxt.py
@@ -1,6 +1,6 @@
 """PPtxt tool"""
 
-from typing import Dict, Sequence, List
+from typing import Dict, Sequence, List, Any
 import regex as re
 
 from guiguts.checkers import CheckerDialog
@@ -11,9 +11,23 @@ from guiguts.utilities import IndexRowCol, IndexRange
 
 
 class PPtxtCheckerDialog(CheckerDialog):
-    """Minimal class to identify dialog type."""
+    """PPtxt dialog."""
 
     manual_page = "Tools_Menu#PPtxt"
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize PPtxt dialog."""
+        super().__init__(
+            "PPtxt Results",
+            tooltip="\n".join(
+                [
+                    "Left click: Select & find issue",
+                    "Right click: Remove issue from list",
+                    "Shift Right click: Remove all matching issues",
+                ]
+            ),
+            **kwargs,
+        )
 
 
 REPORT_LIMIT = 5  # Max number of times to report same issue for some checks
@@ -2521,21 +2535,11 @@ def pptxt(project_dict: ProjectDict) -> None:
 
     # Create the checker dialog to show results
     checker_dialog = PPtxtCheckerDialog.show_dialog(
-        "PPtxt Results",
         rerun_command=lambda: pptxt(project_dict),
-        tooltip="\n".join(
-            [
-                "Left click: Select & find issue",
-                "Right click: Remove issue from list",
-                "Shift Right click: Remove all matching issues",
-            ]
-        ),
     )
-    checker_dialog.reset()
 
     # Get the whole of the file from the main text widget
 
-    # text = maintext().get_text()
     text = maintext().get_text()
     input_lines = text.splitlines()
 

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -127,6 +127,7 @@ class ToplevelDialog(tk.Toplevel):
                 ToplevelDialog._toplevel_dialogs[dlg_name] = cls(title, **kwargs)  # type: ignore[call-arg]
             else:
                 ToplevelDialog._toplevel_dialogs[dlg_name] = cls(**kwargs)  # type: ignore[call-arg]
+        ToplevelDialog._toplevel_dialogs[dlg_name].reset()
         return ToplevelDialog._toplevel_dialogs[dlg_name]  # type: ignore[return-value]
 
     @classmethod

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -103,32 +103,25 @@ class ToplevelDialog(tk.Toplevel):
     @classmethod
     def show_dialog(
         cls: type[TlDlg],
-        title: Optional[str] = None,
-        destroy: bool = False,
         **kwargs: Any,
     ) -> TlDlg:
         """Show the instance of this dialog class, or create it if it doesn't exist.
 
         Args:
             title: Dialog title.
-            destroy: True (default is False) if dialog should be destroyed & re-created, rather than re-used
             kwargs: Optional kwargs to pass to dialog constructor.
         """
-        # If dialog exists, either destroy it or deiconify
+        # If dialog already exists, deiconify it
         dlg_name = cls.__name__
+        # Can we just deiconify dialog
         if dlg := cls.get_dialog():
-            if destroy:
-                dlg.destroy()
-            else:
-                dlg.deiconify()
-        # Now, if dialog doesn't exist (may have been destroyed above) (re-)create it
-        if not cls.get_dialog():
-            if title is not None:
-                ToplevelDialog._toplevel_dialogs[dlg_name] = cls(title, **kwargs)  # type: ignore[call-arg]
-            else:
-                ToplevelDialog._toplevel_dialogs[dlg_name] = cls(**kwargs)  # type: ignore[call-arg]
-        ToplevelDialog._toplevel_dialogs[dlg_name].reset()
-        return ToplevelDialog._toplevel_dialogs[dlg_name]  # type: ignore[return-value]
+            dlg.deiconify()
+        # Or do we need to create it
+        else:
+            dlg = cls(**kwargs)
+        dlg.reset()
+        ToplevelDialog._toplevel_dialogs[dlg_name] = dlg
+        return dlg
 
     @classmethod
     def get_dialog(cls) -> Optional[TlDlg]:

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -113,13 +113,13 @@ class ToplevelDialog(tk.Toplevel):
         """
         # If dialog already exists, deiconify it
         dlg_name = cls.__name__
-        # Can we just deiconify dialog
+        # Can we just deiconify dialog & reset it?
         if dlg := cls.get_dialog():
             dlg.deiconify()
-        # Or do we need to create it
+            dlg.reset()
+        # Or do we need to create it?
         else:
             dlg = cls(**kwargs)
-        dlg.reset()
         ToplevelDialog._toplevel_dialogs[dlg_name] = dlg
         return dlg
 


### PR DESCRIPTION
Re-organization of checker dialog creation to avoid re-creating widgets every time a tool is re-run

Fixes #755 

Testing notes: Do checker dialogs still work? Try Re-running the tool, closing dialog & re-opening from the menus, etc.
Any checker could be broken, but don't feel you need to check them all in great detail. The most at risk are footnotes, sidenote/illustration fixup and spell check.