### PR TITLE
Highlight border of image viewer when focused

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -427,6 +427,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         preferences.set_default(PrefKey.IMAGE_FLOAT_GEOMETRY, "400x600+100+100")
         preferences.set_default(PrefKey.IMAGE_DOCK_SASH_COORD, 300)
         preferences.set_default(PrefKey.IMAGE_SCALE_FACTOR, 0.5)
+        preferences.set_default(PrefKey.IMAGE_VIEWER_ALERT, True)
         preferences.set_default(
             PrefKey.SCANNOS_FILENAME,
             str(DEFAULT_SCANNOS_DIR.joinpath(DEFAULT_REGEX_SCANNOS)),

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -28,6 +28,7 @@ from guiguts.mainwindow import (
     ErrorHandler,
     process_accel,
     mainimage,
+    AutoImageState,
 )
 from guiguts.misc_dialogs import (
     PreferencesDialog,
@@ -183,6 +184,7 @@ class Guiguts:
         """Callback when auto_image preference is changed."""
         statusbar().set("see img", "Auto Img" if value else "See Img")
         if value:
+            mainimage().auto_image_state(AutoImageState.NORMAL)
             self.image_dir_check()
             self.auto_image_check()
 
@@ -191,8 +193,13 @@ class Guiguts:
         if preferences.get(PrefKey.AUTO_IMAGE):
             # Image viewer can temporarily pause auto image viewing,
             # but still need to schedule another call to this method.
-            if not mainimage().auto_image_paused:
+            auto_image_state = mainimage().auto_image_state()
+            if auto_image_state != AutoImageState.PAUSED:
                 self.mainwindow.load_image(self.file.get_current_image_path())
+                if auto_image_state == AutoImageState.RESTARTING:
+                    mainimage().alert_user()
+                    mainimage().auto_image_state(AutoImageState.NORMAL)
+
             root().after(200, self.auto_image_check)
 
     def show_image(self) -> None:

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -599,14 +599,16 @@ class MainImage(tk.Frame):
             self.auto_image_state(AutoImageState.RESTARTING)
 
     def alert_user(self) -> None:
-        """Flash the image border."""
+        """Flash the image border if preference enabled."""
+        if not preferences.get(PrefKey.IMAGE_VIEWER_ALERT):
+            return
 
         def set_canvas_highlight(thickness: int) -> None:
             """Set highlightthickness for canvas"""
             self.canvas["highlightthickness"] = thickness
 
-        set_canvas_highlight(2)
-        self.after(150, lambda: set_canvas_highlight(0))
+        set_canvas_highlight(4)
+        self.after(500, lambda: set_canvas_highlight(0))
 
     def auto_image_state(
         self, value: Optional[AutoImageState] = None

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -29,6 +29,7 @@ from guiguts.widgets import (
     themed_style,
     theme_set_tk_widget_colors,
     Busy,
+    theme_set_tk_widget_highlightcolor,
 )
 
 logger = logging.getLogger(__package__)
@@ -338,17 +339,18 @@ class MainImage(tk.Frame):
 
         self.canvas = tk.Canvas(
             self,
-            highlightthickness=0,
+            highlightthickness=2,
             xscrollcommand=self.hbar.set,
             yscrollcommand=self.vbar.set,
         )
+        theme_set_tk_widget_highlightcolor(self.canvas)
         self.canvas.grid(row=2, column=0, sticky="NSEW")
         self.rowconfigure(2, weight=1)
         self.columnconfigure(0, weight=1)
 
         self.canvas.bind("<Configure>", self.handle_configure)
-        self.bind("<Enter>", self.handle_configure)
-        self.bind("<Leave>", self.handle_configure)
+        self.bind("<Enter>", self.handle_enter)
+        self.bind("<Leave>", self.handle_leave)
         self.canvas.bind("<ButtonPress-1>", self.move_from)
         self.canvas.bind("<B1-Motion>", self.move_to)
         if is_x11():
@@ -561,7 +563,19 @@ class MainImage(tk.Frame):
                 preferences.set(PrefKey.IMAGE_FLOAT_GEOMETRY, tk.Wm.geometry(self))  # type: ignore[call-overload]
             except tk.TclError:
                 pass
+
+    def handle_enter(self, event: tk.Event) -> None:
+        """Handle enter event."""
+        self.handle_configure(event)
+        self.canvas["highlightbackground"] = (
+            "white" if maintext().is_dark_theme() else "black"
+        )
+
+    def handle_leave(self, event: tk.Event) -> None:
+        """Handle leave event."""
+        self.handle_configure(event)
         self.auto_image_paused = False
+        theme_set_tk_widget_highlightcolor(self.canvas)
 
     def next_image(self, reverse: bool = False) -> None:
         """Load the next image alphabetically.

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -141,6 +141,18 @@ class PreferencesDialog(ToplevelDialog):
             variable=PersistentBoolean(PrefKey.BELL_VISUAL),
         ).grid(column=2, row=0, sticky="NEW")
 
+        iv_btn = ttk.Checkbutton(
+            appearance_frame,
+            text="Image Viewer Alert",
+            variable=PersistentBoolean(PrefKey.IMAGE_VIEWER_ALERT),
+        )
+        iv_btn.grid(column=0, row=8, sticky="NEW", pady=5)
+        ToolTip(
+            iv_btn,
+            "Whether to flash the border when Auto Img re-loads the\n"
+            "default image after you manually select a different image",
+        )
+
         # Wrapping tab
         wrapping_frame = ttk.LabelFrame(self.top_frame, text="Wrapping", padding=10)
         wrapping_frame.grid(column=0, row=1, sticky="NSEW", pady=(10, 0))

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -80,6 +80,7 @@ class PrefKey(StrEnum):
     IMAGE_FLOAT_GEOMETRY = auto()
     IMAGE_DOCK_SASH_COORD = auto()
     IMAGE_SCALE_FACTOR = auto()
+    IMAGE_VIEWER_ALERT = auto()
     SCANNOS_FILENAME = auto()
     SCANNOS_HISTORY = auto()
     HIGHLIGHT_QUOTBRAC = auto()

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -700,22 +700,36 @@ def theme_set_tk_widget_colors(widget: tk.Text) -> None:
             background="black",
             foreground="white",
             insertbackground="white",
-            highlightbackground="black",
         )
     elif theme_name == "Light":
         widget.configure(
             background="white",
             foreground="black",
             insertbackground="black",
-            highlightbackground="white",
         )
     elif theme_name == "Default":
         widget.configure(
             background=_theme_default_text_bg,
             foreground=_theme_default_text_fg,
             insertbackground=_theme_default_text_ibg,
-            highlightbackground=_theme_default_text_bg,
         )
+    theme_set_tk_widget_highlightcolor(widget)
+
+
+def theme_set_tk_widget_highlightcolor(widget: tk.Text | tk.Canvas) -> None:
+    """Set border highlight color of a (non-themed) Text or Canvas widget to match
+    the theme colors.
+
+    Args:
+        widget: The widget to be customized.
+    """
+    theme_name = preferences.get(PrefKey.THEME_NAME)
+    if theme_name == "Dark":
+        widget.configure(highlightbackground="black")
+    elif theme_name == "Light":
+        widget.configure(highlightbackground="white")
+    elif theme_name == "Default":
+        widget.configure(highlightbackground=_theme_default_text_bg)
 
 
 def _theme_init_tk_widget_colors() -> None:


### PR DESCRIPTION
When mouse enters/leaves the image viewer, change the border color. Should work correctly with themes. If you change theme, the border won't change immediately, but will as soon as you enter/leave the image viewer. We already tell the user that they may need to restart to get full effect of a theme change.

This is because if the user has AutoImg on, and they use the image viewer buttons to change the image, when the mouse leaves the image viewer, the image will flip back to the AutoImg image.

Fixes #759 as suggested by @tangledhelix 