### PR TITLE
Add link to PPWB

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -853,6 +853,11 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         html_menu.add_button("HTML5 ~Validator (online)...", html_validator_check)
         html_menu.add_button("~CSS Validator (online)...", css_validator_check)
         html_menu.add_button("HTML ~Link Checker...", html_link_check)
+        html_menu.add_separator()
+        html_menu.add_button(
+            "~PP Workbench (www)",
+            lambda: webbrowser.open("https://www.pgdp.net/ppwb/"),
+        )
 
     def init_view_menu(self) -> None:
         """Create the View menu."""
@@ -898,10 +903,10 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         """Create the Help menu."""
         help_menu = Menu(menubar(), "~Help")
         help_menu.add_button(
-            "Guiguts ~Manual", self.show_help_manual, "F1", force_main_only=True
+            "Guiguts ~Manual (www)", self.show_help_manual, "F1", force_main_only=True
         )
         help_menu.add_button("About ~Guiguts", self.help_about)
-        help_menu.add_button("~Regex Quick Reference", self.show_help_regex)
+        help_menu.add_button("~Regex Quick Reference (www)", self.show_help_regex)
         help_menu.add_button(
             "List of ~Compose Sequences", ComposeHelpDialog.show_dialog
         )

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -849,10 +849,11 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         html_menu = Menu(menubar(), "HT~ML")
         html_menu.add_button("HTML ~Generator...", HTMLGeneratorDialog.show_dialog)
         html_menu.add_button("Auto-~Illustrations...", HTMLImageDialog.show_dialog)
+        html_menu.add_separator()
         html_menu.add_button("~Unmatched HTML Tags...", unmatched_html_markup)
+        html_menu.add_button("HTML ~Link Checker...", html_link_check)
         html_menu.add_button("HTML5 ~Validator (online)...", html_validator_check)
         html_menu.add_button("~CSS Validator (online)...", css_validator_check)
-        html_menu.add_button("HTML ~Link Checker...", html_link_check)
         html_menu.add_separator()
         html_menu.add_button(
             "~PP Workbench (www)",


### PR DESCRIPTION
HTML5 and CSS validators can be opened via options in the HTML menu. These are marked "(www)" to indicate that they will open a browser window. Also added "(www)" to a couple of Help menu options.

Fixes #451 