### PR TITLE
Make proofer comment delete undo properly.

### DIFF
--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -1445,6 +1445,7 @@ class ProoferCommentChecker:
         end_mark = ProoferCommentCheckerDialog.mark_from_rowcol(
             checker_entry.text_range.end
         )
+        maintext().undo_block_begin()
         maintext().delete(start_mark, end_mark)
 
 


### PR DESCRIPTION
All operations need a call to undo_block_begin, even single operations, in order to separate them from
manual changes made by the user beforehand.

Fixes #920 

Testing notes: See linked issue. The following is a minimal file that will show the problem as described in the issue:

```

[Illustration: Fig[** .] 42.]

[Illustration: Fig[** .] 52.]

```

As noted in the issue, the key to breaking it is to manually correct the Fig 42 line by deleting the close bracket, then deleting the space, asterisks and open bracket, not by selecting the whole note and typing the correction.

