### PR TITLE
Fix line num click/drag bug & improve shift-drag

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -225,13 +225,22 @@ class TextLineNumbers(tk.Canvas):
         self.bind("<<ThemeChanged>>", lambda event: self.theme_change())
         self.text_color = themed_style().lookup("TButton", "foreground")
 
-        # Drag along the line number gutter to select lines
-        self.drag_begin_index = IndexRowCol(1, 0)
-        self.bind("<Button-1>", self.drag_handler_start)
-        self.bind("<B1-Motion>", self.drag_handler)
-        # Shift-click in line number gutter to extend selection to start of clicked line
-        self.bind("<Shift-Button-1>", self.shift_click_handler)
-        self.bind("<Shift-B1-Motion>", self.shift_drag_handler)
+        # (Shift)-click in line number gutter to select whole lines
+        self.bind(
+            "<Button-1>", lambda evt: self.shift_click_drag_handler(evt, "<Button-1>")
+        )
+        self.bind(
+            "<B1-Motion>", lambda evt: self.shift_click_drag_handler(evt, "<B1-Motion>")
+        )
+        self.bind(
+            "<Shift-Button-1>",
+            lambda evt: self.shift_click_drag_handler(evt, "<Shift-Button-1>"),
+        )
+        self.bind(
+            "<Shift-B1-Motion>",
+            lambda evt: self.shift_click_drag_handler(evt, "<Shift-B1-Motion>"),
+        )
+        self.line_num_click_row = -1
 
     def redraw(self) -> None:
         """Redraw line numbers."""
@@ -281,63 +290,60 @@ class TextLineNumbers(tk.Canvas):
         self.configure(background=themed_style().lookup("TButton", "background"))
         self.text_color = themed_style().lookup("TButton", "foreground")
 
-    def drag_handler_start(self, evt: tk.Event) -> None:
-        """Handle initial click for drag-select operation."""
-        self.textwidget.focus_set()
-        self.drag_begin_index = self.cursor_index(evt)
-        self.drag_handler(evt)
-
-    def drag_handler(self, evt: tk.Event) -> None:
-        """Select text based on the current drag-select motion event."""
-        _range = self.drag_range(evt)
-        maintext().do_select(_range)
-        self.set_insert_index(evt)
-        maintext().linenumbers.redraw()
-        maintext().peer_linenumbers.redraw()
-
     def cursor_index(self, evt: tk.Event) -> IndexRowCol:
         """Return IndexRowCol for the row the cursor is positioned on."""
         return IndexRowCol(self.textwidget.index(f"@0,{evt.y}"))
 
-    def drag_range(self, evt: tk.Event) -> IndexRange:
-        """Return an IndexRange representing text to select for the
-        drag-selection operation in progress."""
-        sorted_rows = sorted((self.drag_begin_index.row, self.cursor_index(evt).row))
-        # Add 1 to end row to select entire row. Instead of using `lineend`
-        # which would leave a jagged end to our selection, select up to the
-        # 0 index on the following line to get the nice rectangle, selecting
-        # only full lines.
-        return IndexRange(
-            IndexRowCol(sorted_rows[0], 0), IndexRowCol(sorted_rows[1] + 1, 0)
-        )
+    def shift_click_drag_handler(self, evt: tk.Event, gen_evt: str) -> None:
+        """Convert (shift)-click/drag in line numbers to (shift)-click/drag
+        in maintext in order to select whole lines.
 
-    def set_insert_index(self, evt: tk.Event) -> None:
-        """Set the insert index so the line number is highlighted properly."""
-        cursor = self.cursor_index(evt)
-        _range = self.drag_range(evt)
-        if self.drag_begin_index.row < cursor.row:
-            # we were dragging downward
-            self.textwidget.mark_set(tk.INSERT, f"{cursor.index()} +1l linestart")
-            self.textwidget.mark_set(TK_ANCHOR_MARK, _range.start.index())
-        elif self.drag_begin_index.row > cursor.row:
-            # we were dragging upward
-            self.textwidget.mark_set(tk.INSERT, _range.start.index())
-            self.textwidget.mark_set(TK_ANCHOR_MARK, f"{_range.end.row}.0")
+        Args:
+            evt: Event that triggered call to this routine.
+            gen_evt: Type of event to generate in maintext.
+        """
+        self.textwidget.focus_set()
+        # Need to check later if click is above/below anchor point
+        try:
+            anchor_index = self.textwidget.index(TK_ANCHOR_MARK)
+        except tk.TclError:
+            anchor_index = ""  # User has never clicked in maintext
+        # Calculate lineheight
+        cursor_index = self.textwidget.index(f"@0,{evt.y}")
+        lineinfo = self.textwidget.dlineinfo(cursor_index)
+        assert lineinfo is not None  # click_index is always visible
+        line_height = lineinfo[3]
+        # A click is equivalent to selecting a whole line of text
+        if gen_evt == "<Button-1>" or not anchor_index:
+            self.textwidget.event_generate("<Button-1>", x=0, y=evt.y)
+            self.textwidget.event_generate(
+                "<Shift-Button-1>", x=0, y=evt.y + line_height
+            )
+            self.line_num_click_row = IndexRowCol(cursor_index).row
         else:
-            # clicked only a single line
-            self.textwidget.mark_set(tk.INSERT, _range.end.index())
-            self.textwidget.mark_set(TK_ANCHOR_MARK, _range.start.index())
-
-    def shift_click_handler(self, evt: tk.Event) -> None:
-        """Convert shift click in line numbers to shift-click in maintext."""
-        self.textwidget.focus_set()
-        self.textwidget.event_generate("<Shift-Button-1>", x=0, y=evt.y)
-        self.redraw()
-
-    def shift_drag_handler(self, evt: tk.Event) -> None:
-        """Convert shift click in line numbers to shift-click in maintext."""
-        self.textwidget.focus_set()
-        self.textwidget.event_generate("<Shift-B1-Motion>", x=0, y=evt.y)
+            # If there's a single line selection where the user clicked originally,
+            # need to move  the anchor point to the correct end of the selection
+            # so that the original line remains selected when dragging up or down
+            ranges = maintext().selected_ranges()
+            single_line_selection = (
+                ranges
+                and ranges[0].start.row == ranges[-1].end.row - 1
+                and ranges[0].start.row == self.line_num_click_row
+            )
+            # Extending downwards
+            if self.textwidget.compare(cursor_index, ">=", anchor_index):
+                if single_line_selection:
+                    self.textwidget.mark_set(TK_ANCHOR_MARK, ranges[0].start.index())
+                # Downwards needs extra line_height adding to y coordinate to select
+                # the line the cursor is over
+                self.textwidget.event_generate(gen_evt, x=0, y=evt.y + line_height)
+            # Extending upwards
+            else:
+                if single_line_selection:
+                    self.textwidget.mark_set(TK_ANCHOR_MARK, ranges[-1].end.index())
+                self.textwidget.event_generate(gen_evt, x=0, y=evt.y)
+        # Position insert cursor on clicked line so that clicked line number is highlighted
+        maintext().mark_set(tk.INSERT, cursor_index)
         self.redraw()
 
 


### PR DESCRIPTION
With split text window, using click & drag in the line numbers in one window, then immediately in the other got a bit confused about where the selection should be.

Also, to select down to a line using Shift-click you had to click in the line below the one you wanted to be the last selected line.

Also, the highlighted line number was often the line below the selection region which looked a bit odd.

Removed the old click & drag code and used the mechanism employed by shift-click & drag (generating events in the main text window). I'm not sure it's any better or simpler than the previous code, but at least all the line number clicking & dragging uses the same mechanism now, and the bug is fixed :)