### PR TITLE
Backup Prefs file

### DIFF
--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -5,6 +5,7 @@ from enum import StrEnum, auto
 import json
 import logging
 import os
+import time
 import tkinter as tk
 from typing import Any, Callable
 
@@ -296,6 +297,26 @@ class Preferences:
         except OSError:
             logger.error(f"Unable to create {self.prefsdir}")
             return
+
+        # Backup to "day" and "week" files if they are not too new.
+        root, ext = os.path.splitext(self.prefsfile)
+        day_backup = root + "_day" + ext
+        week_backup = root + "_week" + ext
+
+        def is_older_than(file: str, seconds: int) -> bool:
+            """Return True if file is more than `seconds` old"""
+            return (
+                not os.path.exists(file)
+                or (time.time() - os.path.getmtime(file)) > seconds
+            )
+
+        if is_older_than(week_backup, 7 * 86400):  # 7 days
+            if os.path.exists(day_backup):
+                os.replace(day_backup, week_backup)
+
+        if is_older_than(day_backup, 86400):  # 1 day
+            if os.path.exists(self.prefsfile):
+                os.replace(self.prefsfile, day_backup)
 
         try:
             with open(self.prefsfile, "w", encoding="utf-8") as fp:


### PR DESCRIPTION
Keep a "day" backup and a "week" backup. These
only get overwritten if they age past their time
period.

Fixes #882

Testing notes:
You may find variants on the following command useful if you do not want to wait for a week to test this:
`touch -m -t 04082015 GGprefs_day.json`
Also, one way to force a save of GGprefs is to load a different file, e.g. from the Recent files menu. Then you can edit the GGprefs file and the two backups and inspect which is the top file in the "recent_files" list. That way you can keep track of when one file is renamed to another.



