### PR TITLE
Fix Footnotes Autoset Chap LZ bug

### DIFF
--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -379,9 +379,10 @@ class FootnoteChecker:
         return -1
 
     def enable_disable_buttons(self) -> None:
-        """Helper function to enable/disable buttons."""
-
-        # Some buttons are disabled if their operation could corrupt the file.
+        """Helper function to enable/disable buttons. Some buttons are
+        disabled if their operation could corrupt the file."""
+        if not self.checker_dialog.winfo_exists():
+            return
 
         # The following flag is set once and never unset.
         if self.fns_have_been_moved:
@@ -787,13 +788,13 @@ def autoset_chapter_lz() -> None:
             restart_point = maintext().rowcol(f"{start_index} +1l")
         search_range = IndexRange(restart_point, maintext().end())
 
-        # The file has changed so rebuild AN/FN records and refresh dialog.
-        _THE_FOOTNOTE_CHECKER.run_check()
-        # Order below is important. A flag is set in display_footnote_entries()
-        # that will determine which, if any, buttons are disabled when they are
-        # displayed.
-        display_footnote_entries()
-        _THE_FOOTNOTE_CHECKER.enable_disable_buttons()
+    # The file has changed so rebuild AN/FN records and refresh dialog.
+    _THE_FOOTNOTE_CHECKER.run_check()
+    # Order below is important. A flag is set in display_footnote_entries()
+    # that will determine which, if any, buttons are disabled when they are
+    # displayed.
+    display_footnote_entries()
+    _THE_FOOTNOTE_CHECKER.enable_disable_buttons()
 
 
 def move_footnotes_to_paragraphs() -> None:


### PR DESCRIPTION
Running Autoset Chap LZ in Footnote Fixup caused repeated refreshing of the dialog (probably forever) that could only be stopped by destroying the dialog, which then caused an exception.

Although fixing the first means the exception doesn't happen, it could probably be triggered by killing the dialog while it is mid-operation, so fixed exception too.

Testing notes:
Almost any file with footnotes should show the problem, I think. [This one](https://github.com/user-attachments/files/19447637/music.zip) certainly does.
