### PR TITLE
Implement autosave

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -476,6 +476,9 @@ class Guiguts:
         preferences.set_default(PrefKey.EBOOKMAKER_EPUB3, True)
         preferences.set_default(PrefKey.EBOOKMAKER_KINDLE, False)
         preferences.set_default(PrefKey.EBOOKMAKER_KF8, False)
+        preferences.set_default(PrefKey.BACKUPS_ENABLED, True)
+        preferences.set_default(PrefKey.AUTOSAVE_ENABLED, True)
+        preferences.set_default(PrefKey.AUTOSAVE_INTERVAL, 5)
 
         # Check all preferences have a default
         for pref_key in PrefKey:

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -10,6 +10,7 @@ import unicodedata
 
 import regex as re
 
+from guiguts.file import the_file
 from guiguts.maintext import maintext
 from guiguts.mainwindow import ScrolledReadOnlyText
 from guiguts.preferences import (
@@ -304,7 +305,6 @@ class PreferencesDialog(ToplevelDialog):
             PrefKey.TEXT_LINE_SPACING,
             "Additional line spacing in text windows",
         )
-
         add_label_spinbox(
             advance_frame,
             1,
@@ -317,6 +317,33 @@ class PreferencesDialog(ToplevelDialog):
             text="Highlight Cursor Line",
             variable=PersistentBoolean(PrefKey.HIGHLIGHT_CURSOR_LINE),
         ).grid(column=0, row=2, sticky="NEW", pady=5)
+
+        backup_btn = ttk.Checkbutton(
+            advance_frame,
+            text="Keep Backup Before Saving",
+            variable=PersistentBoolean(PrefKey.BACKUPS_ENABLED),
+        )
+        backup_btn.grid(column=0, row=3, sticky="E", pady=(10, 0))
+        ToolTip(backup_btn, "Backup file will have '.bak' extension")
+        ttk.Checkbutton(
+            advance_frame,
+            text="Enable Auto Save Every",
+            variable=PersistentBoolean(PrefKey.AUTOSAVE_ENABLED),
+            command=the_file().reset_autosave,
+        ).grid(column=0, row=4, sticky="E")
+        spinbox = ttk.Spinbox(
+            advance_frame,
+            textvariable=PersistentInt(PrefKey.AUTOSAVE_INTERVAL),
+            from_=1,
+            to=60,
+            width=3,
+        )
+        spinbox.grid(column=1, row=4, sticky="EW", padx=5)
+        ToolTip(
+            spinbox,
+            "Autosave your file (with '.bk1', '.bk2' extensions) after this number of minutes",
+        )
+        ttk.Label(advance_frame, text="Minutes").grid(column=2, row=4, sticky="EW")
 
         notebook.bind(
             "<<NotebookTabChanged>>",

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -116,6 +116,9 @@ class PrefKey(StrEnum):
     EBOOKMAKER_EPUB3 = auto()
     EBOOKMAKER_KINDLE = auto()
     EBOOKMAKER_KF8 = auto()
+    BACKUPS_ENABLED = auto()
+    AUTOSAVE_ENABLED = auto()
+    AUTOSAVE_INTERVAL = auto()
 
 
 class Preferences:


### PR DESCRIPTION
1. Pref to Save backup file when user saves manually. Backup file has extension `.bak`
2. Pref to autosave file every N minutes. When autosaved, backup files with extensions `.bk1` and `.bk2` are created. `.bk2` is a copy of the old `.bk1`, and `.bk1` is a copy of the old file, just before the new version is saved.
3. Note that although the user can force a manual save even if they have made no edits, an autosave will not happen if no edits are made.
4. Also, no autosave is done when the currently loaded file has no name, i.e. has never been saved.
5. Default autosave time period is 5 minutes. User can choose between 1 and 60 minutes.

Fixes #839