### PR TITLE
Add HTML Auto-Table

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -22,6 +22,7 @@ from guiguts.html_tools import (
     HTMLLinkChecker,
     CSSValidator,
     EbookmakerChecker,
+    HTMLAutoTableDialog,
 )
 from guiguts.illo_sn_fixup import illosn_check
 
@@ -517,6 +518,10 @@ class Guiguts:
         preferences.set_default(PrefKey.ASCII_TABLE_FILL_CHAR, "@")
         preferences.set_default(PrefKey.ASCII_TABLE_RIGHT_COL, 70)
         preferences.set_default(PrefKey.COMMAND_PALETTE_HISTORY, [])
+        preferences.set_default(PrefKey.AUTOTABLE_MULTILINE, False)
+        preferences.set_default(PrefKey.AUTOTABLE_DEFAULT_ALIGNMENT, "left")
+        preferences.set_default(PrefKey.AUTOTABLE_COLUMN_ALIGNMENT, "")
+        preferences.set_default(PrefKey.AUTOTABLE_COLUMN_ALIGNMENT_HISTORY, [])
 
         # Check all preferences have a default
         for pref_key in PrefKey:
@@ -902,6 +907,7 @@ class Guiguts:
         html_menu = Menu(menubar(), "HT~ML")
         html_menu.add_button("HTML ~Generator...", HTMLGeneratorDialog.show_dialog)
         html_menu.add_button("Auto-~Illustrations...", HTMLImageDialog.show_dialog)
+        html_menu.add_button("Auto-~Table...", HTMLAutoTableDialog.show_dialog)
         html_menu.add_separator()
         html_menu.add_button("~Unmatched HTML Tags", unmatched_html_markup)
         html_menu.add_button("HTML ~Link Checker", lambda: HTMLLinkChecker().run())

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -130,6 +130,10 @@ class PrefKey(StrEnum):
     ASCII_TABLE_FILL_CHAR = auto()
     ASCII_TABLE_RIGHT_COL = auto()
     COMMAND_PALETTE_HISTORY = auto()
+    AUTOTABLE_MULTILINE = auto()
+    AUTOTABLE_DEFAULT_ALIGNMENT = auto()
+    AUTOTABLE_COLUMN_ALIGNMENT = auto()
+    AUTOTABLE_COLUMN_ALIGNMENT_HISTORY = auto()
 
 
 class Preferences:


### PR DESCRIPTION
In the HTML menu, pops a dialog which behaves
much like the Auto-Table controls in the GG1 HTML
Markup dialog.

1. Select a table that is formatted for text (with or without vertical lines)
2. Check whether table is one line per row, or it is "multiline" with blank lines separating rows.
3. Set default column alignments.
4. Specify column alignments not all the same, e.g. "LCR" will  make the first 3 columns left, center, right aligned, and any more cols will use the default.
5. Click the Convert button.

Fixes #449 
