### PR TITLE
Allow user to select leading vertical table line

### DIFF
--- a/src/guiguts/ascii_tables.py
+++ b/src/guiguts/ascii_tables.py
@@ -950,9 +950,7 @@ class ASCIITableDialog(ToplevelDialog):
             ) or maintext().compare(insert_rowcol.index(), ">=", self.end_mark_name):
                 self.selected_column = 0
             else:
-                self.selected_column = self.get_selected_column_from_rowcol(
-                    insert_rowcol
-                ) + (0 if idir < 0 else 1)
+                self.selected_column = self.get_selected_column_from_rowcol(insert_rowcol)- (1 if idir < 0 else 0)
         # Ensure selected column is between 0 & number of columns
         self.selected_column %= self.get_table_grid().num_columns()
         self.refresh_table_display()
@@ -1184,8 +1182,7 @@ class ASCIITableDialog(ToplevelDialog):
         if "|" not in line:
             return -1
         # Ensure result is between 0 & number of cols
-        # Ignore any leading vertical bar
-        return line[1:].count("|", 0, rowcol.col) % self.get_table_grid().num_columns()
+        return line.count("|", 0, rowcol.col) % self.get_table_grid().num_columns()
 
     def table_is_marked(self) -> bool:
         """Returns 'False' if no table has been selected and marked."""

--- a/src/guiguts/ascii_tables.py
+++ b/src/guiguts/ascii_tables.py
@@ -950,7 +950,9 @@ class ASCIITableDialog(ToplevelDialog):
             ) or maintext().compare(insert_rowcol.index(), ">=", self.end_mark_name):
                 self.selected_column = 0
             else:
-                self.selected_column = self.get_selected_column_from_rowcol(insert_rowcol)- (1 if idir < 0 else 0)
+                self.selected_column = self.get_selected_column_from_rowcol(
+                    insert_rowcol
+                ) - (1 if idir < 0 else 0)
         # Ensure selected column is between 0 & number of columns
         self.selected_column %= self.get_table_grid().num_columns()
         self.refresh_table_display()

--- a/src/guiguts/ascii_tables.py
+++ b/src/guiguts/ascii_tables.py
@@ -51,7 +51,6 @@ class ASCIITable:
     def __init__(self) -> None:
         """Initialize ASCII table structure."""
         self.spaced = False
-        self.leading_vertical_line = False
         self.rows: list[ASCIITableRow] = []
 
     def num_columns(self) -> int:
@@ -953,7 +952,7 @@ class ASCIITableDialog(ToplevelDialog):
             else:
                 self.selected_column = self.get_selected_column_from_rowcol(
                     insert_rowcol
-                ) - (1 if idir < 0 else 0)
+                ) + (0 if idir < 0 else 1)
         # Ensure selected column is between 0 & number of columns
         self.selected_column %= self.get_table_grid().num_columns()
         self.refresh_table_display()
@@ -1011,9 +1010,7 @@ class ASCIITableDialog(ToplevelDialog):
             if text_lines[-1] == "":  # Trailing empty line.
                 del text_lines[-1]
             for frag_num, text_line in enumerate(text_lines):
-                if len(text_line) > 0 and text_line[0] == "|":
-                    table.leading_vertical_line = True
-                text_line = re.sub(r"^\||\|$", "", text_line.rstrip())
+                text_line = re.sub(r"|\|$", "", text_line.rstrip())
                 # For each cell line in that text line
                 for col, cell_line in enumerate(re.split(split_regex, text_line)):
                     table.add_text(row, col, frag_num, cell_line)
@@ -1029,7 +1026,6 @@ class ASCIITableDialog(ToplevelDialog):
         """
         text_rows: list[str] = []
         col_widths = table.get_max_column_widths()
-        leading_vertical_line = "|" if table.leading_vertical_line else ""
         for row_num, row in enumerate(table.rows):
             # If necessary, space table with space-replaced previous line
             if table.spaced and row_num > 0:
@@ -1043,7 +1039,7 @@ class ASCIITableDialog(ToplevelDialog):
                         line_parts.append(cell.fragments[line_num])
                     else:
                         line_parts.append(" " * col_widths[col_num])
-                text_rows.append(leading_vertical_line + "|".join(line_parts))
+                text_rows.append("|".join(line_parts))
         text_table = "|\n".join(text_rows) + "|\n"
         maintext().replace(self.start_mark_name, self.end_mark_name, text_table)
 
@@ -1127,14 +1123,30 @@ class ASCIITableDialog(ToplevelDialog):
             break_long_words=False,
         )
         text_rows: list[str] = []
+        leading_vertical_line = True
+        for row in table.rows:
+            for frag in row.cells[0].fragments:
+                if len(frag.strip()) > 0:
+                    leading_vertical_line = False
+                    break
+            else:
+                # No non-empty frag on this row - check next row
+                continue
+            # Non-empty frag found, break outer loop
+            break
         for row in table.rows:
             col_num = 0
-            for col_num, cell in enumerate(row.cells):
+            for idx, cell in enumerate(row.cells):
+                if leading_vertical_line and idx == 0:
+                    continue
                 wrapper.initial_indent = "    |" * col_num + " " if col_num > 0 else ""
                 wrapper.subsequent_indent = wrapper.initial_indent
                 cell_text = re.sub("  +", " ", " ".join(cell.fragments)).strip()
                 text_rows.extend(wrapper.wrap(cell_text))
-            text_rows.append("    |" * col_num)
+                col_num += 1
+            text_rows.append(
+                "    |" * (col_num - 1 if leading_vertical_line else col_num)
+            )
         text_table = "\n".join(text_rows) + "\n"
         maintext().replace(self.start_mark_name, self.end_mark_name, text_table)
 
@@ -1199,7 +1211,7 @@ class ASCIITableDialog(ToplevelDialog):
         if end.col == 0:
             end.row -= 1
         for table_row in range(start.row, end.row + 1):
-            pipe_index = f"{table_row}.0"
+            pipe_index = f"{table_row}.0 -1l lineend"
             for _ in range(self.selected_column + 1):
                 pipe_index = maintext().search(
                     "|", f"{pipe_index}+1c", f"{table_row}.end"


### PR DESCRIPTION
If table has a leading vertical line, i.e. left hand border, it is now possible to select it and move it to the right, then back to the left.

Fixes #918