### PR TITLE
Ebookmaker Mac/Linux support & other changes/improvements

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -476,6 +476,7 @@ class Guiguts:
         preferences.set_default(PrefKey.EBOOKMAKER_EPUB3, True)
         preferences.set_default(PrefKey.EBOOKMAKER_KINDLE, False)
         preferences.set_default(PrefKey.EBOOKMAKER_KF8, False)
+        preferences.set_default(PrefKey.EBOOKMAKER_VERBOSE_OUTPUT, False)
         preferences.set_default(PrefKey.BACKUPS_ENABLED, True)
         preferences.set_default(PrefKey.AUTOSAVE_ENABLED, True)
         preferences.set_default(PrefKey.AUTOSAVE_INTERVAL, 5)

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -116,6 +116,7 @@ class PrefKey(StrEnum):
     EBOOKMAKER_EPUB3 = auto()
     EBOOKMAKER_KINDLE = auto()
     EBOOKMAKER_KF8 = auto()
+    EBOOKMAKER_VERBOSE_OUTPUT = auto()
     BACKUPS_ENABLED = auto()
     AUTOSAVE_ENABLED = auto()
     AUTOSAVE_INTERVAL = auto()


### PR DESCRIPTION
This PR has been tested against Mac and Linux (Ubuntu 24).

**Windows testing is needed!**

### Changes
- Adds checkbox to Ebookmaker dialog to control debug output. By default `-v` is used (which will give INFO), with debug box checked, you also get DEBUG (`-v -v`).
- The path to ebookmaker is now expected to be a **directory** rather than a file. It should be the directory where the user ran `pipenv install` to install ebookmaker. **This is not backward-compatible** so users may need to change its value for ebookmaker to work again **even if it was working previously**.
    - Since Ebookmaker's instructions for install are to use pipenv, my viewpoint is to follow that method and assume that's how the user installed it.
- Minor correction of a label, "Epub formats:" is now "Ebook formats:"
- Set `PIPENV_IGNORE_VIRTUALENVS` in the environment to avoid complications with pipenv if running from within an existing virtual environment. This was often the case during development, but it could easily be the case that users run Guiguts from their own virtual environment.
- Improve detection of the Calibre `ebook-convert` program by using `shutil.which()`
- Ebookmaker appears to never output anything to stdout, only to stderr. I simplified the output handler to combine both streams into one and just output that rather than separate them. Previously, everything was grouped under "Errors" even if it was just debugging or general information.

### TESTING NOTES
To install ebookmaker, you can use [their instructions](https://github.com/gutenbergtools/ebookmaker/blob/master/README.md). Here's the TL;DR version:

```
# make sure you have pipenv; if not, then install it.
which pipenv

# put this in whatever directory name you want
mkdir ebookmaker
cd ebookmaker
pipenv install ebookmaker

# now test it out
pipenv run ebookmaker --version

# if you get an error about pkg_resources, then install setuptools too.
pipenv install setuptools

# test again if needed
pipenv run ebookmaker --version
```

If you want to test MOBI generation, also install [Calibre](https://calibre-ebook.com) and make sure the `ebook-convert` program is on your path.

```
# mac/linux
which ebook-convert

# windows
where ebook-convert
```

- Open an HTML file in Guiguts
- In the HTML menu, run the Ebookmaker item
- Click "Browse" and navigate to the directory where you installed Ebookmaker with pipenv, then select it
- Click "Re-Run" and wait
- You should see a number of INFO: lines and now have at least one ebook file. It will be in the same folder where your HTML file is.
- Check "Show debug output" and click "Re-Run".
- The same books should be built, but now you'll have a ton of DEBUG: lines in the output.
- If you installed Calibre, you can check the kf8 or mobi boxes and click "Re-run". Then you should find .mobi file(s) in your project directory after the run finishes.

