### PR TITLE
Add `$u` to Custom Menu variables

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -1126,22 +1126,15 @@ class Guiguts:
         def ordinal_str() -> str:
             """Format ordinal of single selected char, or char at current insert
             index for statusbar."""
-            # Get character - display nothing if more than one char selected
-            sel_ranges = maintext().selected_ranges()
-            if len(sel_ranges) == 0:
-                char = maintext().get(maintext().get_insert_index().index())
-            elif len(sel_ranges) == 1:
-                char = maintext().selected_text()
-                if len(char) != 1:
-                    return ""
-            else:
-                return ""
+            char = maintext().current_character()
+            if not char:
+                return "    "
             # unicodedata.name fails to return name for "control" characters
             # but the only one we care about is line feed
             if preferences.get(PrefKey.ORDINAL_NAMES):
                 try:
                     name = f": {unicodedata.name(char)}"
-                except ValueError:
+                except (ValueError, TypeError):
                     name = ": LINE FEED" if char == "\n" else ""
             else:
                 name = ""

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1790,6 +1790,18 @@ class MainText(tk.Text):
                 self.focus_widget().tag_add("sel", start_mark, mark)
             next_mark = self.mark_next(mark)
 
+    def current_character(self) -> str:
+        """Return "current" character, i.e. the selected char if just one
+        is selected; the character after the insert cursor if none is
+        selected; empty string otherwise."""
+        sel_ranges = self.selected_ranges()
+        if len(sel_ranges) == 0:
+            return self.get(self.get_insert_index().index())
+        if len(sel_ranges) == 1:
+            char = self.selected_text()
+            return char if len(char) == 1 else ""
+        return ""
+
     def column_delete(self) -> None:
         """Delete the selected column text."""
         if not (ranges := self.selected_ranges()):

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -336,6 +336,7 @@ $f: full pathname of the current File
 $p: Png name of current image, e.g. 007 for 007.png
 $s: Sequence number of current page, e.g. 7 for 7th png, regardless of numbering
 $t: selected Text (only the first line if column selection)
+$u: Unicode codepoint of current character from status bar, e.g. "0041" for capital A.
 
 To assist in opening a hi-res scan for the current page, $s can also be given an offset, \
 e.g. $(s+5) would give 12 for the 5th png.
@@ -364,6 +365,7 @@ e.g. $(s+5) would give 12 for the 5th png.
             $p: png name of current image
             $s: sequence number of current page from start of file
             $t: selected text (only first part if column selection)
+            $u: unicode codepoint of current char
 
             Args:
                 token: The token to make substitutions in.
@@ -388,6 +390,9 @@ e.g. $(s+5) would give 12 for the 5th png.
             token = token.replace("$s", str(sequence_number()))
             # Selected text
             token = token.replace("$t", re.sub(r"\s+", " ", maintext().selected_text()))
+            # Unicode codepoint of current char (single selected char, or char following cursor)
+            cur = maintext().current_character()
+            token = token.replace("$u", f"{ord(cur):04x}" if cur else "")
             return token
 
         def sequence_number() -> int:


### PR DESCRIPTION
`$u` is replaced with the 4 digit hex Unicode codepoint value of the current character shown in the status bar, or the empty string if none.

The following will look it up at unicodeplus.com and fileformat.info:
`https://www.unicodeplus.com/U+$u`
`https://www.fileformat.info/info/unicode/char/$u/index.htm`