### PR TITLE
Improve ebookmaker dialog

### DIFF
--- a/src/guiguts/tools/pptxt.py
+++ b/src/guiguts/tools/pptxt.py
@@ -1373,12 +1373,12 @@ def report_multiple_occurrences_on_line(
     error_start = matches[0].start()
     error_end = matches[-1].end()
     # Add record to the dialog with prefix if repeated matches.
+    repeat_str = f"(x{len(matches)}) " if len(matches) > 1 else ""
     checker_dialog.add_entry(
-        line,
+        f"{repeat_str}{line}",
         IndexRange(f"{line_number}.{error_start}", f"{line_number}.{error_end}"),
-        error_start,
-        error_end,
-        error_prefix=f"(x{len(matches)}) " if len(matches) > 1 else "",
+        error_start + len(repeat_str),
+        error_end + len(repeat_str),
     )
 
 


### PR DESCRIPTION
1. Determine default severity better, and allow calling routine to specify severity when entry is added.
2. Warnings, errors or critical errors from ebookmaker will now have the severity in red at the start of the message.
3. If user chooses to sort by Alpha/Type, sort by severity, preserving message order within severities.
4. Add Suspects Only button.
5. Warn user if they need to select the ebookmaker dir, i.e. if the dialog field is empty.