### PR TITLE
Fix couple nits in PPtxt

### DIFF
--- a/src/guiguts/tools/pptxt.py
+++ b/src/guiguts/tools/pptxt.py
@@ -612,7 +612,9 @@ def weird_characters() -> None:
         # Update dictionary with the weirdos from the line.
         for weirdo in weirdos_list:
             # Skip exceptions
-            if weirdo == "*" and re.fullmatch(r"( {3,10}\*)\1\1\1\1", line):
+            # Thoughtbreak consists of 5 asterisks equally spaced,
+            # and indented by at least 3 spaces.
+            if weirdo == "*" and re.fullmatch(r" {3,}\*( {3,10}\*)\1\1\1", line):
                 continue
             if weirdo in weirdos_lines_dictionary:
                 weirdos_lines_dictionary[weirdo].append(line_number)

--- a/src/guiguts/tools/pptxt.py
+++ b/src/guiguts/tools/pptxt.py
@@ -608,9 +608,12 @@ def weird_characters() -> None:
     line_number = 1
     for line in book:
         # Get list of weirdos on this line. That means any character NOT in the regex.
-        weirdos_list = re.findall(r"[^A-Za-z0-9\s.,:;?!\\\-_—–=“”‘’\[\]\(\){}]", line)
+        weirdos_list = re.findall(r"[^A-Za-z0-9\s.,:;?!&\\\-_—–=“”‘’\[\]\(\){}]", line)
         # Update dictionary with the weirdos from the line.
         for weirdo in weirdos_list:
+            # Skip exceptions
+            if weirdo == "*" and line == "       *" * 5:
+                continue
             if weirdo in weirdos_lines_dictionary:
                 weirdos_lines_dictionary[weirdo].append(line_number)
             else:

--- a/src/guiguts/tools/pptxt.py
+++ b/src/guiguts/tools/pptxt.py
@@ -612,7 +612,7 @@ def weird_characters() -> None:
         # Update dictionary with the weirdos from the line.
         for weirdo in weirdos_list:
             # Skip exceptions
-            if weirdo == "*" and line == "       *" * 5:
+            if weirdo == "*" and re.fullmatch(r"( {3,10}\*)\1\1\1\1", line):
                 continue
             if weirdo in weirdos_lines_dictionary:
                 weirdos_lines_dictionary[weirdo].append(line_number)


### PR DESCRIPTION
1. Don't report ampersand in character checks because there's a better check later in "Ampersand character in line". Fixes #779 
2. Don't report asterisk in `       *       *       *       *       *` in character checks - it's a standard thought break. Fixes #778 