### PR TITLE
Highlight proofer notes

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -332,6 +332,13 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         else:
             maintext().remove_highlights_quotbrac()
 
+    def highlight_proofercomment_callback(self, value: bool) -> None:
+        """Callback when highlight_proofercomment preference is changed."""
+        if value:
+            maintext().highlight_proofercomment()
+        else:
+            maintext().remove_highlights_proofercomment()
+
     def initialize_preferences(self) -> None:
         """Set default preferences and load settings from the GGPrefs file."""
         preferences.set_default(PrefKey.AUTO_IMAGE, False)
@@ -451,6 +458,10 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         preferences.set_default(PrefKey.HTML_IMAGE_UNIT, "%")
         preferences.set_default(PrefKey.HTML_IMAGE_OVERRIDE_EPUB, True)
         preferences.set_default(PrefKey.HTML_IMAGE_ALIGNMENT, "center")
+        preferences.set_default(PrefKey.HIGHLIGHT_PROOFERCOMMENT, True)
+        preferences.set_callback(
+            PrefKey.HIGHLIGHT_PROOFERCOMMENT, self.highlight_proofercomment_callback
+        )
 
         # Check all preferences have a default
         for pref_key in PrefKey:
@@ -640,6 +651,10 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
             maintext().aligncol_active,
             lambda: maintext().highlight_aligncol_callback(True),
             lambda: maintext().highlight_aligncol_callback(False),
+        )
+        search_menu.add_checkbox(
+            "Highlight ~Proofer Comments",
+            root().highlight_proofercomment,
         )
         search_menu.add_separator()
         self.init_bookmark_menu(search_menu)

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -93,6 +93,7 @@ class PrefKey(StrEnum):
     HTML_IMAGE_UNIT = auto()
     HTML_IMAGE_OVERRIDE_EPUB = auto()
     HTML_IMAGE_ALIGNMENT = auto()
+    HIGHLIGHT_PROOFERCOMMENT = auto()
 
 
 class Preferences:

--- a/src/guiguts/root.py
+++ b/src/guiguts/root.py
@@ -46,6 +46,9 @@ class Root(tk.Tk):
         self.allow_config_saves = False
         self.split_text_window = PersistentBoolean(PrefKey.SPLIT_TEXT_WINDOW)
         self.highlight_quotbrac = PersistentBoolean(PrefKey.HIGHLIGHT_QUOTBRAC)
+        self.highlight_proofercomment = PersistentBoolean(
+            PrefKey.HIGHLIGHT_PROOFERCOMMENT
+        )
 
         self.option_add("*tearOff", preferences.get(PrefKey.TEAROFF_MENUS))
         self.rowconfigure(0, weight=1)


### PR DESCRIPTION
Highlights proofer's notes in a visible but subtle way, to draw attention to them. Highlights in a rolling window as the viewport moves to avoid evaluating the entire file.

I chose what I thought were good colors for light & dark mode, but I'm open to feedback.