### PR TITLE
Fix PPhtml class bug

### DIFF
--- a/src/guiguts/tools/pphtml.py
+++ b/src/guiguts/tools/pphtml.py
@@ -896,7 +896,7 @@ class PPhtmlChecker:
             split_content[lnum] = re.sub(r">", "", split_content[lnum])
             # Remove element types: "hr.pb" -> ".pb"
             split_content[lnum] = re.sub(
-                r"(?<![\.\w])\w+(\.\w+)", r"\1", split_content[lnum]
+                r"(?<![-\.\w])\w+(\.\w+)", r"\1", split_content[lnum]
             )
 
         for line in split_content:


### PR DESCRIPTION
When classname had hyphen in, it could get split into two classes.

Fixes #864 