### PR TITLE
Fix several small bugs/annoyances

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -477,7 +477,7 @@ class Guiguts:
         preferences.set_default(PrefKey.EBOOKMAKER_KINDLE, False)
         preferences.set_default(PrefKey.EBOOKMAKER_KF8, False)
         preferences.set_default(PrefKey.BACKUPS_ENABLED, True)
-        preferences.set_default(PrefKey.AUTOSAVE_ENABLED, True)
+        preferences.set_default(PrefKey.AUTOSAVE_ENABLED, False)
         preferences.set_default(PrefKey.AUTOSAVE_INTERVAL, 5)
 
         # Check all preferences have a default

--- a/src/guiguts/html_tools.py
+++ b/src/guiguts/html_tools.py
@@ -562,7 +562,7 @@ def html_validator_check() -> None:
         """Minimal class to identify dialog type so that it can exist
         simultaneously with other checker dialogs."""
 
-        manual_page = "HTML_Menu#HTML_Link_Checker"
+        manual_page = "HTML_Menu#HTML_Validator"
 
         def __init__(self, **kwargs: Any) -> None:
             """Initialize HTML Validator dialog."""
@@ -690,7 +690,7 @@ class CSSValidatorDialog(CheckerDialog):
 
     Uses SOAP/XML interface to CSS validator."""
 
-    manual_page = "HTML_Menu#PPhtml"
+    manual_page = "HTML_Menu#CSS_Validator"
 
     def __init__(self, **kwargs: Any) -> None:
         """Initialize CSS Checker dialog."""

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -323,14 +323,14 @@ class PreferencesDialog(ToplevelDialog):
             text="Keep Backup Before Saving",
             variable=PersistentBoolean(PrefKey.BACKUPS_ENABLED),
         )
-        backup_btn.grid(column=0, row=3, sticky="E", pady=(10, 0))
+        backup_btn.grid(column=0, row=3, sticky="EW", pady=(10, 0))
         ToolTip(backup_btn, "Backup file will have '.bak' extension")
         ttk.Checkbutton(
             advance_frame,
             text="Enable Auto Save Every",
             variable=PersistentBoolean(PrefKey.AUTOSAVE_ENABLED),
             command=the_file().reset_autosave,
-        ).grid(column=0, row=4, sticky="E")
+        ).grid(column=0, row=4, sticky="EW")
         spinbox = ttk.Spinbox(
             advance_frame,
             textvariable=PersistentInt(PrefKey.AUTOSAVE_INTERVAL),

--- a/src/guiguts/spell.py
+++ b/src/guiguts/spell.py
@@ -512,5 +512,4 @@ def spell_check(
             f"{spelling.word} ({spelling.frequency})" + bad_str,
             IndexRange(spelling.rowcol, end_rowcol),
         )
-    checker_dialog.add_footer("", "End of Spelling Check" + sel_only)
     checker_dialog.display_entries()

--- a/src/guiguts/tools/pptxt.py
+++ b/src/guiguts/tools/pptxt.py
@@ -2640,3 +2640,5 @@ def pptxt(project_dict: ProjectDict) -> None:
 
     checker_dialog.add_footer(f"{'-' * 80}")
     checker_dialog.display_entries()
+    # Select first entry (which might not be one with a line number)
+    checker_dialog.select_entry_by_index(0)


### PR DESCRIPTION
Fix erroneous "suspect" reports by PPtxt

PPtxt does not have suspect and non-suspect messages as some other tools do. The `(x5)` prefix showing that an asterisk occurred 5 times on the same line was
mistakenly being identified as a suspect flag.

Fixes #836


PPhtml: Detect ID attributes across line breaks

If `id="my_id"` is split across a line break, it wasn't detected by PPhtml, so might be reported as
`Target my_id not found.`

Use HTML parser instead of single line checks.
Note this error exists in other instances of pphtml.

Fixes #854


Output "Check complete" message in checkers

So that user knows check has run

Link HTML & CSS validators to man page

Manual page link was broken for these two tools.

Minor wording change to PPhtml message

Count of class="chapter" attributes now has quotes round "chapter"

Fix minor pphtml output bug

If CSS contained `.class1.class2`, the list of defined classes began with a superfluous comma, due to a
faulty regex.

Remove spelling when Ctrl-clicked

Cmd/Ctrl-click on a spelling adds it to the project dictionary, but didn't remove it from the spelling error list, unlike the "Add to Proj dict" button.

Fixes #855