### PR TITLE
Don't highlight spellings in blue in dialog

### DIFF
--- a/src/guiguts/spell.py
+++ b/src/guiguts/spell.py
@@ -504,8 +504,6 @@ def spell_check(
         checker_dialog.add_entry(
             f"{spelling.word} ({spelling.frequency})" + bad_str,
             IndexRange(spelling.rowcol, end_rowcol),
-            0,
-            spelling.count,
         )
     checker_dialog.add_footer("", "End of Spelling Check" + sel_only)
     checker_dialog.display_entries()


### PR DESCRIPTION
When spell checking, every word is highlighted in blue in the dialog which some users find too much. If there was context with just the bad spelling in blue, this would be OK, but there isn't. So, don't highlight in blue.

Fixes #478 
