### PR TITLE
Add auto-fit-to-(height, width) in image viewer

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -31,6 +31,8 @@ from guiguts.mainwindow import (
     process_accel,
     mainimage,
     AutoImageState,
+    image_autofit_width_callback,
+    image_autofit_height_callback,
 )
 from guiguts.misc_dialogs import (
     PreferencesDialog,
@@ -486,6 +488,14 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         preferences.set_default(PrefKey.HIGHLIGHT_PROOFERCOMMENT, True)
         preferences.set_callback(
             PrefKey.HIGHLIGHT_PROOFERCOMMENT, self.highlight_proofercomment_callback
+        )
+        preferences.set_default(PrefKey.IMAGE_AUTOFIT_WIDTH, False)
+        preferences.set_callback(
+            PrefKey.IMAGE_AUTOFIT_WIDTH, image_autofit_width_callback
+        )
+        preferences.set_default(PrefKey.IMAGE_AUTOFIT_HEIGHT, False)
+        preferences.set_callback(
+            PrefKey.IMAGE_AUTOFIT_HEIGHT, image_autofit_height_callback
         )
 
         # Check all preferences have a default

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -299,21 +299,25 @@ class MainImage(tk.Frame):
         )
         self.zoom_out_btn.grid(row=0, column=3, sticky="NSEW")
 
-        self.ftw_btn = ttk.Button(
-            control_frame,
-            text="← Fit →",
-            takefocus=False,
-            command=self.image_zoom_to_width,
+        ttk.Label(control_frame, text="Fit:", takefocus=False).grid(
+            row=0, column=4, sticky="NSEW", padx=(5, 0)
         )
-        self.ftw_btn.grid(row=0, column=4, sticky="NSEW", padx=(5, 0))
 
-        self.fth_btn = ttk.Button(
+        self.ftw_btn = ttk.Checkbutton(
             control_frame,
-            text="↑ Fit ↓",
+            text="←→",
             takefocus=False,
-            command=self.image_zoom_to_height,
+            variable=PersistentBoolean(PrefKey.IMAGE_AUTOFIT_WIDTH),
         )
-        self.fth_btn.grid(row=0, column=5, sticky="NSEW")
+        self.ftw_btn.grid(row=0, column=5, sticky="NSEW")
+
+        self.fth_btn = ttk.Checkbutton(
+            control_frame,
+            text="↑↓",
+            takefocus=False,
+            variable=PersistentBoolean(PrefKey.IMAGE_AUTOFIT_HEIGHT),
+        )
+        self.fth_btn.grid(row=0, column=6, sticky="NSEW")
 
         self.invert_btn = ttk.Checkbutton(
             control_frame,
@@ -322,7 +326,7 @@ class MainImage(tk.Frame):
             command=self.show_image,
             variable=PersistentBoolean(PrefKey.IMAGE_INVERT),
         )
-        self.invert_btn.grid(row=0, column=6, sticky="NSEW", padx=(5, 0))
+        self.invert_btn.grid(row=0, column=7, sticky="NSEW", padx=(5, 0))
 
         self.dock_btn = ttk.Checkbutton(
             control_frame,
@@ -331,7 +335,7 @@ class MainImage(tk.Frame):
             command=self.set_image_docking,
             variable=root().image_window_docked_state,
         )
-        self.dock_btn.grid(row=0, column=7, sticky="NSEW", padx=(5, 0))
+        self.dock_btn.grid(row=0, column=8, sticky="NSEW", padx=(5, 0))
 
         self.close_btn = ttk.Button(
             control_frame,
@@ -340,7 +344,7 @@ class MainImage(tk.Frame):
             takefocus=False,
             command=self.hide_func,
         )
-        self.close_btn.grid(row=0, column=8, sticky="NSE")
+        self.close_btn.grid(row=0, column=9, sticky="NSE")
 
         # Separate bindings needed for docked (root) and floated (self) states
         for widget in (root(), self):
@@ -601,6 +605,10 @@ class MainImage(tk.Frame):
             self.canvas.yview_moveto(0)
             self.canvas.xview_moveto(0)
             self.show_image()
+            if preferences.get(PrefKey.IMAGE_AUTOFIT_WIDTH):
+                mainimage().image_zoom_to_width()
+            elif preferences.get(PrefKey.IMAGE_AUTOFIT_HEIGHT):
+                mainimage().image_zoom_to_height()
         else:
             self.clear_image()
         return True
@@ -1167,3 +1175,23 @@ def statusbar() -> StatusBar:
     """Return the single StatusBar widget"""
     assert MainWindow.statusbar is not None
     return MainWindow.statusbar
+
+
+def image_autofit_width_callback(value: bool) -> None:
+    """Callback when fit-to-width checkbox is clicked.
+
+    Deactivates the other mode (due to mutual exclusivity), then
+    activates the appropriate zoom mode."""
+    if value:
+        preferences.set(PrefKey.IMAGE_AUTOFIT_HEIGHT, False)
+        mainimage().image_zoom_to_width()
+
+
+def image_autofit_height_callback(value: bool) -> None:
+    """Callback when fit-to-height checkbox is clicked.
+
+    Deactivates the other mode (due to mutual exclusivity), then
+    activates the appropriate zoom mode."""
+    if value:
+        preferences.set(PrefKey.IMAGE_AUTOFIT_WIDTH, False)
+        mainimage().image_zoom_to_height()

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -271,6 +271,7 @@ class MainImage(tk.Frame):
             command=lambda: self.next_image(reverse=True),
         )
         self.prev_img_button.grid(row=0, column=0, sticky="NSEW")
+        ToolTip(self.prev_img_button, use_pointer_pos=True, msg="Previous image")
 
         self.next_img_button = ttk.Button(
             control_frame,
@@ -280,6 +281,7 @@ class MainImage(tk.Frame):
             command=self.next_image,
         )
         self.next_img_button.grid(row=0, column=1, sticky="NSEW")
+        ToolTip(self.next_img_button, use_pointer_pos=True, msg="Next image")
 
         self.zoom_in_btn = ttk.Button(
             control_frame,
@@ -288,7 +290,8 @@ class MainImage(tk.Frame):
             takefocus=False,
             command=lambda: self.image_zoom(zoom_in=True),
         )
-        self.zoom_in_btn.grid(row=0, column=2, sticky="NSEW", padx=(5, 0))
+        self.zoom_in_btn.grid(row=0, column=2, sticky="NSEW", padx=(10, 0))
+        ToolTip(self.zoom_in_btn, use_pointer_pos=True, msg="Zoom in")
 
         self.zoom_out_btn = ttk.Button(
             control_frame,
@@ -298,26 +301,25 @@ class MainImage(tk.Frame):
             command=lambda: self.image_zoom(zoom_in=False),
         )
         self.zoom_out_btn.grid(row=0, column=3, sticky="NSEW")
-
-        ttk.Label(control_frame, text="Fit:", takefocus=False).grid(
-            row=0, column=4, sticky="NSEW", padx=(5, 0)
-        )
+        ToolTip(self.zoom_out_btn, use_pointer_pos=True, msg="Zoom out")
 
         self.ftw_btn = ttk.Checkbutton(
             control_frame,
-            text="←→",
+            text="Fit ←→",
             takefocus=False,
             variable=PersistentBoolean(PrefKey.IMAGE_AUTOFIT_WIDTH),
         )
-        self.ftw_btn.grid(row=0, column=5, sticky="NSEW")
+        self.ftw_btn.grid(row=0, column=4, sticky="NSEW", padx=(10, 0))
+        ToolTip(self.ftw_btn, use_pointer_pos=True, msg="Fit image to viewer width")
 
         self.fth_btn = ttk.Checkbutton(
             control_frame,
-            text="↑↓",
+            text="Fit ↑↓",
             takefocus=False,
             variable=PersistentBoolean(PrefKey.IMAGE_AUTOFIT_HEIGHT),
         )
-        self.fth_btn.grid(row=0, column=6, sticky="NSEW")
+        self.fth_btn.grid(row=0, column=5, sticky="NSEW", padx=(10, 0))
+        ToolTip(self.fth_btn, use_pointer_pos=True, msg="Fit image to viewer height")
 
         self.invert_btn = ttk.Checkbutton(
             control_frame,
@@ -326,7 +328,8 @@ class MainImage(tk.Frame):
             command=self.show_image,
             variable=PersistentBoolean(PrefKey.IMAGE_INVERT),
         )
-        self.invert_btn.grid(row=0, column=7, sticky="NSEW", padx=(5, 0))
+        self.invert_btn.grid(row=0, column=6, sticky="NSEW", padx=(10, 0))
+        ToolTip(self.invert_btn, use_pointer_pos=True, msg="Invert image colors")
 
         self.dock_btn = ttk.Checkbutton(
             control_frame,
@@ -335,7 +338,12 @@ class MainImage(tk.Frame):
             command=self.set_image_docking,
             variable=root().image_window_docked_state,
         )
-        self.dock_btn.grid(row=0, column=8, sticky="NSEW", padx=(5, 0))
+        self.dock_btn.grid(row=0, column=7, sticky="NSEW", padx=(10, 0))
+        ToolTip(
+            self.dock_btn,
+            use_pointer_pos=True,
+            msg="Dock / undock image viewer from main window",
+        )
 
         self.close_btn = ttk.Button(
             control_frame,
@@ -344,7 +352,8 @@ class MainImage(tk.Frame):
             takefocus=False,
             command=self.hide_func,
         )
-        self.close_btn.grid(row=0, column=9, sticky="NSE")
+        self.close_btn.grid(row=0, column=8, sticky="NSE")
+        ToolTip(self.close_btn, use_pointer_pos=True, msg="Hide image viewer")
 
         # Separate bindings needed for docked (root) and floated (self) states
         for widget in (root(), self):

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -101,6 +101,8 @@ class PrefKey(StrEnum):
     HTML_IMAGE_OVERRIDE_EPUB = auto()
     HTML_IMAGE_ALIGNMENT = auto()
     HIGHLIGHT_PROOFERCOMMENT = auto()
+    IMAGE_AUTOFIT_WIDTH = auto()
+    IMAGE_AUTOFIT_HEIGHT = auto()
 
 
 class Preferences:


### PR DESCRIPTION
Adds two checkboxes to image viewer, to automatically fit the image to the viewport either by height or by width (of the viewport). The modes are mutually exclusive; only one may be active at a time. However, neither is required so they may both be inactive.

Operation is very simple: check the checkbox and the mode starts working; uncheck to turn off. If you check one and the other was checked, it will be automatically unchecked (they are mutually exclusive).

When either mode is turned on, the resize happens immediately. As image navigation happens, resize happens on load of the next/prev image.

If zooming an image manually, the manual zoom is kept until the viewer moves to a different image. If neither mode is active, the manual zoom level is left in place as you move from image to image.

The mode is sticky between restarts, stored in the user preferences.

Fixes #788