### PR TITLE
Add buttons to Proofer Comment Checker

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -62,7 +62,7 @@ from guiguts.misc_tools import (
     FractionConvertType,
     fraction_convert,
     unicode_normalize,
-    proofer_comment_check,
+    ProoferCommentChecker,
     asterisk_check,
     TextMarkupConvertorDialog,
     stealth_scannos,
@@ -710,7 +710,7 @@ class Guiguts:
         search_menu.add_separator()
         search_menu.add_button(
             "Find Proofer ~Comments",
-            proofer_comment_check,
+            lambda: ProoferCommentChecker().run(),
         )
         search_menu.add_button(
             "Find ~Asterisks w/o Slash",


### PR DESCRIPTION
Buttons delete the proofer comment highlighted by
the selected message, or all matching comments
and optionally hiding the message(s).

Also fixed minor errors in tooltips.

Fixes #866