### PR TITLE
Add buttons to checker dialogs

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -320,20 +320,20 @@ class CheckerDialog(ToplevelDialog):
         if generic_buttons:
             rem_btn = ttk.Button(
                 message_controls_frame,
-                text="Remove",
+                text="Hide",
                 command=lambda: self.remove_entry_current(all_matching=False),
             )
             rem_btn.grid(row=0, column=0, sticky="NSEW")
-            ToolTip(rem_btn, "Remove selected message (right-click)")
+            ToolTip(rem_btn, "Hide selected message (right-click)")
             remall_btn = ttk.Button(
                 message_controls_frame,
-                text="Rem. All",
+                text="Hide All",
                 command=lambda: self.remove_entry_current(all_matching=True),
             )
             remall_btn.grid(row=0, column=1, sticky="NSEW")
             ToolTip(
                 remall_btn,
-                "Remove all messages matching selected one (Shift right-click)",
+                "Hide all messages matching selected one (Shift right-click)",
             )
             if process_command is not None:
                 fix_btn = ttk.Button(
@@ -357,7 +357,7 @@ class CheckerDialog(ToplevelDialog):
                 )
                 fixrem_btn = ttk.Button(
                     message_controls_frame,
-                    text="Fix&Rem.",
+                    text="Fix&Hide",
                     command=lambda: self.process_remove_entry_current(
                         all_matching=False
                     ),
@@ -365,11 +365,11 @@ class CheckerDialog(ToplevelDialog):
                 fixrem_btn.grid(row=0, column=4, sticky="NSEW")
                 ToolTip(
                     fixrem_btn,
-                    f"Fix selected problem & remove message ({cmd_ctrl_string()} right-click)",
+                    f"Fix selected problem & hide message ({cmd_ctrl_string()} right-click)",
                 )
                 fixremall_btn = ttk.Button(
                     message_controls_frame,
-                    text="Fix&Rem. All",
+                    text="Fix&Hide All",
                     command=lambda: self.process_remove_entry_current(
                         all_matching=True
                     ),
@@ -377,7 +377,7 @@ class CheckerDialog(ToplevelDialog):
                 fixremall_btn.grid(row=0, column=5, sticky="NSEW")
                 ToolTip(
                     fixremall_btn,
-                    f"Fix and remove all problems matching selected message (Shift {cmd_ctrl_string()} right-click)",
+                    f"Fix and hide all problems matching selected message (Shift {cmd_ctrl_string()} right-click)",
                 )
 
         sort_frame = ttk.Frame(message_controls_frame)
@@ -428,7 +428,7 @@ class CheckerDialog(ToplevelDialog):
         if view_options_dialog_class is not None:
             ttk.Button(
                 message_controls_frame, text="View Options", command=show_view_options
-            ).grid(row=1, column=2, sticky="NSE", pady=5)
+            ).grid(row=1, column=0, sticky="NS", columnspan=7)
         if view_options_filters is None:
             view_options_filters = []
         self.view_options_filters = view_options_filters

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -223,6 +223,7 @@ class CheckerDialog(ToplevelDialog):
         view_options_dialog_class: Optional[type[CheckerViewOptionsDialog]] = None,
         view_options_filters: Optional[list[CheckerFilter]] = None,
         switch_focus_when_clicked: Optional[bool] = None,
+        generic_buttons: bool = True,
         **kwargs: Any,
     ) -> None:
         """Initialize the dialog.
@@ -238,6 +239,7 @@ class CheckerDialog(ToplevelDialog):
             clear_on_undo_redo: True to cause dialog to be cleared if Undo/Redo are used.
             view_options_dialog_class: Class to use for a View Options dialog.
             view_options_filters: List of filters to control which messages are shown.
+            process_buttons: Set to False to disable generic Remove/Fix/etc buttons.
         """
         super().__init__(title, **kwargs)
         self.top_frame.rowconfigure(0, weight=0)
@@ -315,60 +317,68 @@ class CheckerDialog(ToplevelDialog):
         for col in range(6):
             message_controls_frame.columnconfigure(col, weight=1)
 
-        rem_btn = ttk.Button(
-            message_controls_frame,
-            text="Remove",
-            command=lambda: self.remove_entry_current(all_matching=False),
-        )
-        rem_btn.grid(row=0, column=0, sticky="NSEW")
-        ToolTip(rem_btn, "Remove selected message (right-click)")
-        remall_btn = ttk.Button(
-            message_controls_frame,
-            text="Rem. All",
-            command=lambda: self.remove_entry_current(all_matching=True),
-        )
-        remall_btn.grid(row=0, column=1, sticky="NSEW")
-        ToolTip(
-            remall_btn, "Remove all messages matching selected one (Shift right-click)"
-        )
-        if process_command is not None:
-            fix_btn = ttk.Button(
+        if generic_buttons:
+            rem_btn = ttk.Button(
                 message_controls_frame,
-                text="Fix",
-                command=lambda: self.process_entry_current(all_matching=False),
+                text="Remove",
+                command=lambda: self.remove_entry_current(all_matching=False),
             )
-            fix_btn.grid(row=0, column=2, sticky="NSEW")
-            ToolTip(fix_btn, f"Fix selected problem ({cmd_ctrl_string()} left-click)")
-            fixall_btn = ttk.Button(
+            rem_btn.grid(row=0, column=0, sticky="NSEW")
+            ToolTip(rem_btn, "Remove selected message (right-click)")
+            remall_btn = ttk.Button(
                 message_controls_frame,
-                text="Fix All",
-                command=lambda: self.process_entry_current(all_matching=True),
+                text="Rem. All",
+                command=lambda: self.remove_entry_current(all_matching=True),
             )
-            fixall_btn.grid(row=0, column=3, sticky="NSEW")
+            remall_btn.grid(row=0, column=1, sticky="NSEW")
             ToolTip(
-                fixall_btn,
-                f"Fix all problems matching selected message (Shift {cmd_ctrl_string()} left-click)",
+                remall_btn,
+                "Remove all messages matching selected one (Shift right-click)",
             )
-            fixrem_btn = ttk.Button(
-                message_controls_frame,
-                text="Fix&Rem.",
-                command=lambda: self.process_remove_entry_current(all_matching=False),
-            )
-            fixrem_btn.grid(row=0, column=4, sticky="NSEW")
-            ToolTip(
-                fixrem_btn,
-                f"Fix selected problem & remove message ({cmd_ctrl_string()} right-click)",
-            )
-            fixremall_btn = ttk.Button(
-                message_controls_frame,
-                text="Fix&Rem. All",
-                command=lambda: self.process_remove_entry_current(all_matching=True),
-            )
-            fixremall_btn.grid(row=0, column=5, sticky="NSEW")
-            ToolTip(
-                fixremall_btn,
-                f"Fix and remove all problems matching selected message (Shift {cmd_ctrl_string()} right-click)",
-            )
+            if process_command is not None:
+                fix_btn = ttk.Button(
+                    message_controls_frame,
+                    text="Fix",
+                    command=lambda: self.process_entry_current(all_matching=False),
+                )
+                fix_btn.grid(row=0, column=2, sticky="NSEW")
+                ToolTip(
+                    fix_btn, f"Fix selected problem ({cmd_ctrl_string()} left-click)"
+                )
+                fixall_btn = ttk.Button(
+                    message_controls_frame,
+                    text="Fix All",
+                    command=lambda: self.process_entry_current(all_matching=True),
+                )
+                fixall_btn.grid(row=0, column=3, sticky="NSEW")
+                ToolTip(
+                    fixall_btn,
+                    f"Fix all problems matching selected message (Shift {cmd_ctrl_string()} left-click)",
+                )
+                fixrem_btn = ttk.Button(
+                    message_controls_frame,
+                    text="Fix&Rem.",
+                    command=lambda: self.process_remove_entry_current(
+                        all_matching=False
+                    ),
+                )
+                fixrem_btn.grid(row=0, column=4, sticky="NSEW")
+                ToolTip(
+                    fixrem_btn,
+                    f"Fix selected problem & remove message ({cmd_ctrl_string()} right-click)",
+                )
+                fixremall_btn = ttk.Button(
+                    message_controls_frame,
+                    text="Fix&Rem. All",
+                    command=lambda: self.process_remove_entry_current(
+                        all_matching=True
+                    ),
+                )
+                fixremall_btn.grid(row=0, column=5, sticky="NSEW")
+                ToolTip(
+                    fixremall_btn,
+                    f"Fix and remove all problems matching selected message (Shift {cmd_ctrl_string()} right-click)",
+                )
 
         sort_frame = ttk.Frame(message_controls_frame)
         sort_frame.grid(row=0, column=6, sticky="NSE", pady=5)

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -16,6 +16,7 @@ from guiguts.utilities import (
     IndexRange,
     is_mac,
     sing_plur,
+    cmd_ctrl_string,
 )
 from guiguts.widgets import ToplevelDialog, TlDlg, mouse_bind, Busy, ToolTip
 
@@ -200,14 +201,7 @@ class CheckerFilterErrorPrefix(CheckerFilter):
 
 
 class CheckerDialog(ToplevelDialog):
-    """Dialog to show results of running a check.
-
-    Attributes:
-        text: Text widget to contain results.
-        header_frame: Frame at top of widget containing configuration buttons, fields, etc.
-                      Row 0 contains common controls, rows 1+ available for specific dialogs.
-        count_label: Label showing how many linked entries there are in the dialog
-    """
+    """Dialog to show results of running a check."""
 
     # Slight complexity needed.
     # 1. Each type of checker dialog needs its own selection_on_clear flag
@@ -247,34 +241,20 @@ class CheckerDialog(ToplevelDialog):
         """
         super().__init__(title, **kwargs)
         self.top_frame.rowconfigure(0, weight=0)
-        self.header_frame = ttk.Frame(self.top_frame, padding=2)
-        self.header_frame.grid(row=0, column=0, sticky="NSEW")
 
-        self.header_frame.columnconfigure(0, weight=1)
-        options_frame = ttk.Frame(self.header_frame)
-        options_frame.grid(row=0, column=0, sticky="NSEW")
-        options_frame.columnconfigure(0, weight=0)
-        options_frame.columnconfigure(1, weight=1)
-        self.count_label = ttk.Label(options_frame, text="No results")
-        self.count_label.grid(row=0, column=0, sticky="NSW")
-
-        def copy_errors() -> None:
-            """Copy text messages to clipboard."""
-            self.clipboard_clear()
-            self.clipboard_append(self.text.get("1.0", tk.END))
-
-        copy_button = ttk.Button(
-            options_frame, text="Copy Results", command=copy_errors
+        # At top of dialog, header Frame to hold "count" label and Re-run button
+        count_header_frame = ttk.Frame(
+            self.top_frame,
+            padding=2,
+            borderwidth=1,
+            relief=tk.GROOVE,
         )
-        copy_button.grid(row=0, column=1, sticky="NS")
+        count_header_frame.grid(row=0, column=0, sticky="NSEW")
+        count_header_frame.rowconfigure(0, weight=1)
+        count_header_frame.columnconfigure(2, weight=1)
 
-        def rerunner() -> None:
-            self.selection_on_clear[self.__class__.__name__] = None
-            self.rerun_command()
-
-        self.rerun_command = rerun_command
-        self.rerun_button = ttk.Button(options_frame, text="Re-run", command=rerunner)
-        self.rerun_button.grid(row=0, column=2, sticky="NSE", padx=(10, 0))
+        self.count_label = ttk.Label(count_header_frame, text="No results")
+        self.count_label.grid(row=0, column=0, sticky="NSW")
 
         self.suspects_only_btn: Optional[ttk.Checkbutton]
         if show_suspects_only:
@@ -290,18 +270,108 @@ class CheckerDialog(ToplevelDialog):
                 self.display_entries()
 
             self.suspects_only_btn = ttk.Checkbutton(
-                options_frame,
+                count_header_frame,
                 text="Suspects Only",
                 variable=suspects_only_var,
                 command=suspects_only_changed,
                 takefocus=False,
             )
-            self.suspects_only_btn.grid(row=1, column=0, sticky="NSW")
+            self.suspects_only_btn.grid(row=0, column=1, sticky="NSW", padx=(10, 0))
         else:
             self.suspects_only_btn = None
 
-        sort_frame = ttk.Frame(options_frame)
-        sort_frame.grid(row=1, column=1, sticky="NS", pady=5)
+        def copy_errors() -> None:
+            """Copy text messages to clipboard."""
+            self.clipboard_clear()
+            self.clipboard_append(self.text.get("1.0", tk.END))
+
+        copy_button = ttk.Button(
+            count_header_frame, text="Copy Results", command=copy_errors
+        )
+        copy_button.grid(row=0, column=2, sticky="NSE")
+
+        def rerunner() -> None:
+            self.selection_on_clear[self.__class__.__name__] = None
+            self.rerun_command()
+
+        self.rerun_command = rerun_command
+        self.rerun_button = ttk.Button(
+            count_header_frame, text="Re-run", command=rerunner
+        )
+        self.rerun_button.grid(row=0, column=3, sticky="NSE", padx=(10, 0))
+
+        # Next a custom frame with contents determined by the dialog, e.g. Footnote tools
+        self.custom_frame = ttk.Frame(
+            self.top_frame, padding=2, borderwidth=1, relief=tk.GROOVE
+        )
+        self.custom_frame.grid(row=1, column=0, sticky="NSEW")
+
+        # Next controls relating to the message list
+        message_controls_frame = ttk.Frame(
+            self.top_frame, padding=2, borderwidth=1, relief=tk.GROOVE
+        )
+        message_controls_frame.grid(row=2, column=0, sticky="NSEW")
+        message_controls_frame.rowconfigure(0, weight=1)
+        for col in range(6):
+            message_controls_frame.columnconfigure(col, weight=1)
+
+        rem_btn = ttk.Button(
+            message_controls_frame,
+            text="Remove",
+            command=lambda: self.remove_entry_current(all_matching=False),
+        )
+        rem_btn.grid(row=0, column=0, sticky="NSEW")
+        ToolTip(rem_btn, "Remove selected message (right-click)")
+        remall_btn = ttk.Button(
+            message_controls_frame,
+            text="Rem. All",
+            command=lambda: self.remove_entry_current(all_matching=True),
+        )
+        remall_btn.grid(row=0, column=1, sticky="NSEW")
+        ToolTip(
+            remall_btn, "Remove all messages matching selected one (Shift right-click)"
+        )
+        if process_command is not None:
+            fix_btn = ttk.Button(
+                message_controls_frame,
+                text="Fix",
+                command=lambda: self.process_entry_current(all_matching=False),
+            )
+            fix_btn.grid(row=0, column=2, sticky="NSEW")
+            ToolTip(fix_btn, f"Fix selected problem ({cmd_ctrl_string()} left-click)")
+            fixall_btn = ttk.Button(
+                message_controls_frame,
+                text="Fix All",
+                command=lambda: self.process_entry_current(all_matching=True),
+            )
+            fixall_btn.grid(row=0, column=3, sticky="NSEW")
+            ToolTip(
+                fixall_btn,
+                f"Fix all problems matching selected message (Shift {cmd_ctrl_string()} left-click)",
+            )
+            fixrem_btn = ttk.Button(
+                message_controls_frame,
+                text="Fix&Rem.",
+                command=lambda: self.process_remove_entry_current(all_matching=False),
+            )
+            fixrem_btn.grid(row=0, column=4, sticky="NSEW")
+            ToolTip(
+                fixrem_btn,
+                f"Fix selected problem & remove message ({cmd_ctrl_string()} right-click)",
+            )
+            fixremall_btn = ttk.Button(
+                message_controls_frame,
+                text="Fix&Rem. All",
+                command=lambda: self.process_remove_entry_current(all_matching=True),
+            )
+            fixremall_btn.grid(row=0, column=5, sticky="NSEW")
+            ToolTip(
+                fixremall_btn,
+                f"Fix and remove all problems matching selected message (Shift {cmd_ctrl_string()} right-click)",
+            )
+
+        sort_frame = ttk.Frame(message_controls_frame)
+        sort_frame.grid(row=0, column=6, sticky="NSE", pady=5)
         sort_frame.rowconfigure(0, weight=1)
         ttk.Label(
             sort_frame,
@@ -347,20 +417,21 @@ class CheckerDialog(ToplevelDialog):
 
         if view_options_dialog_class is not None:
             ttk.Button(
-                options_frame, text="View Options", command=show_view_options
+                message_controls_frame, text="View Options", command=show_view_options
             ).grid(row=1, column=2, sticky="NSE", pady=5)
         if view_options_filters is None:
             view_options_filters = []
         self.view_options_filters = view_options_filters
 
-        self.top_frame.rowconfigure(1, weight=1)
+        # Next the message list itself
+        self.top_frame.rowconfigure(3, weight=1)
         self.text = ScrolledReadOnlyText(
             self.top_frame,
             context_menu=False,
             wrap=tk.NONE,
             font=maintext().font,
         )
-        self.text.grid(row=1, column=0, sticky="NSEW")
+        self.text.grid(row=3, column=0, sticky="NSEW")
         ToolTip(self.text, tooltip, use_pointer_pos=True)
 
         # 3 binary choices:

--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -1205,7 +1205,7 @@ class FootnoteCheckerDialog(CheckerDialog):
             **kwargs,
         )
 
-        fixit_frame = ttk.Frame(self.header_frame)
+        fixit_frame = ttk.Frame(self.custom_frame)
         fixit_frame.grid(column=0, row=1, sticky="NSEW")
         # Weight only needs setting once for each column, not every row of
         # every column.

--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -1198,8 +1198,8 @@ class FootnoteCheckerDialog(CheckerDialog):
             tooltip="\n".join(
                 [
                     "Left click: Select & find footnote",
-                    "Right click: Remove item from list",
-                    "Shift-Right click: Remove all matching items",
+                    "Right click: Hide item in list",
+                    "Shift-Right click: Also hide all matching items",
                 ]
             ),
             **kwargs,
@@ -1223,7 +1223,7 @@ class FootnoteCheckerDialog(CheckerDialog):
         # --
         self.prev_fn_button = ttk.Button(
             fixit_frame,
-            text="<-- Prev. FN",
+            text="<-- Prev FN",
             command=lambda: next_footnote("back"),
         )
         self.prev_fn_button.grid(column=1, row=0, pady=2, sticky="NSEW")
@@ -1296,7 +1296,7 @@ class FootnoteCheckerDialog(CheckerDialog):
         # --
         self.lz_set_at_chapter_button = ttk.Button(
             fixit_frame,
-            text="Autoset Chap. LZ",
+            text="Autoset Chap LZ",
             command=autoset_chapter_lz,
         )
         self.lz_set_at_chapter_button.grid(column=2, row=2, pady=2, sticky="NSEW")

--- a/src/guiguts/html_tools.py
+++ b/src/guiguts/html_tools.py
@@ -566,7 +566,8 @@ def html_validator_check() -> None:
                 tooltip="\n".join(
                     [
                         "Left click: Select & find validation error",
-                        "Right click: Remove validation error from this list",
+                        "Right click: Hide validation error",
+                        "Shift Right click: Also hide all matching validation errors",
                     ]
                 ),
                 **kwargs,
@@ -694,7 +695,8 @@ def html_link_check() -> None:
                 tooltip="\n".join(
                     [
                         "Left click: Select & find issue",
-                        "Right click: Remove issue from this list",
+                        "Right click: Hide issue",
+                        "Shift Right click: Also hide all matching issues",
                     ]
                 ),
                 **kwargs,

--- a/src/guiguts/illo_sn_fixup.py
+++ b/src/guiguts/illo_sn_fixup.py
@@ -70,8 +70,8 @@ class IlloSNCheckerDialog(CheckerDialog):
             tooltip="\n".join(
                 [
                     f"Left click: Select & find {tag_type} tag",
-                    "Right click: Remove item from list",
-                    "Shift-Right click: Remove all matching items",
+                    "Right click: Hide item",
+                    "Shift-Right click: Also hide all matching items",
                 ]
             ),
             **kwargs,

--- a/src/guiguts/illo_sn_fixup.py
+++ b/src/guiguts/illo_sn_fixup.py
@@ -76,7 +76,7 @@ class IlloSNCheckerDialog(CheckerDialog):
             ),
             **kwargs,
         )
-        frame = ttk.Frame(self.header_frame)
+        frame = ttk.Frame(self.custom_frame)
         frame.grid(column=0, row=1, sticky="NSEW")
         self.move_up_btn = ttk.Button(
             frame,

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -1052,7 +1052,7 @@ def unmatched_markup_check(
 
     # User can control nestability of some unmatched check types
     if nest_reg is None:
-        frame = ttk.Frame(checker_dialog.header_frame)
+        frame = ttk.Frame(checker_dialog.custom_frame)
         frame.grid(column=0, row=1, sticky="NSEW")
         ttk.Checkbutton(
             frame,
@@ -1545,7 +1545,7 @@ class ScannoCheckerDialog(CheckerDialog):
             **kwargs,
         )
 
-        frame = ttk.Frame(self.header_frame)
+        frame = ttk.Frame(self.custom_frame)
         frame.grid(column=0, row=1, sticky="NSEW")
         frame.columnconfigure(1, weight=1)
 
@@ -1944,7 +1944,7 @@ class CurlyQuotesDialog(CheckerDialog):
             **kwargs,
         )
 
-        frame = ttk.Frame(self.header_frame)
+        frame = ttk.Frame(self.custom_frame)
         frame.grid(column=0, row=1, sticky="NSEW", pady=5)
         frame.columnconfigure(3, weight=1)
         ttk.Button(

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -77,9 +77,9 @@ class BasicFixupCheckerDialog(CheckerDialog):
             tooltip="\n".join(
                 [
                     "Left click: Select & find issue",
-                    "Right click: Remove issue from list",
+                    "Right click: Hide issue",
                     f"With {cmd_ctrl_string()} key: Also fix issue",
-                    "With Shift key: Also remove/fix matching issues",
+                    "With Shift key: Also hide/fix all matching issues",
                 ]
             ),
             **kwargs,
@@ -660,8 +660,8 @@ class UnmatchedCheckerDialog(CheckerDialog):
             tooltip="\n".join(
                 [
                     "Left click: Select & find issue",
-                    "Right click: Remove issue from list",
-                    "Shift-Right click: Remove all matching issues",
+                    "Right click: Hide issue",
+                    "Shift-Right click: Also hide all matching issues",
                 ]
             ),
             **kwargs,
@@ -1325,7 +1325,8 @@ def proofer_comment_check() -> None:
                 tooltip="\n".join(
                     [
                         "Left click: Select & find comment",
-                        "Right click: Remove comment from this list",
+                        "Right click: Hide commentt",
+                        "Right click: Also hide all matching comments",
                     ]
                 ),
                 **kwargs,
@@ -1371,7 +1372,8 @@ def asterisk_check() -> None:
                 tooltip="\n".join(
                     [
                         "Left click: Select & find occurrence of asterisk",
-                        "Right click: Remove occurrence from this list",
+                        "Right click: Hide message",
+                        "Shfit Right click: Also hide all matching message",
                     ]
                 ),
                 **kwargs,
@@ -1537,9 +1539,9 @@ class ScannoCheckerDialog(CheckerDialog):
             tooltip="\n".join(
                 [
                     "Left click: Select & find occurrence of scanno",
-                    "Right click: Remove occurrence of scanno from list",
+                    "Right click: Hide occurrence of scanno in list",
                     f"With {cmd_ctrl_string()} key: Also fix this occurrence",
-                    "With Shift key: Also remove/fix matching occurrences",
+                    "With Shift key: Also hide/fix matching occurrences",
                 ]
             ),
             **kwargs,
@@ -1937,7 +1939,8 @@ class CurlyQuotesDialog(CheckerDialog):
             tooltip="\n".join(
                 [
                     "Left click: Select & find curly quote warning",
-                    "Right click: Remove warning from list",
+                    "Right click: Hide warning",
+                    "Shift Right click: Hide all matching warnings",
                     f"With {cmd_ctrl_string()} key: Convert straight to curly, or swap open⇔close",
                 ]
             ),

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -461,8 +461,8 @@ class SearchDialog(ToplevelDialog):
                     tooltip="\n".join(
                         [
                             "Left click: Select & find string",
-                            "Right click: Remove string from this list",
-                            "Shift Right click: Remove all occurrences of string from this list",
+                            "Right click: Hide string from this list",
+                            "Shift Right click: Hide all occurrences of string in this list",
                         ]
                     ),
                     **kwargs,

--- a/src/guiguts/spell.py
+++ b/src/guiguts/spell.py
@@ -74,8 +74,8 @@ class SpellCheckerDialog(CheckerDialog):
             tooltip="\n".join(
                 [
                     "Left click: Select & find spelling error",
-                    "Right click: Remove spelling error from list",
-                    "Shift Right click: Remove all occurrences of spelling error from list",
+                    "Right click: Skip spelling error",
+                    "Shift Right click: Skip all matching spelling errors",
                     f"With {cmd_ctrl_string()} key: Also add spelling to project dictionary",
                 ]
             ),

--- a/src/guiguts/spell.py
+++ b/src/guiguts/spell.py
@@ -132,7 +132,6 @@ class SpellCheckerDialog(CheckerDialog):
         ToolTip(
             global_dict_button,
             f"{cmd_ctrl_string()}+A",
-            use_pointer_pos=True,
         )
         project_dict_button = ttk.Button(
             frame,
@@ -145,8 +144,7 @@ class SpellCheckerDialog(CheckerDialog):
             self.bind(key_event, lambda _: invoke_and_break(project_dict_button))
         ToolTip(
             project_dict_button,
-            f"{cmd_ctrl_string()}+P",
-            use_pointer_pos=True,
+            f"{cmd_ctrl_string()}+P or {cmd_ctrl_string()}-click message",
         )
         skip_button = ttk.Button(
             frame,
@@ -159,8 +157,7 @@ class SpellCheckerDialog(CheckerDialog):
             self.bind(key_event, lambda _: invoke_and_break(skip_button))
         ToolTip(
             skip_button,
-            f"{cmd_ctrl_string()}+S",
-            use_pointer_pos=True,
+            f"{cmd_ctrl_string()}+S or right-click message",
         )
         skip_all_button = ttk.Button(
             frame,
@@ -173,8 +170,7 @@ class SpellCheckerDialog(CheckerDialog):
             self.bind(key_event, lambda _: invoke_and_break(skip_all_button))
         ToolTip(
             skip_all_button,
-            f"{cmd_ctrl_string()}+I",
-            use_pointer_pos=True,
+            f"{cmd_ctrl_string()}+I or Shift+right-click message",
         )
 
 
@@ -485,6 +481,7 @@ def spell_check(
             add_global_word_callback,
         ),
         process_command=process_spelling,
+        generic_buttons=False,
         switch_focus_when_clicked=False,
         add_global_word_callback=add_global_word_callback,
     )

--- a/src/guiguts/spell.py
+++ b/src/guiguts/spell.py
@@ -81,7 +81,7 @@ class SpellCheckerDialog(CheckerDialog):
             ),
             **kwargs,
         )
-        frame = ttk.Frame(self.header_frame)
+        frame = ttk.Frame(self.custom_frame)
         frame.grid(column=0, row=1, sticky="NSEW", pady=5)
         ttk.Label(
             frame,

--- a/src/guiguts/tools/bookloupe.py
+++ b/src/guiguts/tools/bookloupe.py
@@ -163,8 +163,8 @@ class BookloupeCheckerDialog(CheckerDialog):
             tooltip="\n".join(
                 [
                     "Left click: Select & find issue",
-                    "Right click: Remove message from list",
-                    "Shift-Right click: Remove all matching messages",
+                    "Right click: Hide message",
+                    "Shift-Right click: Hide all matching messages",
                 ]
             ),
             **kwargs,

--- a/src/guiguts/tools/jeebies.py
+++ b/src/guiguts/tools/jeebies.py
@@ -66,7 +66,7 @@ class JeebiesCheckerDialog(CheckerDialog):
             ),
             **kwargs,
         )
-        frame = ttk.Frame(self.header_frame)
+        frame = ttk.Frame(self.custom_frame)
         frame.grid(column=0, row=1, sticky="NSEW")
         ttk.Label(
             frame,

--- a/src/guiguts/tools/jeebies.py
+++ b/src/guiguts/tools/jeebies.py
@@ -59,9 +59,9 @@ class JeebiesCheckerDialog(CheckerDialog):
             tooltip="\n".join(
                 [
                     "Left click: Select & find he/be error",
-                    "Right click: Remove he/be error from list",
+                    "Right click: Hide he/be error",
                     f"With {cmd_ctrl_string()} key: Also toggle queried he/be",
-                    "Shift Right click: Also remove all matching he/be errors",
+                    "Shift Right click: Also hide all matching he/be errors",
                 ]
             ),
             **kwargs,

--- a/src/guiguts/tools/levenshtein.py
+++ b/src/guiguts/tools/levenshtein.py
@@ -60,8 +60,8 @@ class LevenshteinCheckerDialog(CheckerDialog):
             tooltip="\n".join(
                 [
                     "Left click: Select & find highlighted word in file",
-                    "Right click: Remove line with highlighted word from list",
-                    "Shift Right click: Also remove all matching lines from list",
+                    "Right click: Hide line in list",
+                    "Shift Right click: Also Hide all matching lines in list",
                 ]
             ),
             **kwargs,

--- a/src/guiguts/tools/levenshtein.py
+++ b/src/guiguts/tools/levenshtein.py
@@ -69,7 +69,7 @@ class LevenshteinCheckerDialog(CheckerDialog):
 
         self.edit_distance = PersistentInt(PrefKey.LEVENSHTEIN_DISTANCE)
 
-        frame = ttk.Frame(self.header_frame)
+        frame = ttk.Frame(self.custom_frame)
         frame.grid(column=0, row=1, sticky="NSEW")
         ttk.Label(
             frame,

--- a/src/guiguts/tools/pphtml.py
+++ b/src/guiguts/tools/pphtml.py
@@ -1,0 +1,177 @@
+"""PPhtml tool."""
+
+from html.parser import HTMLParser
+import os.path
+from typing import Any
+
+from PIL import Image
+import regex as re
+
+from guiguts.checkers import CheckerDialog
+from guiguts.file import the_file
+from guiguts.maintext import maintext
+from guiguts.utilities import IndexRange, IndexRowCol
+
+
+class OutlineHTMLParser(HTMLParser):
+    """Parse HTML file to get document outline of h1-h6 elements"""
+
+    h1_6_tags = ("h1", "h2", "h3", "h4", "h5", "h6")
+
+    def __init__(self) -> None:
+        """Initialize HTML outline parser."""
+        super().__init__()
+        self.outline: list[tuple[str, IndexRange]] = []
+        self.tag = ""
+        self.showh = False
+        self.tag_start = IndexRowCol(0, 0)
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        """Handle h1-h6 start tag."""
+        if tag in self.h1_6_tags:
+            self.tag = tag + ": "
+            self.showh = True
+            tag_index = self.getpos()
+            self.tag_start = IndexRowCol(tag_index[0], tag_index[1])
+
+    def handle_data(self, data: str) -> None:
+        """Get contents of h1-h6 tag."""
+        if self.showh:
+            self.tag = self.tag + " " + data
+
+    def handle_endtag(self, tag: str) -> None:
+        """Handle h1-h6 end tag."""
+        if tag in self.h1_6_tags:
+            self.showh = False
+            self.tag = self.tag.rstrip()
+            self.tag = re.sub(r"\s+", " ", self.tag)
+            match = re.match(r"h(\d)", self.tag)
+            if match:
+                indent = "  " * int(match.group(1))
+                tag_index = self.getpos()
+                self.outline.append(
+                    (
+                        "  " + indent + self.tag,
+                        IndexRange(
+                            self.tag_start, IndexRowCol(tag_index[0], tag_index[1] + 5)
+                        ),
+                    )
+                )
+
+
+class PPhtmlCheckerDialog(CheckerDialog):
+    """Dialog to show PPhtml results."""
+
+    manual_page = "HTML_Menu#PPhtml"
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize PPhtml dialog."""
+        super().__init__(
+            "PPhtml Results",
+            tooltip="\n".join(
+                [
+                    "Left click: Select & find error",
+                    "Right click: Hide error",
+                    "Shift Right click: Hide all matching errors",
+                ]
+            ),
+            **kwargs,
+        )
+
+
+class PPhtmlChecker:
+    """PPhtml checker"""
+
+    def __init__(self) -> None:
+        """Initialize PPhtml checker"""
+        self.dialog = PPhtmlCheckerDialog.show_dialog(rerun_command=self.run)
+        self.images_dir = ""
+        self.image_files: list[str] = []  # list of files in images folder
+        self.filedata: list[str] = []  # string of image file information
+
+    def run(self) -> None:
+        """Run PPhtml"""
+
+        self.dialog.reset()
+        self.image_tests()
+        self.heading_outline()
+
+        self.dialog.display_entries()
+
+    def image_tests(self) -> None:
+        """Various checks relating to image files."""
+
+        # find filenames of all the images
+        self.images_dir = os.path.join(os.path.dirname(the_file().filename), "images")
+        self.add_section("Image Checks")
+        if not os.path.isdir(self.images_dir):
+            self.dialog.add_entry("*** No images folder found ***")
+            return
+        self.image_files = [
+            fn
+            for fn in os.listdir(self.images_dir)
+            if os.path.isfile(os.path.join(self.images_dir, fn))
+        ]
+        self.scan_images()
+        # self.allImagesUsed()
+        # self.allTargetsAvailable()
+        # self.allImages200k()
+        # self.coverImage()
+        # self.otherImage()
+        # if self.verbose:
+        #     self.imageSummary()
+
+    def scan_images(self) -> None:
+        """Scan each image, getting size, checking filename, etc."""
+        errors = []
+        test_passed = True
+        # Check filenames
+        for filename in self.image_files:
+            if " " in filename:
+                errors.append(f"  filename '{filename}' contains spaces")
+                test_passed = False
+            if re.search(r"\p{Lu}", filename):
+                errors.append(f"  filename '{filename}' not all lower case")
+                test_passed = False
+
+        # Make sure all are JPEG or PNG images
+        for filename in self.image_files:
+            try:
+                with Image.open(os.path.join(self.images_dir, filename)) as im:
+                    self.filedata.append(
+                        f"{filename}|{im.format}|{im.size[0]}x{im.size[1]}|{im.mode}"
+                    )
+            except IOError:
+                errors.append(f"  file '{filename}' is not an image")
+                test_passed = False
+                continue
+            if im.format not in ("JPEG", "PNG"):
+                errors.append(f"  file '{filename}' is of type {im.format }")
+                test_passed = False
+
+        pass_string = "[pass]" if test_passed else "*FAIL*"
+        self.add_subsection(f"{pass_string} Image folder consistency tests")
+        for line in errors:
+            self.dialog.add_entry(line)
+
+    def heading_outline(self) -> None:
+        """Output Document Heading Outline."""
+        # Document Heading Outline
+        parser = OutlineHTMLParser()
+        parser.feed(maintext().get_text())
+        self.add_section("Document Heading Outline")
+        for line, pos in parser.outline:
+            self.dialog.add_entry(line, pos)
+
+    def add_section(self, text: str) -> None:
+        """Add section heading to dialog."""
+        self.dialog.add_header("", f"----- {text} -----")
+
+    def add_subsection(self, text: str) -> None:
+        """Add subsection heading to dialog."""
+        self.dialog.add_header(f"--- {text} ---")
+
+
+def pphtml() -> None:
+    """Instantiate & run PPhtml checker."""
+    PPhtmlChecker().run()

--- a/src/guiguts/tools/pptxt.py
+++ b/src/guiguts/tools/pptxt.py
@@ -22,8 +22,8 @@ class PPtxtCheckerDialog(CheckerDialog):
             tooltip="\n".join(
                 [
                     "Left click: Select & find issue",
-                    "Right click: Remove issue from list",
-                    "Shift Right click: Remove all matching issues",
+                    "Right click: Hide issue",
+                    "Shift Right click: Hide all matching issues",
                 ]
             ),
             **kwargs,


### PR DESCRIPTION
There are either 2 or 6 buttons, depending on whether the checker is able to Fix a reported problem. The buttons should resize with the dialog width.

Each button has a tooltip, and clicking on each one is equivalent to using Ctrl/Cmd/Shift Left/Right mouse buttons in the message list, but just using a simple mouse click.

Fixes #752

I have decided for now not to add a Preference setting to control whether these buttons are shown. 