### PR TITLE
Make cursor line highlighting optional

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -429,6 +429,10 @@ class Guiguts:
             PrefKey.HIGHLIGHT_QUOTBRAC, self.highlight_quotbrac_callback
         )
         preferences.set_default(PrefKey.HIGHLIGHT_HTML_TAGS, False)
+        preferences.set_default(PrefKey.HIGHLIGHT_CURSOR_LINE, True)
+        preferences.set_callback(
+            PrefKey.HIGHLIGHT_CURSOR_LINE, lambda _: maintext().highlight_cursor_line()
+        )
         preferences.set_default(PrefKey.COLUMN_NUMBERS, False)
         preferences.set_callback(
             PrefKey.COLUMN_NUMBERS, lambda value: maintext().show_column_numbers(value)

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -3692,8 +3692,11 @@ class MainText(tk.Text):
         """Add a highlight to entire line cursor is focused on."""
         self.tag_remove(HighlightTag.CURSOR_LINE, "1.0", tk.END)
 
-        # Don't re-highlight if there's currently a selection
-        if not self.selected_ranges():
+        # Don't re-highlight if cursor line highlighting disabled, or if currently a selection
+        if (
+            preferences.get(PrefKey.HIGHLIGHT_CURSOR_LINE)
+            and not self.selected_ranges()
+        ):
             row = self.get_insert_index().row
             self.tag_add(HighlightTag.CURSOR_LINE, f"{row}.0", f"{row + 1}.0")
 

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -312,6 +312,11 @@ class PreferencesDialog(ToplevelDialog):
             PrefKey.TEXT_CURSOR_WIDTH,
             "Width of insert cursor in main text window",
         )
+        ttk.Checkbutton(
+            advance_frame,
+            text="Highlight Cursor Line",
+            variable=PersistentBoolean(PrefKey.HIGHLIGHT_CURSOR_LINE),
+        ).grid(column=0, row=2, sticky="NEW", pady=5)
 
         notebook.bind(
             "<<NotebookTabChanged>>",

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -93,6 +93,7 @@ class PrefKey(StrEnum):
     SCANNOS_HISTORY = auto()
     HIGHLIGHT_QUOTBRAC = auto()
     HIGHLIGHT_HTML_TAGS = auto()
+    HIGHLIGHT_CURSOR_LINE = auto()
     COLUMN_NUMBERS = auto()
     HTML_ITALIC_MARKUP = auto()
     HTML_BOLD_MARKUP = auto()


### PR DESCRIPTION
"Highlight Cursor Line" checkbox added to "Advanced" tab of Preferences dialog.

The cursor line highlighting is distracting to some users.