### PR TITLE
Change Help About Guiguts dialog to text widget

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -7,9 +7,6 @@ import logging
 import importlib.resources
 from importlib.metadata import version
 import os.path
-import platform
-import sys
-from tkinter import messagebox
 from typing import Optional
 import unicodedata
 import webbrowser
@@ -45,6 +42,7 @@ from guiguts.misc_dialogs import (
     ComposeHelpDialog,
     UnicodeBlockDialog,
     UnicodeSearchDialog,
+    HelpAboutDialog,
 )
 from guiguts.misc_tools import (
     basic_fixup_check,
@@ -270,38 +268,6 @@ class Guiguts:
         """Exit the program."""
         if self.file.check_save():
             root().quit()
-
-    def help_about(self) -> None:
-        """Display a 'Help About' dialog."""
-        help_message = f"""Guiguts - an application to support creation of ebooks for PG
-
-Guiguts version: {version('guiguts')}
-
-Python version: {sys.version}
-Tk/Tcl version: {root().call("info", "patchlevel")}
-OS Platform: {platform.platform()}
-OS Release: {platform.release()}
-
-Copyright Contributors to the Guiguts-py project.
-
-This program is free software; you can redistribute it
-and/or modify it under the terms of the GNU General Public
-License as published by the Free Software Foundation;
-either version 2 of the License, or (at your option) any
-later version.
-
-This program is distributed in the hope that it will be
-useful, but WITHOUT ANY WARRANTY; without even
-the implied warranty of MERCHANTABILITY or FITNESS
-FOR A PARTICULAR PURPOSE.  See the GNU General
-Public License for more details.
-
-You should have received a copy of the GNU General Public
-License along with this program; if not, write to the
-Free Software Foundation, Inc., 51 Franklin Street,
-Fifth Floor, Boston, MA 02110-1301 USA."""
-
-        messagebox.showinfo(title="About Guiguts", message=help_message)
 
     def show_page_details_dialog(self) -> None:
         """Show the page details display/edit dialog."""
@@ -910,7 +876,7 @@ Fifth Floor, Boston, MA 02110-1301 USA."""
         help_menu.add_button(
             "Guiguts ~Manual (www)", self.show_help_manual, "F1", force_main_only=True
         )
-        help_menu.add_button("About ~Guiguts", self.help_about)
+        help_menu.add_button("About ~Guiguts", HelpAboutDialog.show_dialog)
         help_menu.add_button("~Regex Quick Reference (www)", self.show_help_regex)
         help_menu.add_button(
             "List of ~Compose Sequences", ComposeHelpDialog.show_dialog

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -1,14 +1,17 @@
 """Miscellaneous dialogs."""
 
+from importlib.metadata import version
+import platform
+import sys
 import tkinter as tk
 from tkinter import ttk, font, filedialog
 from typing import Any
-import sys
 import unicodedata
 
 import regex as re
 
 from guiguts.maintext import maintext
+from guiguts.mainwindow import ScrolledReadOnlyText
 from guiguts.preferences import (
     PrefKey,
     PersistentBoolean,
@@ -269,6 +272,85 @@ class PreferencesDialog(ToplevelDialog):
             PrefKey.WRAP_INDEX_RIGHT_MARGIN,
             "Right margin for index entries",
         )
+
+
+class HelpAboutDialog(ToplevelDialog):
+    """A "Help About Guiguts" dialog with version numbers."""
+
+    manual_page = ""  # Main manual page
+
+    def __init__(self) -> None:
+        """Initialize preferences dialog."""
+        super().__init__("Help About Guiguts", resize_x=False, resize_y=False)
+
+        # Default font is monospaced. Helvetica is guaranteed to give a proportional font
+        font_family = "Helvetica"
+        font_small = 10
+        font_medium = 12
+        font_large = 14
+        title_start = "1.0"
+        title_end = "2.0 lineend"
+        version_start = "3.0"
+        version_end = "9.0"
+
+        def copy_to_clipboard() -> None:
+            """Copy text to clipboard."""
+            self.clipboard_clear()
+            self.clipboard_append(self.text.get(version_start, version_end))
+
+        copy_button = ttk.Button(
+            self.top_frame,
+            text="Copy Version Information to Clipboard",
+            command=copy_to_clipboard,
+            takefocus=False,
+        )
+        copy_button.grid(row=0, column=0, pady=(5, 5))
+        self.text = ScrolledReadOnlyText(
+            self.top_frame, wrap=tk.NONE, font=(font_family, font_small)
+        )
+        self.text.grid(row=1, column=0, sticky="NSEW")
+        ToolTip(
+            self.text,
+            "Copy version information when reporting issues",
+            use_pointer_pos=True,
+        )
+
+        self.text.insert(
+            tk.END,
+            f"""Guiguts - an application to support creation of ebooks for PG
+
+Guiguts version: {version('guiguts')}
+
+Python version: {sys.version}
+Tk/Tcl version: {root().call("info", "patchlevel")}
+OS Platform: {platform.platform()}
+OS Release: {platform.release()}
+
+
+
+Copyright Contributors to the Guiguts-py project.
+
+This program is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public
+License as published by the Free Software Foundation;
+either version 2 of the License, or (at your option) any
+later version.
+
+This program is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE.  See the GNU General
+Public License for more details.
+
+You should have received a copy of the GNU General Public
+License along with this program; if not, write to the
+Free Software Foundation, Inc., 51 Franklin Street,
+Fifth Floor, Boston, MA 02110-1301 USA.""",
+        )
+        self.text.tag_add("title_tag", title_start, title_end)
+        self.text.tag_config("title_tag", font=(font_family, font_large))
+        self.text.tag_add("version_tag", version_start, version_end)
+        self.text.tag_config("version_tag", font=(font_family, font_medium))
 
 
 _compose_dict: dict[str, str] = {}


### PR DESCRIPTION
In order to allow user to easily copy version information to report a bug, a label wasn't really suitable. Text widget allows them to
1. Use the button provided!
2. Click & drag to select, then use Ctrl-C to copy
3. Right click to use context menu to select/copy

Fixes #802 