### PR TITLE
Track image auto-fit with change in viewer size

### DIFF
--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -360,7 +360,7 @@ class File:
             True if OK to continue with intended operation.
         """
         # Good(?) place to ensure image position gets saved
-        mainimage().handle_configure(tk.Event())
+        mainimage().handle_configure(None)
 
         if not maintext().is_modified():
             return True


### PR DESCRIPTION
Bug-fix: when auto-fit modes are on, and the height or width of the viewer changes (whichever is relevant), the image was not redrawn until a new image was loaded.

Testing notes:

Using image viewer, either docked, or undocked, turn on an auto-fit mode and then resize the viewer. That can be one of:
- resize undocked window
- resize main window with docked viewer
- resize image viewer using the divider between it and the text pane(s)

It should dynamically resize to match the mode you've chosen (either by height or by width).

If the image changes (using either status-bar `<` `>` buttons or `Auto Image`) then it should also pop to the auto-fit size. If you manually zoom in/out it should remain as you zoomed it unless you either resize the window, or change to a different image.

If you navigate to a different image with the image viewer `<` `>` buttons and then leave the viewer with Auto Image on, then the zoom will reset as the image resets.

Fixes #804