### PR TITLE
Fix image viewer crash

### DIFF
--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -946,8 +946,9 @@ class MainImage(tk.Frame):
             return
         self.canvas["background"] = themed_style().lookup("TButton", "background")
         image = self.image
-        scaled_width = int(self.image_scale * image.width)
-        scaled_height = int(self.image_scale * image.height)
+        self.image_scale = max(self.image_scale, 50 / image.width, 50 / image.height)
+        scaled_width = int(self.image_scale * image.width + 1)
+        scaled_height = int(self.image_scale * image.height + 1)
         if preferences.get(PrefKey.IMAGE_INVERT):
             image = ImageChops.invert(self.image)
         if self.imagetk:

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -947,6 +947,7 @@ class MainImage(tk.Frame):
         self.canvas["background"] = themed_style().lookup("TButton", "background")
         image = self.image
         self.image_scale = max(self.image_scale, 50 / image.width, 50 / image.height)
+        preferences.set(PrefKey.IMAGE_SCALE_FACTOR, self.image_scale)
         scaled_width = int(self.image_scale * image.width + 1)
         scaled_height = int(self.image_scale * image.height + 1)
         if preferences.get(PrefKey.IMAGE_INVERT):


### PR DESCRIPTION
If very small viewer scale was saved into Prefs, it could attempt to resize a subsequent image to smaller than 1 pixel, which was treated as zero.

Fixed by rounding up, and also ensuring image will be shown at least 50 pixels in width/height.

Fixes #899


Testing notes: Manually edit GGprefs.json & at about line 78 change `image_scale_factor` to something like 0.000001. Also ensure that fit to height/width are turned off, or they will override that scale. That should cause the crash in `master` but not this branch.

