### PR TITLE
Don't re-show image viewer when closed

### DIFF
--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -1067,7 +1067,12 @@ class MainWindow:
 
     def hide_image(self) -> None:
         """Stop showing the current image."""
-        # preferences.set(PrefKey.AUTO_IMAGE, False)
+        # If only showing internal viewer, then closing it also requires
+        # turning off AutoImg, or it will just be shown again
+        # If external viewer is on, then AutoImg can remain on, and
+        # display images in external viewer once internal viewer is closed.
+        if not preferences.get(PrefKey.IMAGE_VIEWER_EXTERNAL):
+            preferences.set(PrefKey.AUTO_IMAGE, False)
         self.clear_image()
         root().wm_forget(mainimage())  # type: ignore[arg-type]
         self.paned_window.forget(mainimage())


### PR DESCRIPTION
If AutoImg is on, and the External Viewer is turned off, then closing the image viewer just made it reappear again.

Now, if External Viewer is off, when image viewer is closed, we turn off AutoImg.