### PR TITLE
Add keyboard bindings to change tabs

### DIFF
--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -28,6 +28,7 @@ from guiguts.widgets import (
     OkApplyCancelDialog,
     mouse_bind,
     Combobox,
+    Notebook,
 )
 
 COMBO_SEPARATOR = "―" * 20
@@ -44,7 +45,7 @@ class PreferencesDialog(ToplevelDialog):
         self.minsize(250, 10)
 
         # Set up tab notebook
-        notebook = ttk.Notebook(self.top_frame, takefocus=False)
+        notebook = Notebook(self.top_frame, takefocus=False)
         notebook.grid(column=0, row=0, sticky="NSEW")
         notebook.enable_traversal()
 

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -463,6 +463,7 @@ class Notebook(ttk.Notebook):
     def __init__(self, parent: tk.Widget, *args: Any, **kwargs: Any) -> None:
         super().__init__(parent, *args, **kwargs)
         self.toplevel = self.winfo_toplevel()
+        self.tab_list: list[tk.Widget] = []
 
         # On Macs, bind Command-Option with Left/Right arrows to switch tabs
         # Standard Ctrl-tab & Shift-Ctrl-tab are inbuilt on all systems
@@ -481,6 +482,7 @@ class Notebook(ttk.Notebook):
 
     def add(self, child: tk.Widget, *args: Any, **kwargs: Any) -> None:
         super().add(child, *args, **kwargs)
+        self.tab_list.append(child)
 
         def select_tab(tab: int) -> str:
             """Select specific tab (for use with keyboard binding).
@@ -491,6 +493,31 @@ class Notebook(ttk.Notebook):
             Returns:
                 "break" to avoid default behavior (bookmark shortcuts)
             """
+            # TESTING: try uncommenting each of the following blocks of code one at a time
+
+            # Test 1
+            # self.hide(tab-1)
+
+            # Test 2
+            # self.select(tab - 1)
+            # self.hide(tab-1)
+
+            # Test 3
+            # self.select(tab - 1)
+            # self.hide(tab-1)
+            # self.add(self.tabs()[tab-1])
+
+            # Test 4
+            # self.select(tab - 1)
+            # self.hide(tab-1)
+            # self.update()
+            # self.add(self.tabs()[tab-1])
+            # self.update()
+
+            # Test 5
+            # self.tab_list[tab-1].focus_force()
+
+            # Keep the following lines unchanged in all tests
             self.select(tab - 1)
             return "break"
 


### PR DESCRIPTION
Apply keyboard bindings to tabbed Notebook widget. Only example currently in code is Preferences dialog.

Already inbuilt were (Shift-)Ctrl-Tab to switch to prev/next. Added Cmd/Ctrl-digit, e.g. Ctrl-1 to change to first tab, to match behavior in other apps, e.g. browsers.
On Macs, added Command-Option-Left/Right to switch to prev/next to match behavior in browsers.

Fixes #822 

Testing notes: On macOS, Cmd-3 should change to the third tab, for example, and Cmd-Option-Left/Right should cycle round tabs.