### PR TITLE
Bookloupe should split words at emdash

### DIFF
--- a/src/guiguts/tools/bookloupe.py
+++ b/src/guiguts/tools/bookloupe.py
@@ -634,8 +634,9 @@ class BookloupeChecker:
             step: Line number being checked.
             line: Text of line being checked.
         """
-        # Consider hyphenated words (but not numbers, e.g. 1-3/4) as two separate words
-        line = re.sub(r"(?<!\d)-(?!\d)", " ", line)
+        # Consider hyphenated (or emdashed) words as two separate words
+        # but exclude DP-style fractions, e.g. 1-3/4)
+        line = re.sub(r"(?<!\d)[-—](?!\d)", " ", line)
         # Split at spaces, ignoring leading/trailing non-word characters on words
         for match in re.finditer(
             r"(?<![^ ])[^\p{Letter}\p{Number}'’{}]*(.+?)[^\p{Letter}\p{Number}'’{}]*(?![^ ])",


### PR DESCRIPTION
"Query word" and "Digit in" errors were being reported for things that were two words joined by an emdash. Split on emdash (in addition to existing splits on hyphen and space) in these circumstances.

Fixes #898 
Fixed #913 