### PR TITLE
Remove pylint warning suppression directives

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -1090,9 +1090,7 @@ class Guiguts:
 
             root().after(2500, self.update_theme)
 
-    def high_contrast_callback(
-        self, value: bool  # pylint: disable=unused-argument
-    ) -> None:
+    def high_contrast_callback(self, _value: bool) -> None:
         """Callback for when HIGH_CONTRAST preference is changed"""
         # re-display image
         mainimage().show_image(internal_only=True)

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -1061,14 +1061,14 @@ def bin_name(basename: str) -> str:
 
 # For convenient access, store the single File instance here,
 # with a function to set/query it.
-_the_file = None  # pylint: disable=invalid-name
+_THE_FILE = None
 
 
 def the_file(file: Optional[File] = None) -> File:
     """Store and return the single File widget"""
-    global _the_file
+    global _THE_FILE
     if file is not None:
-        assert _the_file is None
-        _the_file = file
-    assert _the_file is not None
-    return _the_file
+        assert _THE_FILE is None
+        _THE_FILE = file
+    assert _THE_FILE is not None
+    return _THE_FILE

--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -23,9 +23,7 @@ from guiguts.utilities import (
 
 logger = logging.getLogger(__package__)
 
-_the_footnote_checker: Optional["FootnoteChecker"] = (
-    None  # pylint: disable=invalid-name
-)
+_THE_FOOTNOTE_CHECKER: Optional["FootnoteChecker"] = None
 
 INSERTION_MARK_PREFIX = "Shadow"
 
@@ -532,41 +530,41 @@ def sort_key_type(
 
 def join_to_previous() -> None:
     """Join the selected footnote to the previous one."""
-    assert _the_footnote_checker is not None
+    assert _THE_FOOTNOTE_CHECKER is not None
     maintext().undo_block_begin()
-    fn_index = _the_footnote_checker.get_selected_fn_index()
+    fn_index = _THE_FOOTNOTE_CHECKER.get_selected_fn_index()
     if fn_index < 0:
         return  # No selection
     if fn_index == 0:
         return  # Can't join first footnote to previous
-    fn_records = _the_footnote_checker.get_fn_records()
+    fn_records = _THE_FOOTNOTE_CHECKER.get_fn_records()
     fn_record = fn_records[fn_index]
-    fn_cur_start = _the_footnote_checker.checker_dialog.mark_from_rowcol(
+    fn_cur_start = _THE_FOOTNOTE_CHECKER.checker_dialog.mark_from_rowcol(
         fn_record.start
     )
-    fn_cur_end = _the_footnote_checker.checker_dialog.mark_from_rowcol(fn_record.end)
+    fn_cur_end = _THE_FOOTNOTE_CHECKER.checker_dialog.mark_from_rowcol(fn_record.end)
     prev_record = fn_records[fn_index - 1]
-    fn_prev_end = _the_footnote_checker.checker_dialog.mark_from_rowcol(prev_record.end)
+    fn_prev_end = _THE_FOOTNOTE_CHECKER.checker_dialog.mark_from_rowcol(prev_record.end)
     continuation_text = maintext().get(fn_cur_start, fn_cur_end)[11:]
     maintext().delete(f"{fn_cur_start} -1l linestart", f"{fn_cur_end} +1l linestart")
     maintext().delete(f"{fn_prev_end} -1c", f"{fn_prev_end} lineend")
     maintext().insert(fn_prev_end, "\n" + continuation_text)
-    _the_footnote_checker.checker_dialog.remove_entry_current()
+    _THE_FOOTNOTE_CHECKER.checker_dialog.remove_entry_current()
     # Note index of the record to which we joined the continuation text.
     saved_prev_rec_index = fn_index - 1
-    _the_footnote_checker.run_check()
+    _THE_FOOTNOTE_CHECKER.run_check()
     display_footnote_entries(auto_select_line=False)
-    fn_records = _the_footnote_checker.get_fn_records()
+    fn_records = _THE_FOOTNOTE_CHECKER.get_fn_records()
     prev_record = fn_records[saved_prev_rec_index]
     # Get index into dialog entries for this record.
-    dialog_entry_index = _the_footnote_checker.map_fn_record_to_dialog_index(
+    dialog_entry_index = _THE_FOOTNOTE_CHECKER.map_fn_record_to_dialog_index(
         prev_record
     )
     if dialog_entry_index < 0:
         logger.error("Unexpected return from 'join_to_previous()'")
         return
     # Make it the selected entry in the dialog.
-    _the_footnote_checker.checker_dialog.select_entry_by_index(dialog_entry_index)
+    _THE_FOOTNOTE_CHECKER.checker_dialog.select_entry_by_index(dialog_entry_index)
 
 
 def next_footnote(direction: str) -> None:
@@ -577,12 +575,12 @@ def next_footnote(direction: str) -> None:
     Args:
         direction: "back" to previous FN or "forward" to next FN.
     """
-    assert _the_footnote_checker is not None
-    cur_fn_index = _the_footnote_checker.get_selected_fn_index()
+    assert _THE_FOOTNOTE_CHECKER is not None
+    cur_fn_index = _THE_FOOTNOTE_CHECKER.get_selected_fn_index()
     if cur_fn_index < 0:
         logger.error("No footnote selected")  # No selection
         return
-    fn_records = _the_footnote_checker.get_fn_records()
+    fn_records = _THE_FOOTNOTE_CHECKER.get_fn_records()
     if cur_fn_index == 0 and direction == "back":
         # Can't move behind first footnote.
         fn_record = fn_records[cur_fn_index]
@@ -595,25 +593,25 @@ def next_footnote(direction: str) -> None:
         # direction must be "back".
         fn_record = fn_records[cur_fn_index - 1]
     # Get index into dialog entries for the footnote we've moved to.
-    dialog_entry_index = _the_footnote_checker.map_fn_record_to_dialog_index(fn_record)
+    dialog_entry_index = _THE_FOOTNOTE_CHECKER.map_fn_record_to_dialog_index(fn_record)
     if dialog_entry_index < 0:
         logger.error("Unexpected return from 'next_footnote()'")
         return
     # Make it the selected entry in the dialog.
-    _the_footnote_checker.checker_dialog.select_entry_by_index(dialog_entry_index)
+    _THE_FOOTNOTE_CHECKER.checker_dialog.select_entry_by_index(dialog_entry_index)
 
 
 def set_anchor() -> None:
     """Insert anchor using label of selected footnote."""
-    assert _the_footnote_checker is not None
+    assert _THE_FOOTNOTE_CHECKER is not None
     maintext().undo_block_begin()
     insert_index = maintext().get_insert_index().index()
     # Get label to use  for anchor from the selected FN.
-    fn_index = _the_footnote_checker.get_selected_fn_index()
+    fn_index = _THE_FOOTNOTE_CHECKER.get_selected_fn_index()
     if fn_index < 0:
         logger.error("No footnote selected")  # No selection
         return
-    fn_records = _the_footnote_checker.get_fn_records()
+    fn_records = _THE_FOOTNOTE_CHECKER.get_fn_records()
     fn_record = fn_records[fn_index]
     fn_line_text = fn_record.text
     fn_label_start = 10
@@ -621,28 +619,28 @@ def set_anchor() -> None:
     fn_label = fn_line_text[fn_label_start:fn_label_end]
     maintext().insert(f"{insert_index}", f"[{fn_label}]")
     # Update AN and FN record arrays then refresh the dialog.
-    _the_footnote_checker.run_check()
+    _THE_FOOTNOTE_CHECKER.run_check()
     display_footnote_entries(auto_select_line=False)
     # Make new anchor the selected entry in the dialog.
-    fn_records = _the_footnote_checker.get_fn_records()
+    fn_records = _THE_FOOTNOTE_CHECKER.get_fn_records()
     # Get the footnote we previously selected.
     fn_record = fn_records[fn_index]
     # From that we can get the start index of the new anchor we created.
-    an_records = _the_footnote_checker.get_an_records()
+    an_records = _THE_FOOTNOTE_CHECKER.get_an_records()
     assert fn_record.an_index is not None
     an_record = an_records[fn_record.an_index]
     # Get index into dialog entries for this record.
-    dialog_entry_index = _the_footnote_checker.map_an_record_to_dialog_index(an_record)
+    dialog_entry_index = _THE_FOOTNOTE_CHECKER.map_an_record_to_dialog_index(an_record)
     if dialog_entry_index < 0:
         logger.error("Unexpected return from 'set_anchor()'")
         return
     # Make it the selected entry in the dialog.
-    _the_footnote_checker.checker_dialog.select_entry_by_index(dialog_entry_index)
+    _THE_FOOTNOTE_CHECKER.checker_dialog.select_entry_by_index(dialog_entry_index)
 
 
 def set_lz_at_cursor() -> None:
     """Insert FOOTNOTES: header at cursor."""
-    assert _the_footnote_checker is not None
+    assert _THE_FOOTNOTE_CHECKER is not None
     maintext().undo_block_begin()
     insert_index = maintext().get_insert_index().index()
     insert_rowcol = maintext().get_insert_index()
@@ -652,12 +650,12 @@ def set_lz_at_cursor() -> None:
     # add spacing as appropriate.
     maintext().insert(f"{insert_index}", "FOOTNOTES:")
     # The file has changed so rebuild AN/FN records and refresh dialog.
-    _the_footnote_checker.run_check()
+    _THE_FOOTNOTE_CHECKER.run_check()
     # Order below is important. A flag is set in display_footnote_entries()
     # that will determine which, if any, buttons are disabled when they are
     # displayed.
     display_footnote_entries()
-    _the_footnote_checker.enable_disable_buttons()
+    _THE_FOOTNOTE_CHECKER.enable_disable_buttons()
     # Reposition main text window to display the inserted header in the midle of the window.
     maintext().set_insert_index(insert_rowcol)
 
@@ -671,18 +669,18 @@ def reindex() -> None:
 
     FOOTNOTE_INDEX_STYLE values are 'number', 'letter' or 'roman'.
     """
-    assert _the_footnote_checker is not None
+    assert _THE_FOOTNOTE_CHECKER is not None
     maintext().undo_block_begin()
     # Check index style used last time Footnotes Fixup was run or default if first run.
     index_style = preferences.get(PrefKey.FOOTNOTE_INDEX_STYLE)
-    an_records = _the_footnote_checker.get_an_records()
-    fn_records = _the_footnote_checker.get_fn_records()
+    an_records = _THE_FOOTNOTE_CHECKER.get_an_records()
+    fn_records = _THE_FOOTNOTE_CHECKER.get_fn_records()
     for index in range(1, len(an_records) + 1):
         if index_style == "roman":
             label = roman.toRoman(index)
             label = label + "."
         elif index_style == "letter":
-            label = _the_footnote_checker.alpha(index)
+            label = _THE_FOOTNOTE_CHECKER.alpha(index)
         else:
             label = str(index)
         an_record = an_records[index - 1]
@@ -690,7 +688,7 @@ def reindex() -> None:
             f"{an_record.start.index()} linestart",
             f"{an_record.start.index()} lineend",
         )
-        hl_start, hl_end = _the_footnote_checker.get_anchor_hilite_columns_from_marks(
+        hl_start, hl_end = _THE_FOOTNOTE_CHECKER.get_anchor_hilite_columns_from_marks(
             an_record
         )
         replacement_text = f"{an_line_text[0:hl_start]}[{label}]{an_line_text[hl_end:]}"
@@ -708,22 +706,22 @@ def reindex() -> None:
         maintext().delete(f"{fn_start}", f"{fn_start} lineend")
         maintext().insert(f"{fn_start}", fn_line_text)
     # AN/FN file entries have changed. Update AN/FN records.
-    _the_footnote_checker.run_check()
+    _THE_FOOTNOTE_CHECKER.run_check()
     # Maintain the order of function calls below.
     display_footnote_entries()
-    _the_footnote_checker.enable_disable_buttons()
+    _THE_FOOTNOTE_CHECKER.enable_disable_buttons()
 
 
 def autoset_end_lz() -> None:
     """Insert a 'FOOTNOTES:' LZ header line at end of file."""
-    assert _the_footnote_checker is not None
+    assert _THE_FOOTNOTE_CHECKER is not None
     maintext().undo_block_begin()
     # If the last line of the file is not a blank line then add one.
     end_of_file = maintext().end().index()
     if maintext().get(f"{end_of_file} linestart", f"{end_of_file} lineend") != "":
-        _the_footnote_checker.add_blank_line_at_eof()
+        _THE_FOOTNOTE_CHECKER.add_blank_line_at_eof()
     end_of_file = maintext().end().index()
-    _the_footnote_checker.set_lz(end_of_file)
+    _THE_FOOTNOTE_CHECKER.set_lz(end_of_file)
 
 
 def autoset_chapter_lz() -> None:
@@ -741,18 +739,18 @@ def autoset_chapter_lz() -> None:
     are deleted after footnotes have been moved to LZs - see call to
     remove_unused_lz_headers() in the function move_footnotes_to_lz().
     """
-    assert _the_footnote_checker is not None
+    assert _THE_FOOTNOTE_CHECKER is not None
     maintext().undo_block_begin()
     # If the last line of the file is not a blank line then add one.
     end_of_file = maintext().end().index()
     if maintext().get(f"{end_of_file} linestart", f"{end_of_file} lineend") != "":
-        _the_footnote_checker.add_blank_line_at_eof()
+        _THE_FOOTNOTE_CHECKER.add_blank_line_at_eof()
     # Append LZ header to end of file to catch footnotes in the last chapter
     autoset_end_lz()
     # Set search range for finding 'chapter breaks'. Look for them from the
     # start of the first anchor rather than after the first 200 lines as
     # in GG1.
-    an_records = _the_footnote_checker.get_an_records()
+    an_records = _THE_FOOTNOTE_CHECKER.get_an_records()
     first_an = an_records[0]
     search_range = IndexRange(first_an.start, maintext().end())
     # Loop, finding all chapter breaks; i.e. block of 4 blank lines. Method
@@ -781,7 +779,7 @@ def autoset_chapter_lz() -> None:
             == ""
         ):
             # Insert the LZ header.
-            _the_footnote_checker.set_lz(start_index)
+            _THE_FOOTNOTE_CHECKER.set_lz(start_index)
             # Advance past inserted LZ.
             restart_point = maintext().rowcol(f"{start_index} +6l")
         else:
@@ -790,12 +788,12 @@ def autoset_chapter_lz() -> None:
         search_range = IndexRange(restart_point, maintext().end())
 
         # The file has changed so rebuild AN/FN records and refresh dialog.
-        _the_footnote_checker.run_check()
+        _THE_FOOTNOTE_CHECKER.run_check()
         # Order below is important. A flag is set in display_footnote_entries()
         # that will determine which, if any, buttons are disabled when they are
         # displayed.
         display_footnote_entries()
-        _the_footnote_checker.enable_disable_buttons()
+        _THE_FOOTNOTE_CHECKER.enable_disable_buttons()
 
 
 def move_footnotes_to_paragraphs() -> None:
@@ -824,11 +822,11 @@ def move_footnotes_to_paragraphs() -> None:
     The third pass iterates through footnote records in reverse order removing
     any blank lines left behind when footnotes are deleted.
     """
-    assert _the_footnote_checker is not None
+    assert _THE_FOOTNOTE_CHECKER is not None
     maintext().undo_block_begin()
     # Check for any duplicate footnote labels and warn user that they should
     # reindex footnotes before attempting to move them to paragraphs or LZ(s).
-    if not _the_footnote_checker.ok_to_move_fns():
+    if not _THE_FOOTNOTE_CHECKER.ok_to_move_fns():
         logger.error(
             "Duplicate labels - reindex footnotes before moving them to paragraphs"
         )
@@ -837,8 +835,8 @@ def move_footnotes_to_paragraphs() -> None:
     # Can now reliably place insertion marks after the Checker mark so that
     # they maintain the required ordering. We'll flip the gravity back again
     # at the end of this function.
-    _the_footnote_checker.change_gravity_right_to_left()
-    an_records = _the_footnote_checker.get_an_records()
+    _THE_FOOTNOTE_CHECKER.change_gravity_right_to_left()
+    an_records = _THE_FOOTNOTE_CHECKER.get_an_records()
     # If the last line of the file is not a blank line then add one. If the
     # last line of the file is a footnote then because its end Checker mark
     # is currently tk.LEFT the newline will be correctly placed after the
@@ -855,7 +853,7 @@ def move_footnotes_to_paragraphs() -> None:
     # at the start of the Page Marker. Those two locations are the same.
 
     mark_prefix = (
-        _the_footnote_checker.checker_dialog.get_mark_prefix() + INSERTION_MARK_PREFIX
+        _THE_FOOTNOTE_CHECKER.checker_dialog.get_mark_prefix() + INSERTION_MARK_PREFIX
     )
     file_end = maintext().end().index()
     match_regex = r"^$"
@@ -944,12 +942,12 @@ def move_footnotes_to_paragraphs() -> None:
     # before deleting the original and then inserting the unchanged footnote text
     # at its named insertion mark from the first pass.
 
-    fn_records = _the_footnote_checker.get_fn_records()
+    fn_records = _THE_FOOTNOTE_CHECKER.get_fn_records()
     for fn_record_index, fn_record in enumerate(fn_records):
-        fn_cur_start = _the_footnote_checker.checker_dialog.mark_from_rowcol(
+        fn_cur_start = _THE_FOOTNOTE_CHECKER.checker_dialog.mark_from_rowcol(
             fn_record.start
         )
-        fn_cur_end = _the_footnote_checker.checker_dialog.mark_from_rowcol(
+        fn_cur_end = _THE_FOOTNOTE_CHECKER.checker_dialog.mark_from_rowcol(
             fn_record.end
         )
         fn_lines = maintext().get(fn_cur_start, fn_cur_end)
@@ -988,14 +986,14 @@ def move_footnotes_to_paragraphs() -> None:
     # insertion mark after the last FN in a list of FNs that followed it.
 
     # Restore RIGHT gravity to the Checker mark at the end of each footnote.
-    _the_footnote_checker.change_gravity_left_to_right()
+    _THE_FOOTNOTE_CHECKER.change_gravity_left_to_right()
     # Rebuild FN and AN record arrays.
-    _the_footnote_checker.run_check()
+    _THE_FOOTNOTE_CHECKER.run_check()
     # Get FN records in reverse order. It is necessary that the 'for' loop below
     # works backwards from the last footnote to the first footnote so that the
     # location of each footnote that is processed is not affected by the deletion
     # of blank lines below it in the file.
-    fn_records = _the_footnote_checker.get_fn_records()
+    fn_records = _THE_FOOTNOTE_CHECKER.get_fn_records()
     fn_records_reversed = fn_records.copy()
     fn_records_reversed.reverse()
     for fn_record in fn_records_reversed:
@@ -1021,13 +1019,13 @@ def move_footnotes_to_paragraphs() -> None:
 
     # Footnotes have been moved. Rebuild anchor and footnote record arrays
     # to reflect the changes.
-    _the_footnote_checker.run_check()
+    _THE_FOOTNOTE_CHECKER.run_check()
     # Set flag to disable buttons after dialog refreshed so that user
     # cannot execute a second FN move that might corrupt the file.
-    _the_footnote_checker.fns_have_been_moved = True
+    _THE_FOOTNOTE_CHECKER.fns_have_been_moved = True
     # Maintain the order of function calls below.
     display_footnote_entries()
-    _the_footnote_checker.enable_disable_buttons()
+    _THE_FOOTNOTE_CHECKER.enable_disable_buttons()
 
 
 def move_footnotes_to_lz() -> None:
@@ -1038,11 +1036,11 @@ def move_footnotes_to_lz() -> None:
     4-line chapter break and an added one at end of file. This means that all
     footnotes have a LZ below them.
     """
-    assert _the_footnote_checker is not None
+    assert _THE_FOOTNOTE_CHECKER is not None
     maintext().undo_block_begin()
     # Check for any duplicate footnote labels and warn user that they should
     # reindex footnotes before attempting to move them to paragraphs or LZ(s).
-    if not _the_footnote_checker.ok_to_move_fns():
+    if not _THE_FOOTNOTE_CHECKER.ok_to_move_fns():
         logger.error("Duplicate labels - reindex footnotes before moving them to LZ(s)")
         return
 
@@ -1057,16 +1055,16 @@ def move_footnotes_to_lz() -> None:
     # first footnote. Each footnote moved is inserted immediately below the LZ
     # header so pushing down higher-numbered footnotes already moved.
 
-    fn_records = _the_footnote_checker.get_fn_records()
+    fn_records = _THE_FOOTNOTE_CHECKER.get_fn_records()
     fn_records_reversed = fn_records.copy()
     fn_records_reversed.reverse()
-    an_records = _the_footnote_checker.get_an_records()
+    an_records = _THE_FOOTNOTE_CHECKER.get_an_records()
     footnotes_header = "FOOTNOTES:"
     for fn_record in fn_records_reversed:
-        fn_cur_start = _the_footnote_checker.checker_dialog.mark_from_rowcol(
+        fn_cur_start = _THE_FOOTNOTE_CHECKER.checker_dialog.mark_from_rowcol(
             fn_record.start
         )
-        fn_cur_end = _the_footnote_checker.checker_dialog.mark_from_rowcol(
+        fn_cur_end = _THE_FOOTNOTE_CHECKER.checker_dialog.mark_from_rowcol(
             fn_record.end
         )
         fn_lines = maintext().get(fn_cur_start, fn_cur_end)
@@ -1074,7 +1072,7 @@ def move_footnotes_to_lz() -> None:
         assert fn_record.an_index is not None
         an_cur = an_records[fn_record.an_index]
         an_cur_end = maintext().index(
-            _the_footnote_checker.checker_dialog.mark_from_rowcol(an_cur.end)
+            _THE_FOOTNOTE_CHECKER.checker_dialog.mark_from_rowcol(an_cur.end)
         )
         # Is there an LZ below the *anchor* of this footnote?
         #
@@ -1124,12 +1122,12 @@ def move_footnotes_to_lz() -> None:
             )
             # The last line of the file will be (the last line of) a
             # footnote. Add a blank line after it.
-            _the_footnote_checker.add_blank_line_at_eof()
+            _THE_FOOTNOTE_CHECKER.add_blank_line_at_eof()
     # Remove unused LZ headers ('FOOTNOTES:'). Only needed when moving to
     # chapter end LZs but will be invoked for end LZ too. It does no harm
     # in this latter case and saves setting/testing flags to make it apply
     # only when moving FNs to chapter end LZs.
-    _the_footnote_checker.remove_unused_lz_headers()
+    _THE_FOOTNOTE_CHECKER.remove_unused_lz_headers()
     # Ensure correct number of lines after 'FOOTNOTES:' header. If 4 blank
     # lines before, then add extra blank line after to make 2 blank lines.
     matches = maintext().find_matches(footnotes_header, maintext().start_to_end())
@@ -1142,13 +1140,13 @@ def move_footnotes_to_lz() -> None:
             maintext().insert(f"{match_idx}+1l", "\n")
     # Footnotes have been moved. Rebuild anchor and footnote record arrays
     # to reflect the changes.
-    _the_footnote_checker.run_check()
+    _THE_FOOTNOTE_CHECKER.run_check()
     # Set flag to disable buttons when dialog refreshed so that user cannot
     # execute a second footnote move that might corrupt the file.
-    _the_footnote_checker.fns_have_been_moved = True
+    _THE_FOOTNOTE_CHECKER.fns_have_been_moved = True
     # Maintain order of function calls below.
     display_footnote_entries()
-    _the_footnote_checker.enable_disable_buttons()
+    _THE_FOOTNOTE_CHECKER.enable_disable_buttons()
 
 
 def tidy_footnotes() -> None:
@@ -1157,14 +1155,14 @@ def tidy_footnotes() -> None:
     Copies and deletes the original footnote then reinserts edited
     version at the same place.
     """
-    assert _the_footnote_checker is not None
+    assert _THE_FOOTNOTE_CHECKER is not None
     maintext().undo_block_begin()
-    fn_records = _the_footnote_checker.get_fn_records()
+    fn_records = _THE_FOOTNOTE_CHECKER.get_fn_records()
     for fn_record in fn_records:
-        fn_cur_start = _the_footnote_checker.checker_dialog.mark_from_rowcol(
+        fn_cur_start = _THE_FOOTNOTE_CHECKER.checker_dialog.mark_from_rowcol(
             fn_record.start
         )
-        fn_cur_end = _the_footnote_checker.checker_dialog.mark_from_rowcol(
+        fn_cur_end = _THE_FOOTNOTE_CHECKER.checker_dialog.mark_from_rowcol(
             fn_record.end
         )
         fn_label_and_text_part = maintext().get(
@@ -1176,10 +1174,10 @@ def tidy_footnotes() -> None:
     # As there are no longer any '[Footnote ...' style records in the file
     # the effect of invoking run_check() here will be to clear the dialog
     # as there are no footnotes to report.
-    _the_footnote_checker.run_check()
+    _THE_FOOTNOTE_CHECKER.run_check()
     # Maintain order of function calls below.
     display_footnote_entries()
-    _the_footnote_checker.enable_disable_buttons()
+    _THE_FOOTNOTE_CHECKER.enable_disable_buttons()
 
 
 class FootnoteCheckerDialog(CheckerDialog):
@@ -1322,7 +1320,7 @@ class FootnoteCheckerDialog(CheckerDialog):
 
 def footnote_check() -> None:
     """Check footnotes in the currently loaded file."""
-    global _the_footnote_checker
+    global _THE_FOOTNOTE_CHECKER
 
     if not tool_save():
         return
@@ -1333,19 +1331,19 @@ def footnote_check() -> None:
         show_suspects_only=True,
     )
 
-    if _the_footnote_checker is None:
-        _the_footnote_checker = FootnoteChecker(checker_dialog)
-    elif not _the_footnote_checker.checker_dialog.winfo_exists():
-        _the_footnote_checker.checker_dialog = checker_dialog
-    _the_footnote_checker.fns_have_been_moved = False
+    if _THE_FOOTNOTE_CHECKER is None:
+        _THE_FOOTNOTE_CHECKER = FootnoteChecker(checker_dialog)
+    elif not _THE_FOOTNOTE_CHECKER.checker_dialog.winfo_exists():
+        _THE_FOOTNOTE_CHECKER.checker_dialog = checker_dialog
+    _THE_FOOTNOTE_CHECKER.fns_have_been_moved = False
 
-    _the_footnote_checker.run_check()
+    _THE_FOOTNOTE_CHECKER.run_check()
     # Order below is important. The display_footnote_entries() function will
     # set a flag if any dialog records have an error prefix. This flag is
     # checked in display_buttons() and will determine which, if any, buttons
     # are disabled when they are displayed.
     display_footnote_entries()
-    _the_footnote_checker.enable_disable_buttons()
+    _THE_FOOTNOTE_CHECKER.enable_disable_buttons()
 
 
 def check_fn_string(fn_record: FootnoteRecord) -> str:
@@ -1375,13 +1373,13 @@ def check_fn_string(fn_record: FootnoteRecord) -> str:
 
 def display_footnote_entries(auto_select_line: bool = True) -> None:
     """(Re-)display the footnotes in the checker dialog."""
-    assert _the_footnote_checker is not None
-    checker_dialog = _the_footnote_checker.checker_dialog
+    assert _THE_FOOTNOTE_CHECKER is not None
+    checker_dialog = _THE_FOOTNOTE_CHECKER.checker_dialog
     checker_dialog.reset()
-    fn_records = _the_footnote_checker.get_fn_records()
-    an_records = _the_footnote_checker.get_an_records()
+    fn_records = _THE_FOOTNOTE_CHECKER.get_fn_records()
+    an_records = _THE_FOOTNOTE_CHECKER.get_an_records()
     # Boolean to determine if buttons are to be set disabled or normal.
-    _the_footnote_checker.fn_check_errors = False
+    _THE_FOOTNOTE_CHECKER.fn_check_errors = False
     errors_flagged = False
     for fn_index, fn_record in enumerate(fn_records):
         # Flag common footnote typos. All non-conformant FNs
@@ -1459,10 +1457,10 @@ def display_footnote_entries(auto_select_line: bool = True) -> None:
         # and moved to their required landing zone. This flag is checked by the
         # display_buttons() function and determines which, if any, buttons are
         # disabled when displayed.
-        _the_footnote_checker.fn_check_errors = True
+        _THE_FOOTNOTE_CHECKER.fn_check_errors = True
     else:
-        _the_footnote_checker.fn_check_errors = False
-    for an_record in _the_footnote_checker.get_an_records():
+        _THE_FOOTNOTE_CHECKER.fn_check_errors = False
+    for an_record in _THE_FOOTNOTE_CHECKER.get_an_records():
         checker_dialog.add_entry(
             an_record.text,
             IndexRange(an_record.start, an_record.end),
@@ -1470,4 +1468,4 @@ def display_footnote_entries(auto_select_line: bool = True) -> None:
             an_record.hilite_end,
         )
     checker_dialog.display_entries(auto_select_line)
-    _the_footnote_checker.enable_disable_buttons()
+    _THE_FOOTNOTE_CHECKER.enable_disable_buttons()

--- a/src/guiguts/illo_sn_fixup.py
+++ b/src/guiguts/illo_sn_fixup.py
@@ -17,8 +17,8 @@ from guiguts.utilities import (
 
 logger = logging.getLogger(__package__)
 
-_the_illo_checker: Optional["IlloSNChecker"] = None  # pylint: disable=invalid-name
-_the_sn_checker: Optional["IlloSNChecker"] = None  # pylint: disable=invalid-name
+_THE_ILLO_CHECKER: Optional["IlloSNChecker"] = None
+_THE_SN_CHECKER: Optional["IlloSNChecker"] = None
 
 
 class IlloSNRecord:
@@ -454,7 +454,7 @@ def move_selection_up(tag_type: str) -> None:
     Args:
         tag_type: a string which is either "Sidenote" or "Illustration".
     """
-    checker = _the_illo_checker if tag_type == "Illustration" else _the_sn_checker
+    checker = _THE_ILLO_CHECKER if tag_type == "Illustration" else _THE_SN_CHECKER
     assert checker is not None
     selected_illosn_index = checker.get_selected_illosn_index()
     if selected_illosn_index < 0:
@@ -547,7 +547,7 @@ def move_selection_down(tag_type: str) -> None:
     Args:
         tag_type: a string which is either "Sidenote" or "Illustration".
     """
-    checker = _the_illo_checker if tag_type == "Illustration" else _the_sn_checker
+    checker = _THE_ILLO_CHECKER if tag_type == "Illustration" else _THE_SN_CHECKER
     assert checker is not None
     selected_illosn_index = checker.get_selected_illosn_index()
     if selected_illosn_index < 0:
@@ -633,8 +633,8 @@ def illosn_check(tag_type: str) -> None:
     Args:
         tag_type: which tag to check for - "Illustration" or "Sidenote"
     """
-    global _the_illo_checker
-    global _the_sn_checker
+    global _THE_ILLO_CHECKER
+    global _THE_SN_CHECKER
 
     if not tool_save():
         return
@@ -646,17 +646,17 @@ def illosn_check(tag_type: str) -> None:
         clear_on_undo_redo=True,
     )
     if tag_type == "Illustration":
-        if _the_illo_checker is None:
-            _the_illo_checker = IlloSNChecker(checker_dialog)
-        elif not _the_illo_checker.checker_dialog.winfo_exists():
-            _the_illo_checker.checker_dialog = checker_dialog
-        the_checker = _the_illo_checker
+        if _THE_ILLO_CHECKER is None:
+            _THE_ILLO_CHECKER = IlloSNChecker(checker_dialog)
+        elif not _THE_ILLO_CHECKER.checker_dialog.winfo_exists():
+            _THE_ILLO_CHECKER.checker_dialog = checker_dialog
+        the_checker = _THE_ILLO_CHECKER
     else:
-        if _the_sn_checker is None:
-            _the_sn_checker = IlloSNChecker(checker_dialog)
-        elif not _the_sn_checker.checker_dialog.winfo_exists():
-            _the_sn_checker.checker_dialog = checker_dialog
-        the_checker = _the_sn_checker
+        if _THE_SN_CHECKER is None:
+            _THE_SN_CHECKER = IlloSNChecker(checker_dialog)
+        elif not _THE_SN_CHECKER.checker_dialog.winfo_exists():
+            _THE_SN_CHECKER.checker_dialog = checker_dialog
+        the_checker = _THE_SN_CHECKER
 
     the_checker.run_check(tag_type)
     display_illosn_entries(tag_type)
@@ -674,7 +674,7 @@ def display_illosn_entries(tag_type: str) -> None:
         tag_type: which tag to check for - "Illustration" or "Sidenote"
     """
     assert tag_type in ("Illustration", "Sidenote")
-    the_checker = _the_illo_checker if tag_type == "Illustration" else _the_sn_checker
+    the_checker = _THE_ILLO_CHECKER if tag_type == "Illustration" else _THE_SN_CHECKER
     assert the_checker is not None
     checker_dialog = the_checker.checker_dialog
     checker_dialog.reset()

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -3807,16 +3807,12 @@ class MainText(tk.Text):
         self.tag_lower("sel", HighlightTag.QUOTEMARK)
         self.peer.tag_lower("sel", HighlightTag.QUOTEMARK)
 
-    def _autoscroll_start(
-        self, event: tk.Event  # pylint: disable=unused-argument
-    ) -> None:
+    def _autoscroll_start(self, _event: tk.Event) -> None:
         """When Button-1 is pressed, turn mouse-drag monitoring on"""
         self._autoscroll_active = True
         self._on_change()
 
-    def _autoscroll_stop(
-        self, event: tk.Event  # pylint: disable=unused-argument
-    ) -> None:
+    def _autoscroll_stop(self, _event: tk.Event) -> None:
         """When Button-1 is released, turn mouse-drag monitoring off"""
         self._autoscroll_active = False
         self._on_change()
@@ -3919,14 +3915,14 @@ class TclRegexCompileError(Exception):
 
 # For convenient access, store the single MainText instance here,
 # with a function to set/query it.
-_single_widget = None  # pylint: disable=invalid-name
+_THE_MAINTEXT = None
 
 
 def maintext(text_widget: Optional[MainText] = None) -> MainText:
     """Store and return the single MainText widget"""
-    global _single_widget
+    global _THE_MAINTEXT
     if text_widget is not None:
-        assert _single_widget is None
-        _single_widget = text_widget
-    assert _single_widget is not None
-    return _single_widget
+        assert _THE_MAINTEXT is None
+        _THE_MAINTEXT = text_widget
+    assert _THE_MAINTEXT is not None
+    return _THE_MAINTEXT

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -8,7 +8,7 @@ import os
 import tkinter as tk
 from typing import Any, Callable
 
-from guiguts.utilities import is_x11, is_windows, called_from_test, load_dict_from_json
+from guiguts.utilities import is_x11, is_windows, CALLED_FROM_TEST, load_dict_from_json
 
 if is_windows():
     from win32com.shell import shell, shellcon  # type: ignore # pylint: disable=import-error, no-name-in-module
@@ -152,7 +152,7 @@ class Preferences:
                 os.path.expanduser("~"), "Documents", "GGprefs"
             )
         # If testing, use a test prefs file so tests and normal running do not interact
-        if called_from_test:
+        if CALLED_FROM_TEST:
             prefs_name = "GGprefs_test.json"
         else:
             prefs_name = "GGprefs.json"
@@ -308,7 +308,7 @@ class Preferences:
 
     def _remove_test_prefs_file(self) -> None:
         """Remove temporary JSON file used for prefs during testing."""
-        if called_from_test and os.path.exists(self.prefsfile):
+        if CALLED_FROM_TEST and os.path.exists(self.prefsfile):
             os.remove(self.prefsfile)
 
 

--- a/src/guiguts/root.py
+++ b/src/guiguts/root.py
@@ -13,7 +13,7 @@ from guiguts.utilities import is_x11
 
 logger = logging.getLogger(__package__)
 
-_the_root = None  # pylint: disable=invalid-name
+_THE_ROOT = None
 
 
 class RootWindowState(StrEnum):
@@ -28,9 +28,9 @@ class Root(tk.Tk):
     """Inherits from Tk root window"""
 
     def __init__(self, **kwargs: Any) -> None:
-        global _the_root
-        assert _the_root is None
-        _the_root = self
+        global _THE_ROOT
+        assert _THE_ROOT is None
+        _THE_ROOT = self
 
         super().__init__(**kwargs)
         self.geometry(preferences.get(PrefKey.ROOT_GEOMETRY))
@@ -138,5 +138,5 @@ class Root(tk.Tk):
 
 def root() -> Root:
     """Return the single instance of Root"""
-    assert _the_root is not None
-    return _the_root
+    assert _THE_ROOT is not None
+    return _THE_ROOT

--- a/src/guiguts/spell.py
+++ b/src/guiguts/spell.py
@@ -30,7 +30,7 @@ SPELL_CHECK_OK_YES = 0
 SPELL_CHECK_OK_NO = 1
 SPELL_CHECK_OK_BAD = 2
 
-_the_spell_checker: Optional["SpellChecker"] = None  # pylint: disable=invalid-name
+_THE_SPELL_CHECKER: Optional["SpellChecker"] = None
 
 
 class DictionaryNotFoundError(Exception):
@@ -437,21 +437,21 @@ def get_spell_checker() -> SpellChecker | None:
         A SpellChecker object if required dictionary present, otherwise None
     """
 
-    global _the_spell_checker
+    global _THE_SPELL_CHECKER
 
     # If we already have a spell checker with the wrong languages, delete it
     if (
-        _the_spell_checker is not None
-        and _the_spell_checker.language_list != maintext().get_language_list()
+        _THE_SPELL_CHECKER is not None
+        and _THE_SPELL_CHECKER.language_list != maintext().get_language_list()
     ):
-        _the_spell_checker = None
-    if _the_spell_checker is None:
+        _THE_SPELL_CHECKER = None
+    if _THE_SPELL_CHECKER is None:
         try:
-            _the_spell_checker = SpellChecker()
+            _THE_SPELL_CHECKER = SpellChecker()
         except DictionaryNotFoundError as exc:
             logger.error(f"Dictionary not found for language: {exc.language}")
             return None
-    return _the_spell_checker
+    return _THE_SPELL_CHECKER
 
 
 def spell_check(

--- a/src/guiguts/tools/jeebies.py
+++ b/src/guiguts/tools/jeebies.py
@@ -352,7 +352,6 @@ class JeebiesChecker:
                     hebe_count == 0 or behe_count / hebe_count > DISCRIMINATOR_LEVEL
                 ):
                     count_of_suspects += 1
-                    info = f"({behe_count}/{hebe_count})"
 
                     # Add this 2-form and its info to the dialog
 
@@ -369,7 +368,6 @@ class JeebiesChecker:
                     line = file_lines_list[line_number - 1]
 
                     self.add_to_dialog(
-                        info,
                         line,
                         line_number,
                         hebe_position_on_line,
@@ -385,7 +383,6 @@ class JeebiesChecker:
                     # dictionary.
 
                     count_of_suspects += 1
-                    info = f"({behe_count}/{hebe_count})"
 
                     # Query this 2-form phrase in the report.
 
@@ -402,7 +399,6 @@ class JeebiesChecker:
                     line = file_lines_list[line_number - 1]
 
                     self.add_to_dialog(
-                        info,
                         line,
                         line_number,
                         hebe_position_on_line,
@@ -471,7 +467,7 @@ class JeebiesChecker:
     ) -> int:
         """Look for suspect "w1 be w2" or "w1 he w2" phrases in paragraphs."""
 
-        def make_dialog_line(info: str, checker_dialog: JeebiesCheckerDialog) -> None:
+        def make_dialog_line(checker_dialog: JeebiesCheckerDialog) -> None:
             """Helper function for abstraction of repeated code."""
 
             # We have the start position in the paragraph string of a suspect hebe.
@@ -486,9 +482,7 @@ class JeebiesChecker:
             )
             line = file_lines_list[line_number - 1]
 
-            self.add_to_dialog(
-                info, line, line_number, hebe_position_on_line, checker_dialog
-            )
+            self.add_to_dialog(line, line_number, hebe_position_on_line, checker_dialog)
 
         ####
         # Find and report 3-word hebe suspects in paragraph text
@@ -531,11 +525,10 @@ class JeebiesChecker:
             ):
                 # Query this 3-form phrase.
                 suspects_count += 1
-                info = f"({behe_count}/{hebe_count})"
 
                 # Query this 3-form phrase in the report.
 
-                make_dialog_line(info, checker_dialog)
+                make_dialog_line(checker_dialog)
 
             elif check_level == "normal" and hebe_count == 0 and behe_count == 0:
                 # Neither 'he' nor 'be' versions of our 3-form phrase are in the
@@ -557,21 +550,19 @@ class JeebiesChecker:
 
                 # Neither 2-form phrase in the dictionary.
                 suspects_count += 1
-                info = f"({behe_count}/{hebe_count})"
 
                 # Query this 3-form phrase in the report.
 
-                make_dialog_line(info, checker_dialog)
+                make_dialog_line(checker_dialog)
 
             elif check_level == "paranoid" and hebe_count == 0 and behe_count == 0:
                 # Neither 'he' nor 'be' versions of our 3-form phrase are in the
                 # dictionary. Query it in report.
                 suspects_count += 1
-                info = f"({behe_count}/{hebe_count})"
 
                 # Query this 3-form phrase in the report.
 
-                make_dialog_line(info, checker_dialog)
+                make_dialog_line(checker_dialog)
 
         return suspects_count
 
@@ -616,7 +607,6 @@ class JeebiesChecker:
 
     def add_to_dialog(
         self,
-        info: str,  # pylint: disable=unused-argument
         line: str,
         line_number: int,
         hebe_start: int,
@@ -625,7 +615,6 @@ class JeebiesChecker:
         """Helper function that abstracts repeated code.
 
         Args:
-            info: Ratio of 'he' or 'be freq / 'be' or 'he' freq expressed as a string.
             line: Text of file line.
             line_num: Its line number in the file.
             hebe_start: The position on line of string 'he' or 'be'.

--- a/src/guiguts/tools/levenshtein.py
+++ b/src/guiguts/tools/levenshtein.py
@@ -29,8 +29,6 @@ SPELL_CHECK_OK_BAD = 2
 
 LINES_IN_REPORT_LIMIT = 4
 
-_the_levenshtein_checker = None  # pylint: disable=invalid-name
-
 #########################################################
 # levenshtein.py
 # Python author: Quentin Campbell (DP:qgc) - 2024.

--- a/src/guiguts/utilities.py
+++ b/src/guiguts/utilities.py
@@ -18,7 +18,7 @@ TraversablePath = importlib.resources.abc.Traversable | Path
 
 # Flag so application code can detect if within a pytest run - only use if really needed
 # See: https://pytest.org/en/7.4.x/example/simple.html#detect-if-running-from-within-a-pytest-run
-called_from_test = False  # pylint: disable=invalid-name
+CALLED_FROM_TEST = False
 
 
 #
@@ -211,7 +211,7 @@ def sing_plur(count: int, singular: str, plural: str = "") -> str:
 # This is necessary since the bell requires various Tk features/widgets,
 # like root and the status bar. We don't want to have to import those
 # into every module that wants to sound the bell, e.g. Search.
-_bell_callback = None  # pylint: disable=invalid-name
+_BELL_CALLBACK = None
 
 
 def bell_set_callback(callback: Callable[[], None]) -> None:
@@ -219,14 +219,14 @@ def bell_set_callback(callback: Callable[[], None]) -> None:
 
     Args:
         callback: Bell-sounding function."""
-    global _bell_callback
-    _bell_callback = callback
+    global _BELL_CALLBACK
+    _BELL_CALLBACK = callback
 
 
 def sound_bell() -> None:
     """Call the registered bell callback in order to sound the bell."""
-    assert _bell_callback is not None
-    _bell_callback()
+    assert _BELL_CALLBACK is not None
+    _BELL_CALLBACK()
 
 
 def process_label(label: str) -> tuple[int, str]:

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -694,21 +694,21 @@ def mouse_bind(
 # with a function to set/query it.
 # Also store the default colors for a Text widget that are not
 # altered by the default themes.
-_single_style = None  # pylint: disable=invalid-name
-_theme_default_text_bg = ""  # pylint: disable=invalid-name
-_theme_default_text_fg = ""  # pylint: disable=invalid-name
-_theme_default_text_ibg = ""  # pylint: disable=invalid-name
+_SINGLE_STYLE = None
+_THEME_DEFAULT_TEXT_BG = ""
+_THEME_DEFAULT_TEXT_FG = ""
+_THEME_DEFAULT_TEXT_IBG = ""
 
 
 def themed_style(style: Optional[ttk.Style] = None) -> ttk.Style:
     """Store and return the single Style object"""
-    global _single_style
+    global _SINGLE_STYLE
     if style is not None:
-        assert _single_style is None
-        _single_style = style
+        assert _SINGLE_STYLE is None
+        _SINGLE_STYLE = style
         _theme_init_tk_widget_colors()
-    assert _single_style is not None
-    return _single_style
+    assert _SINGLE_STYLE is not None
+    return _SINGLE_STYLE
 
 
 def theme_name_internal_from_user(user_theme: str) -> str:
@@ -741,11 +741,11 @@ def _theme_init_tk_widget_colors() -> None:
 
     Needs to be called before theme is changed from default theme.
     """
-    global _theme_default_text_bg, _theme_default_text_fg, _theme_default_text_ibg
+    global _THEME_DEFAULT_TEXT_BG, _THEME_DEFAULT_TEXT_FG, _THEME_DEFAULT_TEXT_IBG
     temp_text = tk.Text()
-    _theme_default_text_bg = temp_text.cget("background")
-    _theme_default_text_fg = temp_text.cget("foreground")
-    _theme_default_text_ibg = temp_text.cget("insertbackground")
+    _THEME_DEFAULT_TEXT_BG = temp_text.cget("background")
+    _THEME_DEFAULT_TEXT_FG = temp_text.cget("foreground")
+    _THEME_DEFAULT_TEXT_IBG = temp_text.cget("insertbackground")
     temp_text.destroy()
 
 

--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -36,7 +36,7 @@ from guiguts.widgets import (
     Busy,
 )
 
-_the_word_lists = None  # pylint: disable=invalid-name
+_THE_WORD_LISTS = None
 
 RETURN_ARROW = "⏎"
 MARKUP_TYPES = "i|b|sc|f|g|u|cite|em|strong"
@@ -745,12 +745,12 @@ class WordFrequencyDialog(ToplevelDialog):
 
 def word_frequency() -> None:
     """Do word frequency analysis on file."""
-    global _the_word_lists
+    global _THE_WORD_LISTS
 
     if not tool_save():
         return
 
-    _the_word_lists = WFWordLists()
+    _THE_WORD_LISTS = WFWordLists()
 
     wf_dialog = WordFrequencyDialog.show_dialog()
     wf_populate(wf_dialog)
@@ -815,10 +815,10 @@ def wf_populate_all(wf_dialog: WordFrequencyDialog) -> None:
     Args:
         wf_dialog: The word frequency dialog.
     """
-    assert _the_word_lists is not None
+    assert _THE_WORD_LISTS is not None
     wf_dialog.reset()
 
-    all_words = _the_word_lists.get_all_words()
+    all_words = _THE_WORD_LISTS.get_all_words()
     total_cnt = 0
     for word, freq in all_words.items():
         wf_dialog.add_entry(word, freq)
@@ -835,11 +835,11 @@ def wf_populate_emdashes(wf_dialog: WordFrequencyDialog) -> None:
     Args:
         wf_dialog: The word frequency dialog.
     """
-    assert _the_word_lists is not None
+    assert _THE_WORD_LISTS is not None
     wf_dialog.reset()
 
-    all_words = _the_word_lists.get_all_words()
-    emdash_words = _the_word_lists.get_emdash_words()
+    all_words = _THE_WORD_LISTS.get_all_words()
+    emdash_words = _THE_WORD_LISTS.get_emdash_words()
     suspect_cnt = 0
     for emdash_word, freq in emdash_words.items():
         # Check for suspect, i.e. also seen with a single hyphen
@@ -865,11 +865,11 @@ def wf_populate_hyphens(wf_dialog: WordFrequencyDialog) -> None:
     Args:
         wf_dialog: The word frequency dialog.
     """
-    assert _the_word_lists is not None
+    assert _THE_WORD_LISTS is not None
     wf_dialog.reset()
 
-    all_words = _the_word_lists.get_all_words()
-    emdash_words = _the_word_lists.get_emdash_words()
+    all_words = _THE_WORD_LISTS.get_all_words()
+    emdash_words = _THE_WORD_LISTS.get_emdash_words()
 
     # See if word pair suspects exist, e.g. "flash light" for "flash-light"
     word_pairs: WFDict = WFDict()
@@ -951,10 +951,10 @@ def wf_populate_by_match(
         desc: Description for message, e.g. desc "ALLCAPS" -> message "27 ALLCAPS words"
         match_func: Function that returns Truthy result if word matches the required criteria
     """
-    assert _the_word_lists is not None
+    assert _THE_WORD_LISTS is not None
     wf_dialog.reset()
 
-    all_words = _the_word_lists.get_all_words()
+    all_words = _THE_WORD_LISTS.get_all_words()
     count = 0
     for word, freq in all_words.items():
         if match_func(word):
@@ -1094,10 +1094,10 @@ def wf_populate_accents(wf_dialog: WordFrequencyDialog) -> None:
     Args:
         wf_dialog: The word frequency dialog.
     """
-    assert _the_word_lists is not None
+    assert _THE_WORD_LISTS is not None
     wf_dialog.reset()
 
-    all_words = _the_word_lists.get_all_words()
+    all_words = _THE_WORD_LISTS.get_all_words()
     suspect_cnt = 0
     total_cnt = 0
     for word, freq in all_words.items():
@@ -1128,10 +1128,10 @@ def wf_populate_ligatures(wf_dialog: WordFrequencyDialog) -> None:
     Args:
         wf_dialog: The word frequency dialog.
     """
-    assert _the_word_lists is not None
+    assert _THE_WORD_LISTS is not None
     wf_dialog.reset()
 
-    all_words = _the_word_lists.get_all_words()
+    all_words = _THE_WORD_LISTS.get_all_words()
     suspect_cnt = 0
     total_cnt = 0
     suspects_only = preferences.get(PrefKey.WFDIALOG_SUSPECTS_ONLY)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,4 +10,4 @@ def pytest_configure(config: pytest.Config) -> None:  # pylint: disable=unused-a
 
     See: https://pytest.org/en/7.4.x/example/simple.html#detect-if-running-from-within-a-pytest-run
     """
-    guiguts.utilities.called_from_test = True
+    guiguts.utilities.CALLED_FROM_TEST = True


### PR DESCRIPTION
Several related to the case of variable names not following the established convention - case changed as needed. Some were "unused-argument" - underscore prepended to variable in line with convention, or argument removed.