### PR TITLE
Improve Stealth scannos

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -439,6 +439,7 @@ class Guiguts:
                 str(DEFAULT_SCANNOS_DIR.joinpath(DEFAULT_MISSPELLED_SCANNOS)),
             ],
         )
+        preferences.set_default(PrefKey.SCANNOS_AUTO_ADVANCE, True)
         preferences.set_default(PrefKey.HIGHLIGHT_QUOTBRAC, False)
         preferences.set_callback(
             PrefKey.HIGHLIGHT_QUOTBRAC, self.highlight_quotbrac_callback

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -834,13 +834,16 @@ class CheckerDialog(ToplevelDialog):
                 self.mark_from_rowcol(text_range.end), text_range.end, gravity=tk.RIGHT
             )
 
-    def display_entries(self, auto_select_line: bool = True) -> None:
+    def display_entries(
+        self, auto_select_line: bool = True, complete_msg: bool = True
+    ) -> None:
         """Display all the stored entries in the dialog according to
         the sort setting.
 
         Args:
             auto_select_line: Default True. Set to False if calling routine takes
             responsibility for selecting a line in the dialog.
+            complete_msg: Set to False if "Check complete" message not wanted.
         """
 
         Busy.busy()
@@ -907,7 +910,8 @@ class CheckerDialog(ToplevelDialog):
                     ERROR_PREFIX_TAG_NAME, start_rowcol.index(), end_rowcol.index()
                 )
         # Output "Check complete", so user knows it's done
-        self.text.insert(tk.END, "\nCheck complete\n")
+        if complete_msg:
+            self.text.insert(tk.END, "\nCheck complete\n")
 
         # The default automatic highlighting of previously selected line, or if none
         # the first suitable line, is undesirable when an application immediately

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -26,7 +26,7 @@ from guiguts.preferences import (
     preferences,
     PersistentBoolean,
 )
-from guiguts.search import get_regex_replacement
+from guiguts.search import get_regex_replacement, message_from_regex_exception
 from guiguts.utilities import (
     IndexRowCol,
     IndexRange,
@@ -1650,29 +1650,38 @@ class ScannoCheckerDialog(CheckerDialog):
                 [
                     "Left click: Select & find occurrence of scanno",
                     "Right click: Hide occurrence of scanno in list",
-                    f"With {cmd_ctrl_string()} key: Also fix this occurrence",
-                    "With Shift key: Also hide/fix matching occurrences",
+                    f"{cmd_ctrl_string()} left click: Fix this occurrence of scanno",
+                    f"{cmd_ctrl_string()} right click: Fix this occurrence and remove from list",
                 ]
             ),
             **kwargs,
         )
 
-        frame = ttk.Frame(self.custom_frame)
+        frame = ttk.Frame(self.custom_frame, padding=2)
         frame.grid(column=0, row=1, sticky="NSEW")
         self.custom_frame.columnconfigure(0, weight=1)
         frame.columnconfigure(1, weight=1)
+        for row in range(4):
+            frame.rowconfigure(row, uniform="equal height")
 
+        self.auto_checkbtn = ttk.Checkbutton(
+            frame,
+            text="Auto Adv.",
+            variable=PersistentBoolean(PrefKey.SCANNOS_AUTO_ADVANCE),
+            takefocus=False,
+        )
+        self.auto_checkbtn.grid(column=0, row=0, sticky="NSEW", pady=2)
         self.file_combo = PathnameCombobox(
             frame,
             PrefKey.SCANNOS_HISTORY,
             PrefKey.SCANNOS_FILENAME,
         )
-        self.file_combo.grid(column=1, row=0, sticky="NSEW", pady=5)
+        self.file_combo.grid(column=1, row=0, sticky="NSEW", pady=2)
         self.file_combo["state"] = "readonly"
         self.file_combo.bind("<<ComboboxSelected>>", lambda _e: self.select_file())
         ttk.Button(
             frame, text="Load File", command=self.choose_file, takefocus=False
-        ).grid(column=2, row=0, sticky="NSEW", padx=(5, 0), pady=5)
+        ).grid(column=2, row=0, sticky="NSEW", padx=(5, 0), pady=2)
 
         self.prev_btn = ttk.Button(
             frame,
@@ -1680,51 +1689,63 @@ class ScannoCheckerDialog(CheckerDialog):
             command=lambda: self.prev_next_scanno(prev=True),
             takefocus=False,
         )
-        self.prev_btn.grid(column=0, row=1, sticky="NSEW", padx=(0, 5), pady=5)
+        self.prev_btn.grid(column=0, row=1, sticky="NSEW", padx=(0, 5), pady=2)
         self.scanno_textvariable = tk.StringVar(self, "")
         search = ttk.Entry(
             frame,
             textvariable=self.scanno_textvariable,
-            state="readonly",
             font=maintext().font,
         )
-        search.grid(column=1, row=1, sticky="NSEW", pady=5)
+        search.grid(column=1, row=1, sticky="NSEW", pady=2)
+        search.bind("<Return>", lambda _: self.list_scannos(update_fields=False))
         self.next_btn = ttk.Button(
             frame,
             text="Next Scanno",
             command=lambda: self.prev_next_scanno(prev=False),
             takefocus=False,
         )
-        self.next_btn.grid(column=2, row=1, sticky="NSEW", padx=(5, 0), pady=5)
+        self.next_btn.grid(column=2, row=1, sticky="NSEW", padx=(5, 0), pady=2)
 
+        ttk.Button(
+            frame,
+            text="Swap Terms",
+            command=self.swap_terms,
+            takefocus=False,
+        ).grid(column=0, row=2, sticky="NSEW", padx=(0, 5), pady=2)
         self.replacement_textvariable = tk.StringVar(self, "")
         replace = ttk.Entry(
             frame,
             textvariable=self.replacement_textvariable,
-            state="readonly",
             font=maintext().font,
         )
-        replace.grid(column=1, row=2, sticky="NSEW")
+        replace.grid(column=1, row=2, sticky="NSEW", pady=2)
+        replace.bind("<Return>", lambda _: self.list_scannos(update_fields=False))
         ttk.Button(
-            frame, text="Replace", command=self.replace_scanno, takefocus=False
-        ).grid(column=2, row=2, sticky="NSEW", padx=(5, 0))
+            frame,
+            text="Replace",
+            command=lambda: self.process_entry_current(all_matching=False),
+            takefocus=False,
+        ).grid(column=2, row=2, sticky="NSEW", padx=(5, 0), pady=2)
 
+        self.count_textvariable = tk.StringVar(self, "")
         ttk.Label(
             frame,
-            text="Hint: ",
-        ).grid(column=0, row=3, sticky="NSE", pady=5)
-        self.hint_textvariable = tk.StringVar(self, "")
-        self.hint = ttk.Entry(
-            frame,
-            textvariable=self.hint_textvariable,
-            state="readonly",
+            textvariable=self.count_textvariable,
+        ).grid(column=0, row=3, sticky="NS", padx=(0, 5), pady=2)
+        self.hint_textvariable = tk.StringVar(self, "Hint: ")
+        ttk.Entry(frame, textvariable=self.hint_textvariable, state="readonly").grid(
+            column=1, row=3, sticky="NSEW", pady=2
         )
-        self.hint.grid(column=1, row=3, sticky="NSEW", pady=5)
+        ttk.Button(
+            frame,
+            text="Replace All",
+            command=lambda: self.process_entry_current(all_matching=True),
+            takefocus=False,
+        ).grid(column=2, row=3, sticky="NSEW", padx=(5, 0), pady=2)
 
         self.scanno_list: list[Scanno] = []
         self.whole_word = False
         self.scanno_number = 0
-        self.load_scannos()
 
     def choose_file(self) -> None:
         """Choose & load a scannos file."""
@@ -1801,7 +1822,9 @@ class ScannoCheckerDialog(CheckerDialog):
                 prev = False
             else:
                 self.scanno_number += -1 if prev else 1
-            if self.any_matches(slurp_text, find_range):
+            if self.any_matches(slurp_text, find_range) or not preferences.get(
+                PrefKey.SCANNOS_AUTO_ADVANCE
+            ):
                 self.list_scannos()
                 return
         # No matches found, so display first/last scanno
@@ -1829,31 +1852,48 @@ class ScannoCheckerDialog(CheckerDialog):
         )
         return bool(match)
 
-    def list_scannos(self) -> None:
-        """Display current scanno and list of results."""
+    def list_scannos(self, update_fields: bool = True) -> None:
+        """Display current scanno and list of results.
+
+        Args:
+            update_fields: Set to False if fields should not be updated.
+        """
         self.reset()
         if not self.scanno_list:
             self.display_entries(complete_msg=False)
             return
-        scanno = self.scanno_list[self.scanno_number]
-        self.scanno_textvariable.set(scanno[Scanno.MATCH])
-        self.replacement_textvariable.set(scanno[Scanno.REPLACEMENT])
-        self.hint_textvariable.set(scanno[Scanno.HINT])
+        if update_fields:
+            scanno = self.scanno_list[self.scanno_number]
+            self.scanno_textvariable.set(scanno[Scanno.MATCH])
+            self.replacement_textvariable.set(scanno[Scanno.REPLACEMENT])
+            self.hint_textvariable.set(f"Hint: {scanno[Scanno.HINT]}")
+            self.count_textvariable.set(
+                f"{self.scanno_number + 1} / {len(self.scanno_list)}"
+            )
 
         find_range = IndexRange(maintext().start().index(), maintext().end().index())
         slurp_text = maintext().get_text()
         slice_start = 0
 
         while True:
-            match, match_start = maintext().find_match_in_range(
-                scanno[Scanno.MATCH],
-                slurp_text[slice_start:],
-                find_range,
-                nocase=False,
-                regexp=True,
-                wholeword=self.whole_word,
-                backwards=False,
-            )
+            try:
+                match, match_start = maintext().find_match_in_range(
+                    self.scanno_textvariable.get(),
+                    slurp_text[slice_start:],
+                    find_range,
+                    nocase=False,
+                    regexp=True,
+                    wholeword=self.whole_word,
+                    backwards=False,
+                )
+            except re.error as e:
+                logger.error(
+                    f"Scanno regex {self.scanno_number + 1} has an error:\n{message_from_regex_exception(e)}"
+                )
+                self.display_entries(complete_msg=False)
+                self.lift()
+                return
+
             if match is None:
                 break
             line = maintext().get(
@@ -1900,12 +1940,12 @@ class ScannoCheckerDialog(CheckerDialog):
             complete_msg=(self.scanno_number >= len(self.scanno_list) - 1)
         )
 
-    def replace_scanno(self) -> None:
-        """Replace current match using replacement"""
-        current_index = self.current_entry_index()
-        if current_index is None:
-            return
-        do_replace_scanno(self.entries[current_index])
+    def swap_terms(self) -> None:
+        """Swap search & replace terms in dialog."""
+        tempstr = self.scanno_textvariable.get()
+        self.scanno_textvariable.set(self.replacement_textvariable.get())
+        self.replacement_textvariable.set(tempstr)
+        self.list_scannos(update_fields=False)
 
 
 _the_stealth_scannos_dialog: Optional[ScannoCheckerDialog] = None
@@ -1925,7 +1965,6 @@ def do_replace_scanno(checker_entry: CheckerEntry) -> None:
         replacement = get_regex_replacement(
             search_string, replace_string, match_text, flags=0
         )
-        maintext().undo_block_begin()
         maintext().replace(start, end, replacement)
 
 
@@ -1939,7 +1978,10 @@ def stealth_scannos() -> None:
     _the_stealth_scannos_dialog = ScannoCheckerDialog.show_dialog(
         rerun_command=stealth_scannos,
         process_command=do_replace_scanno,
+        show_all_buttons=False,
+        match_on_highlight=None,
     )
+    _the_stealth_scannos_dialog.load_scannos()
 
 
 DQUOTES = "“”"

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -94,6 +94,7 @@ class PrefKey(StrEnum):
     IMAGE_VIEWER_INTERNAL = auto()
     SCANNOS_FILENAME = auto()
     SCANNOS_HISTORY = auto()
+    SCANNOS_AUTO_ADVANCE = auto()
     HIGHLIGHT_QUOTBRAC = auto()
     HIGHLIGHT_HTML_TAGS = auto()
     HIGHLIGHT_CURSOR_LINE = auto()


### PR DESCRIPTION
Fix various requests/bugs:

1. Only output "Check complete" message when it gets to the last Scanno in the file.
2. Auto-start the scanno checks when the dialog is popped or a new file loaded.
3. Add Auto Advance checkbox - necessary to allow user to switch it off if they want to swap terms, or to manually adjust the regexes.
4. Make the search/replace fields be editable
5. Add Swap Terms button to swap search/replace
6. Trap bad regexes & report via error rather than traceback.
7. Display number of scanno regex being displayed, e.g. "7/23"
8. Add Replace All button to replace all occurrences shown in list. This deliberately does not remove the messages in the list, so the user can click through if they want to check the fix was done correctly.

Fixes #942 
Fixes #941 
Fixes #939 
Fixes #928 
Fixes #921 

Testing notes: Probably looking at the linked issues would give the best idea of the aim of this PR
