### PR TITLE
RTL experiment

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -76,7 +76,7 @@ from guiguts.tools.bookloupe import bookloupe_check
 from guiguts.tools.jeebies import jeebies_check, JeebiesParanoiaLevel
 from guiguts.tools.levenshtein import levenshtein_check, LevenshteinEditDistance
 from guiguts.tools.pptxt import pptxt
-from guiguts.utilities import is_mac, folder_dir_str
+from guiguts.utilities import is_mac, is_windows, is_x11, folder_dir_str
 from guiguts.widgets import themed_style, theme_name_internal_from_user
 from guiguts.word_frequency import word_frequency, WFDisplayType, WFSortType
 
@@ -456,7 +456,12 @@ class Guiguts:
             PrefKey.IMAGE_AUTOFIT_HEIGHT, image_autofit_height_callback
         )
         preferences.set_default(PrefKey.CHECKER_GRAY_UNUSED_OPTIONS, False)
-        preferences.set_default(PrefKey.AUTOFIX_RTL_TEXT, not is_mac())
+        if is_windows():
+            preferences.set_default(PrefKey.AUTOFIX_RTL_TEXT, "word")
+        elif is_x11():
+            preferences.set_default(PrefKey.AUTOFIX_RTL_TEXT, "char")
+        else:
+            preferences.set_default(PrefKey.AUTOFIX_RTL_TEXT, "off")
 
         # Check all preferences have a default
         for pref_key in PrefKey:

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -456,6 +456,7 @@ class Guiguts:
             PrefKey.IMAGE_AUTOFIT_HEIGHT, image_autofit_height_callback
         )
         preferences.set_default(PrefKey.CHECKER_GRAY_UNUSED_OPTIONS, False)
+        preferences.set_default(PrefKey.AUTOFIX_RTL_TEXT, not is_mac())
 
         # Check all preferences have a default
         for pref_key in PrefKey:
@@ -562,6 +563,11 @@ class Guiguts:
         edit_menu.add_button(
             "To~ggle Column/Regular Selection",
             maintext().toggle_selection_type,
+        )
+        edit_menu.add_separator()
+        edit_menu.add_button(
+            "Paste ~Hebrew/RTL text",
+            maintext().paste_rtl,
         )
         edit_menu.add_separator()
         case_menu = Menu(edit_menu, "C~hange Case")

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -456,6 +456,8 @@ class Guiguts:
             PrefKey.IMAGE_AUTOFIT_HEIGHT, image_autofit_height_callback
         )
         preferences.set_default(PrefKey.CHECKER_GRAY_UNUSED_OPTIONS, False)
+        # Retain the RTL fix Pref for now, even though it is not in the Prefs dialog
+        # For debugging etc, it can be manually edited in the GGprefs file.
         if is_windows():
             preferences.set_default(PrefKey.AUTOFIX_RTL_TEXT, "word")
         elif is_x11():
@@ -570,9 +572,19 @@ class Guiguts:
             maintext().toggle_selection_type,
         )
         edit_menu.add_separator()
-        edit_menu.add_button(
-            "Paste ~Hebrew/RTL text",
-            maintext().paste_rtl,
+        rtl_menu = Menu(edit_menu, "Right-to-left Te~xt")
+        if not is_mac():
+            rtl_menu.add_button(
+                (
+                    "Paste ~Hebrew & spaces only (no punctuation)"
+                    if is_windows()
+                    else "Paste ~Hebrew, Arabic & spaces only (no punctuation)"
+                ),
+                maintext().paste_rtl,
+            )
+        rtl_menu.add_button(
+            "Surround selected text with RLM...LRM markers",
+            maintext().surround_rtl,
         )
         edit_menu.add_separator()
         case_menu = Menu(edit_menu, "C~hange Case")

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1830,13 +1830,20 @@ class MainText(tk.Text):
 
     def reverse_rtl(self, text: str) -> str:
         """Reverse sections of RTL text within string."""
-        if not preferences.get(PrefKey.AUTOFIX_RTL_TEXT):
-            return text
-        return re.sub(
-            r"[\u0590-\u05FF\uFB2A-\uFB4E][\u0590-\u05FF\uFB2A-\uFB4E ]*[\u0590-\u05FF\uFB2A-\uFB4E]",
-            lambda match: " ".join(reversed(match.group().split(" "))),
-            text,
-        )
+        autofix_rtl = preferences.get(PrefKey.AUTOFIX_RTL_TEXT)
+        if autofix_rtl == "word":
+            return re.sub(
+                r"[\u0590-\u05FF\uFB2A-\uFB4E][\u0590-\u05FF\uFB2A-\uFB4E ]*[\u0590-\u05FF\uFB2A-\uFB4E]",
+                lambda match: " ".join(reversed(match.group().split(" "))),
+                text,
+            )
+        if autofix_rtl == "char":
+            return re.sub(
+                r"[\u0590-\u05FF\uFB2A-\uFB4E][\u0590-\u05FF\uFB2A-\uFB4E ]*[\u0590-\u05FF\uFB2A-\uFB4E]",
+                lambda match: match.group()[::-1],
+                text,
+            )
+        return text
 
     def clipboard_append(self, string: str, **kw: Any) -> None:
         """Override appending text to clipboard to deal with macOS limitation."""

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -310,33 +310,6 @@ class PreferencesDialog(ToplevelDialog):
             PrefKey.TEXT_CURSOR_WIDTH,
             "Width of insert cursor in main text window",
         )
-        rtl_frame = ttk.Frame(advance_frame)
-        rtl_frame.grid(row=2, column=0, sticky="NSEW", columnspan=2)
-        ttk.Label(rtl_frame, text="RTL Text Autofix:").grid(
-            row=0, column=0, sticky="NSEW", padx=(0, 10)
-        )
-        autofix_rtl = PersistentString(PrefKey.AUTOFIX_RTL_TEXT)
-        ttk.Radiobutton(
-            rtl_frame,
-            text="Off",
-            variable=autofix_rtl,
-            value="off",
-            takefocus=False,
-        ).grid(row=0, column=1, sticky="NSEW", padx=(0, 10))
-        ttk.Radiobutton(
-            rtl_frame,
-            text="Word",
-            variable=autofix_rtl,
-            value="word",
-            takefocus=False,
-        ).grid(row=0, column=2, sticky="NSEW", padx=(0, 10))
-        ttk.Radiobutton(
-            rtl_frame,
-            text="Char",
-            variable=autofix_rtl,
-            value="char",
-            takefocus=False,
-        ).grid(row=0, column=3, sticky="NSEW")
 
         notebook.bind(
             "<<NotebookTabChanged>>",

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -310,6 +310,11 @@ class PreferencesDialog(ToplevelDialog):
             PrefKey.TEXT_CURSOR_WIDTH,
             "Width of insert cursor in main text window",
         )
+        ttk.Checkbutton(
+            advance_frame,
+            text="Auto-fix Hebrew/RTL text (not usually needed on Mac)",
+            variable=PersistentBoolean(PrefKey.AUTOFIX_RTL_TEXT),
+        ).grid(column=0, row=2, sticky="NEW", pady=5, columnspan=2)
 
         notebook.bind(
             "<<NotebookTabChanged>>",

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -310,11 +310,33 @@ class PreferencesDialog(ToplevelDialog):
             PrefKey.TEXT_CURSOR_WIDTH,
             "Width of insert cursor in main text window",
         )
-        ttk.Checkbutton(
-            advance_frame,
-            text="Auto-fix Hebrew/RTL text (not usually needed on Mac)",
-            variable=PersistentBoolean(PrefKey.AUTOFIX_RTL_TEXT),
-        ).grid(column=0, row=2, sticky="NEW", pady=5, columnspan=2)
+        rtl_frame = ttk.Frame(advance_frame)
+        rtl_frame.grid(row=2, column=0, sticky="NSEW", columnspan=2)
+        ttk.Label(rtl_frame, text="RTL Text Autofix:").grid(
+            row=0, column=0, sticky="NSEW", padx=(0, 10)
+        )
+        autofix_rtl = PersistentString(PrefKey.AUTOFIX_RTL_TEXT)
+        ttk.Radiobutton(
+            rtl_frame,
+            text="Off",
+            variable=autofix_rtl,
+            value="off",
+            takefocus=False,
+        ).grid(row=0, column=1, sticky="NSEW", padx=(0, 10))
+        ttk.Radiobutton(
+            rtl_frame,
+            text="Word",
+            variable=autofix_rtl,
+            value="word",
+            takefocus=False,
+        ).grid(row=0, column=2, sticky="NSEW", padx=(0, 10))
+        ttk.Radiobutton(
+            rtl_frame,
+            text="Char",
+            variable=autofix_rtl,
+            value="char",
+            takefocus=False,
+        ).grid(row=0, column=3, sticky="NSEW")
 
         notebook.bind(
             "<<NotebookTabChanged>>",

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -108,6 +108,7 @@ class PrefKey(StrEnum):
     IMAGE_AUTOFIT_WIDTH = auto()
     IMAGE_AUTOFIT_HEIGHT = auto()
     CHECKER_GRAY_UNUSED_OPTIONS = auto()
+    AUTOFIX_RTL_TEXT = auto()
 
 
 class Preferences:


### PR DESCRIPTION
Add advanced "Autofix RTL text" preference.
If this is False there is no change in behavior.
Defaults to False on Macs and True on Windows/Linux.

When a file is loaded, sections of Hebrew (ATM) are word-order reversed, i.e. order of chars within word is unchanged, just order of words changed.
When a file is saved, the same happens.
Also, and extra "Paste RTL text" menu option added for pasting in Hebrew from the forums.