### PR TITLE
Improve setting of shortcut keystrokes

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -798,11 +798,11 @@ class Guiguts:
         # Because keyboard layouts are different, need to bind to several keys for some bookmarks
         kbd = get_keyboard_layout()
         shortcuts = [
-            ("!", "!"),
-            ("@", '"'),
-            ("#", "sterling"),
-            ("$", "$"),
-            ("%", "%"),
+            ("exclam", "exclam"),
+            ("at", "quotedbl"),
+            ("numbersign", "sterling"),
+            ("dollar", "dollar"),
+            ("percent", "percent"),
         ]
         # Shift+Cmd+number no good for Mac due to clash with screen capture shortcuts
         # Ctrl+number could also clash on Mac with virtual desktop switching, but
@@ -812,7 +812,7 @@ class Guiguts:
                 # Add tilde before one of the letters in "okmar"
                 "Set Bo" + "okmar"[: bm - 1] + "~" + "okmar"[bm - 1 :] + f"k ~{bm}",
                 lambda num=bm: self.file.set_bookmark(num),  # type:ignore[misc]
-                f"Ctrl+Key-{keys[kbd]}",
+                f"Ctrl+Shift+Key-{keys[kbd]}",
             )
 
         for bm in range(1, 6):

--- a/src/guiguts/html_tools.py
+++ b/src/guiguts/html_tools.py
@@ -590,6 +590,7 @@ class HTMLValidator:
 
     def run(self) -> None:
         """Do the check and add messages to the dialog."""
+        self.dialog.reset()
 
         validator_url = "https://validator.w3.org/nu/"
 

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -4455,15 +4455,12 @@ class MenubarMetadata:
                     break
 
     def metadata_from_shortcut(self, shortcut: str) -> Optional[EntryMetadata]:
-        """Return metadata that has given shortcut assigned (or None).
-        Copes with "Key-" being present/absent."""
+        """Return metadata that has given shortcut assigned (or None)."""
         if not shortcut:
             return None
-        shortcut = shortcut.replace("Key-", "")
         all_commands = self.get_all_palette_commands()
         for command in all_commands:
-            cmd_shortcut = process_accel(command.shortcut)[0]
-            if cmd_shortcut == shortcut:
+            if command.shortcut == shortcut:
                 return command
         return None
 

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -4460,7 +4460,7 @@ class MenubarMetadata:
             return None
         all_commands = self.get_all_palette_commands()
         for command in all_commands:
-            if command.shortcut == shortcut:
+            if process_accel(command.shortcut)[0] == shortcut:
                 return command
         return None
 

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -1064,8 +1064,10 @@ class CommandEditDialog(OkCancelDialog):
             True if successful.
         """
         new_shortcut = self.shortcut
-        # Don't allow shortcuts that don't use Ctrl/Cmd/Alt
-        if not any(m in new_shortcut for m in ["Ctrl", "Cmd", "Alt"]):
+        # Don't allow shortcuts that don't use Ctrl/Cmd/Alt except for F keys
+        if not any(m in new_shortcut for m in ["Ctrl", "Cmd", "Alt"]) and not re.search(
+            r"F\d+$", new_shortcut
+        ):
             logger.error(
                 f"Shortcut must include Ctrl or {'Cmd' if is_mac() else 'Alt'}"
             )
@@ -1076,6 +1078,15 @@ class CommandEditDialog(OkCancelDialog):
         # Don't allow shortcuts that use Option
         if "Option" in new_shortcut:
             logger.error("Option key may not be used for shortcuts")
+            self.lift()
+            self.focus()
+            return False
+
+        # Plain F1 is reserved
+        if new_shortcut == "F1":
+            logger.error(
+                f"F1 without Shift, Ctrl or {'Cmd' if is_mac() else 'Alt'} is reserved for Help"
+            )
             self.lift()
             self.focus()
             return False

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -1054,24 +1054,10 @@ class CommandEditDialog(OkApplyCancelDialog):
             True if successful.
         """
         new_shortcut = self.shortcut
-        single_char_keyname = (
-            len(re.sub(r".*\+", "", self.shortcut_variable.get())) == 1
-        )
-        if single_char_keyname and not (
-            "Ctrl" in new_shortcut
-            or "Cmd" in new_shortcut
-            or "Alt" in new_shortcut
-            or "Option" in new_shortcut
-        ):
+        # Don't allow shortcuts that don't use Ctrl/Cmd/Alt
+        if not any(m in new_shortcut for m in ["Ctrl", "Cmd", "Alt"]):
             logger.error(
                 f"Shortcut must include Ctrl or {'Cmd' if is_mac() else 'Alt'}"
-            )
-            self.lift()
-            self.focus()
-            return False
-        if new_shortcut == "F1":
-            logger.error(
-                f"F1 without Shift, Ctrl or {'Cmd' if is_mac() else 'Alt'} is reserved for Help"
             )
             self.lift()
             self.focus()

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -1091,6 +1091,13 @@ class CommandEditDialog(OkCancelDialog):
             self.focus()
             return False
 
+        # Cmd+? is reserved for Help too
+        if new_shortcut == "Cmd+Shift+?":
+            logger.error("Cmd+Shift+? is reserved for Help")
+            self.lift()
+            self.focus()
+            return False
+
         # Other reserved shortcuts
         ctrl_cmd = "Cmd" if is_mac() else "Ctrl"
         display_shortcut = process_accel(new_shortcut)[0]
@@ -1165,6 +1172,10 @@ class CommandEditDialog(OkCancelDialog):
         keysym = event.keysym
         if keysym in self.MODIFIER_KEYS:
             self.pressed_modifiers.add(keysym)
+        elif (
+            event.keysym in ("BackSpace", "Delete") and len(self.pressed_modifiers) == 0
+        ):
+            self.shortcut = ""
         else:
             # Combine the current modifiers with the key
             mods = sorted(set(self.MODIFIER_KEYS[kk] for kk in self.pressed_modifiers))

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -1064,10 +1064,11 @@ class CommandEditDialog(OkCancelDialog):
             True if successful.
         """
         new_shortcut = self.shortcut
+        display_shortcut = process_accel(new_shortcut)[0]
         # Don't allow shortcuts that don't use Ctrl/Cmd/Alt except for F keys
-        if not any(m in new_shortcut for m in ["Ctrl", "Cmd", "Alt"]) and not re.search(
-            r"F\d+$", new_shortcut
-        ):
+        if not any(
+            m in display_shortcut for m in ["Ctrl", "Cmd", "Alt"]
+        ) and not re.search(r"F\d+$", display_shortcut):
             logger.error(
                 f"Shortcut must include Ctrl or {'Cmd' if is_mac() else 'Alt'}"
             )
@@ -1076,14 +1077,14 @@ class CommandEditDialog(OkCancelDialog):
             return False
 
         # Don't allow shortcuts that use Option
-        if "Option" in new_shortcut:
+        if "Option" in display_shortcut:
             logger.error("Option key may not be used for shortcuts")
             self.lift()
             self.focus()
             return False
 
         # Plain F1 is reserved
-        if new_shortcut == "F1":
+        if display_shortcut == "F1":
             logger.error(
                 f"F1 without Shift, Ctrl or {'Cmd' if is_mac() else 'Alt'} is reserved for Help"
             )
@@ -1091,8 +1092,8 @@ class CommandEditDialog(OkCancelDialog):
             self.focus()
             return False
 
-        # Cmd+? is reserved for Help too
-        if new_shortcut == "Cmd+Shift+?":
+        # Cmd+Shift+? is reserved for Help too
+        if display_shortcut == "Cmd+Shift+?":
             logger.error("Cmd+Shift+? is reserved for Help")
             self.lift()
             self.focus()
@@ -1100,7 +1101,6 @@ class CommandEditDialog(OkCancelDialog):
 
         # Other reserved shortcuts
         ctrl_cmd = "Cmd" if is_mac() else "Ctrl"
-        display_shortcut = process_accel(new_shortcut)[0]
         for res_key in ("A", "C", "V", "X"):
             if display_shortcut == f"{ctrl_cmd}+{res_key}":
                 logger.error(

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -1091,6 +1091,18 @@ class CommandEditDialog(OkCancelDialog):
             self.focus()
             return False
 
+        # Other reserved shortcuts
+        ctrl_cmd = "Cmd" if is_mac() else "Ctrl"
+        display_shortcut = process_accel(new_shortcut)[0]
+        for res_key in ("A", "C", "V", "X"):
+            if display_shortcut == f"{ctrl_cmd}+{res_key}":
+                logger.error(
+                    f"{display_shortcut} is a reserved shortcut and may not be reassigned"
+                )
+                self.lift()
+                self.focus()
+                return False
+
         # Bind do_nothing to dummy widget, to test if the bind sequence is legal
         def do_nothing(_: tk.Event) -> None:
             """Do nothing."""

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -1470,12 +1470,11 @@ class CommandPaletteDialog(ToplevelDialog):
         # If (some) modifier keys pressed with character when typing in list,
         # don't add the char to the entry field:
         # Shift, Caps Lock, etc. are OK, but not Ctrl, Cmd, Alt (platform-specific)
-        BAD_MODIFIERS = 0x0004 | 0x0008 | 0x0080 | 0x20000
+        bad_modifiers = 0x0004 | 0x0008 | 0x0080 | 0x20000
+        state = int(event.state)
         if event.keysym in ("BackSpace", "Delete"):
             self.search_var.set(current_text[:-1])
-        elif (
-            event.char and event.char.isprintable() and not event.state & BAD_MODIFIERS
-        ):
+        elif event.char and event.char.isprintable() and not state & bad_modifiers:
             # If a proper char, add it to the entry
             self.search_var.set(current_text + event.char)
         self.update_list()  # Update the list based on the new search text

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -1264,6 +1264,11 @@ class CommandPaletteDialog(ToplevelDialog):
         """Store function to be called to recreate menus."""
         cls.recreate_menus_callback = callback
 
+    def grab_focus(self) -> None:
+        """Override grabbing focus to set focus to Entry field."""
+        super().grab_focus()
+        self.entry.focus()
+
     def update_list(self) -> None:
         """Update the command list based on search input."""
 

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -1467,14 +1467,18 @@ class CommandPaletteDialog(ToplevelDialog):
     def handle_list_typing(self, event: tk.Event) -> None:
         """Handle key press in the list to simulate typing in the Entry box."""
         current_text = self.search_var.get()
+        # If (some) modifier keys pressed with character when typing in list,
+        # don't add the char to the entry field:
+        # Shift, Caps Lock, etc. are OK, but not Ctrl, Cmd, Alt (platform-specific)
+        BAD_MODIFIERS = 0x0004 | 0x0008 | 0x0080 | 0x20000
         if event.keysym in ("BackSpace", "Delete"):
             self.search_var.set(current_text[:-1])
-            self.update_list()  # Update the list based on the new search text
         elif (
-            event.char and event.char.isprintable()
-        ):  # If a proper char, add it to the entry
+            event.char and event.char.isprintable() and not event.state & BAD_MODIFIERS
+        ):
+            # If a proper char, add it to the entry
             self.search_var.set(current_text + event.char)
-            self.update_list()  # Update the list based on the new search text
+        self.update_list()  # Update the list based on the new search text
 
     def add_to_history(self, label: str, parent_label: str) -> None:
         """Store given entry in history list pref.

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -1070,6 +1070,13 @@ class CommandEditDialog(OkApplyCancelDialog):
             self.focus()
             return False
 
+        # Don't allow shortcuts that use Option
+        if "Option" in new_shortcut:
+            logger.error("Option key may not be used for shortcuts")
+            self.lift()
+            self.focus()
+            return False
+
         # Bind do_nothing to dummy widget, to test if the bind sequence is legal
         def do_nothing(_: tk.Event) -> None:
             """Do nothing."""

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -1066,9 +1066,11 @@ class CommandEditDialog(OkCancelDialog):
         new_shortcut = self.shortcut
         display_shortcut = process_accel(new_shortcut)[0]
         # Don't allow shortcuts that don't use Ctrl/Cmd/Alt except for F keys
-        if not any(
-            m in display_shortcut for m in ["Ctrl", "Cmd", "Alt"]
-        ) and not re.search(r"F\d+$", display_shortcut):
+        if (
+            display_shortcut
+            and not any(m in display_shortcut for m in ["Ctrl", "Cmd", "Alt"])
+            and not re.search(r"F\d+$", display_shortcut)
+        ):
             logger.error(
                 f"Shortcut must include Ctrl or {'Cmd' if is_mac() else 'Alt'}"
             )
@@ -1114,15 +1116,18 @@ class CommandEditDialog(OkCancelDialog):
         def do_nothing(_: tk.Event) -> None:
             """Do nothing."""
 
-        try:
-            test_key = process_accel(new_shortcut)[1]
-            self.dummy_widget.bind(test_key, do_nothing)
-            self.dummy_widget.unbind(test_key)
-        except tk.TclError:
-            logger.error(f"Key combination {test_key} is not supported as a shortcut.")
-            self.lift()
-            self.focus()
-            return False
+        if new_shortcut:
+            try:
+                test_key = process_accel(new_shortcut)[1]
+                self.dummy_widget.bind(test_key, do_nothing)
+                self.dummy_widget.unbind(test_key)
+            except tk.TclError:
+                logger.error(
+                    f"Key combination {test_key} is not supported as a shortcut."
+                )
+                self.lift()
+                self.focus()
+                return False
 
         shortcuts_dict = KeyboardShortcutsDict()
 

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -35,6 +35,7 @@ from guiguts.widgets import (
     ToolTip,
     insert_in_focus_widget,
     OkApplyCancelDialog,
+    OkCancelDialog,
     mouse_bind,
     Combobox,
     Notebook,
@@ -970,7 +971,7 @@ class RecentPlusEntry:
         self.entry = entry
 
 
-class CommandEditDialog(OkApplyCancelDialog):
+class CommandEditDialog(OkCancelDialog):
     """Command Edit Dialog."""
 
     manual_page = "Help_Menu#User-defined_Keyboard_Shortcuts"
@@ -991,7 +992,9 @@ class CommandEditDialog(OkApplyCancelDialog):
 
     def __init__(self, command_dlg: "CommandPaletteDialog") -> None:
         """Initialize the command edit window."""
-        super().__init__("Command Edit", resize_x=False, resize_y=False)
+        super().__init__(
+            "Command Edit", display_apply=False, resize_x=False, resize_y=False
+        )
 
         self.cmd_dlg = command_dlg
         ttk.Label(self.top_frame, text="Label:").grid(

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -993,7 +993,7 @@ class CommandEditDialog(OkCancelDialog):
     def __init__(self, command_dlg: "CommandPaletteDialog") -> None:
         """Initialize the command edit window."""
         super().__init__(
-            "Command Edit", display_apply=False, resize_x=False, resize_y=False
+            "Shortcut Edit", display_apply=False, resize_x=False, resize_y=False
         )
 
         self.cmd_dlg = command_dlg
@@ -1101,7 +1101,9 @@ class CommandEditDialog(OkCancelDialog):
         new_assign = f"{menu}|{label}" if menu else label
 
         # If shortcut is already assigned, check whether user wants to continue
-        command = menubar_metadata().metadata_from_shortcut(new_shortcut)
+        command = menubar_metadata().metadata_from_shortcut(
+            process_accel(new_shortcut)[0]
+        )
         if command is not None:
             menu = command.display_parent_label()
             label = command.display_label()

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -1474,10 +1474,11 @@ class CommandPaletteDialog(ToplevelDialog):
         state = int(event.state)
         if event.keysym in ("BackSpace", "Delete"):
             self.search_var.set(current_text[:-1])
+            self.update_list()  # Update the list based on the new search text
         elif event.char and event.char.isprintable() and not state & bad_modifiers:
             # If a proper char, add it to the entry
             self.search_var.set(current_text + event.char)
-        self.update_list()  # Update the list based on the new search text
+            self.update_list()  # Update the list based on the new search text
 
     def add_to_history(self, label: str, parent_label: str) -> None:
         """Store given entry in history list pref.

--- a/src/guiguts/utilities.py
+++ b/src/guiguts/utilities.py
@@ -378,10 +378,9 @@ def get_keyboard_layout() -> int:
             )
             for line in result.stdout.splitlines():
                 if "KeyboardLayout Name" in line:
+                    # May begin with "British" or "U.S." or "US"
                     layout = re.sub(r'.*"([^"]+)";$', r"\1", line)
                     break
-            # e.g. "British" or "U.S."
-            print(f"Keyboard layout: {layout}")
         except subprocess.SubprocessError:
             pass
     else:
@@ -395,7 +394,7 @@ def get_keyboard_layout() -> int:
                     break
         except subprocess.SubprocessError:
             pass
-    return 1 if layout in ("00000809", "gb", "British") else 0
+    return 1 if layout.startswith(("00000809", "gb", "British")) else 0
 
 
 class DiacriticRemover:

--- a/src/guiguts/utilities.py
+++ b/src/guiguts/utilities.py
@@ -367,15 +367,21 @@ def get_keyboard_layout() -> int:
         try:
             result = subprocess.run(
                 [
-                    "osascript",
-                    "-e",
-                    'tell application "System Events" to get name of current keyboard layout',
+                    "defaults",
+                    "read",
+                    "~/Library/Preferences/com.apple.HIToolbox.plist",
+                    "AppleSelectedInputSources",
                 ],
                 capture_output=True,
                 text=True,
                 check=False,
             )
-            layout = result.stdout.strip()  # e.g. "British" or "U.S."
+            for line in result.stdout.splitlines():
+                if "KeyboardLayout Name" in line:
+                    layout = re.sub(r'.*"([^"]+)";$', r"\1", line)
+                    break
+            # e.g. "British" or "U.S."
+            print(f"Keyboard layout: {layout}")
         except subprocess.SubprocessError:
             pass
     else:

--- a/src/guiguts/utilities.py
+++ b/src/guiguts/utilities.py
@@ -22,6 +22,69 @@ TraversablePath = importlib.resources.abc.Traversable | Path
 # See: https://pytest.org/en/7.4.x/example/simple.html#detect-if-running-from-within-a-pytest-run
 CALLED_FROM_TEST = False
 
+# Event keysym names as keys, display names as values
+SUPPORTED_SHORTCUT_KEYS = {
+    "F1": "F1",
+    "F2": "F2",
+    "F3": "F3",
+    "F4": "F4",
+    "F5": "F5",
+    "F6": "F6",
+    "F7": "F7",
+    "F8": "F8",
+    "F9": "F9",
+    "F10": "F10",
+    "F11": "F11",
+    "F12": "F12",
+    "Left": "Left",
+    "Right": "Right",
+    "Up": "Up",
+    "Down": "Down",
+    "Home": "Home",
+    "End": "End",
+    "Prior": "PgUp",
+    "Next": "PgDn",
+    "Insert": "Insert",
+    "exclam": "!",
+    "quotedbl": '"',
+    "numbersign": "#",
+    "dollar": "$",
+    "percent": "%",
+    "ampersand": "&",
+    "quoteright": "'",
+    "parenleft": "(",
+    "parenright": ")",
+    "asterisk": "*",
+    "plus": "+",
+    "comma": ",",
+    "minus": "-",
+    "period": ".",
+    "slash": "/",
+    "colon": ":",
+    "semicolon": ";",
+    "less": "<",
+    "equal": "=",
+    "greater": ">",
+    "question": "?",
+    "at": "@",
+    "bracketleft": "[",
+    "backslash": "\\",
+    "bracketright": "]",
+    "asciicircum": "^",
+    "underscore": "_",
+    "quoteleft": "`",
+    "braceleft": "{",
+    "bar": "|",
+    "braceright": "}",
+    "asciitilde": "~",
+    "sterling": "£",
+    "notsign": "¬",
+    "grave": "`",
+    "apostrophe": "'",
+    "plusminus": "±",
+    "section": "§",
+}
+
 
 #
 # Functions to check which OS is being used
@@ -273,9 +336,8 @@ def process_accel(accel: str) -> tuple[str, str]:
         keyevent = keyevent.replace("Alt+", "Alt-")
     accel = accel.replace("Key-", "")
     # More friendly names for display
-    accel = accel.replace("sterling", "£")
-    accel = accel.replace("Prior", "PgUp")
-    accel = accel.replace("Next", "PgDn")
+    for key, display in SUPPORTED_SHORTCUT_KEYS.items():
+        accel = accel.replace(key, display)
     return (accel, f"<{keyevent}>")
 
 

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -336,38 +336,44 @@ class ToplevelDialog(tk.Toplevel):
 class OkApplyCancelDialog(ToplevelDialog):
     """A ToplevelDialog with OK, Apply & Cancel buttons."""
 
-    def __init__(self, title: str, **kwargs: Any) -> None:
-        """Initialize the dialog."""
+    def __init__(self, title: str, display_apply: bool = True, **kwargs: Any) -> None:
+        """Initialize the dialog.
+
+        Args:
+            title: Title for dialog.
+            display_apply: Set to False if Apply button not required.
+        """
         super().__init__(title, **kwargs)
-        button_frame = ttk.Frame(self, padding=5)
-        button_frame.grid(row=1, column=0, sticky="NSEW")
-        button_frame.columnconfigure(0, weight=1)
-        ok_button = ttk.Button(
+        outer_button_frame = ttk.Frame(self, padding=5)
+        outer_button_frame.grid(row=1, column=0, sticky="NSEW")
+        outer_button_frame.columnconfigure(0, weight=1)
+        button_frame = ttk.Frame(outer_button_frame)
+        button_frame.grid(row=1, column=0)
+        column = 0
+        ttk.Button(
             button_frame,
             text="OK",
             default="active",
             command=self.ok_pressed,
             takefocus=False,
-        )
-        ok_button.grid(row=0, column=0)
-        button_frame.columnconfigure(1, weight=1)
-        apply_button = ttk.Button(
-            button_frame,
-            text="Apply",
-            default="normal",
-            command=self.apply_changes,
-            takefocus=False,
-        )
-        apply_button.grid(row=0, column=1)
-        button_frame.columnconfigure(2, weight=1)
-        cancel_button = ttk.Button(
+        ).grid(row=0, column=column, padx=5)
+        if display_apply:
+            column += 1
+            ttk.Button(
+                button_frame,
+                text="Apply",
+                default="normal",
+                command=self.apply_changes,
+                takefocus=False,
+            ).grid(row=0, column=column, padx=5)
+        column += 1
+        ttk.Button(
             button_frame,
             text="Cancel",
             default="normal",
             command=self.cancel_pressed,
             takefocus=False,
-        )
-        cancel_button.grid(row=0, column=2)
+        ).grid(row=0, column=column, padx=5)
         self.bind("<Return>", lambda event: self.ok_pressed())
         self.bind("<Escape>", lambda event: self.cancel_pressed())
 
@@ -390,6 +396,19 @@ class OkApplyCancelDialog(ToplevelDialog):
     def cancel_pressed(self) -> None:
         """Destroy dialog."""
         self.destroy()
+
+
+class OkCancelDialog(OkApplyCancelDialog):
+    """A ToplevelDialog with OK & Cancel buttons."""
+
+    def __init__(self, title: str, **kwargs: Any) -> None:
+        """Initialize the dialog.
+
+        Args:
+            title: Title for dialog.
+        """
+        kwargs["display_apply"] = False
+        super().__init__(title, **kwargs)
 
 
 class Combobox(ttk.Combobox):

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -129,14 +129,11 @@ class ToplevelDialog(tk.Toplevel):
         if dlg := cls.get_dialog():
             dlg.deiconify()
             dlg.reset()
-            # On Linux, Window Managers stop dialogs being brought to the front by deiconify,
-            # or anything else. Destroying the dialog and recreating it gets round that.
-            if is_x11():
-                dlg.destroy()
         # Or do we need to create it?
         if not cls.get_dialog():
             dlg = cls(**kwargs)
         ToplevelDialog._toplevel_dialogs[dlg_name] = dlg
+        dlg.grab_focus()
         return dlg
 
     @classmethod
@@ -161,6 +158,11 @@ class ToplevelDialog(tk.Toplevel):
         with another dialog.
         """
         return cls.__name__.removesuffix("Dialog")
+
+    def grab_focus(self) -> None:
+        """Grab focus and raise to top (if permitted by window manager)."""
+        if is_x11():
+            grab_focus(self)
 
     def got_focus(self) -> None:
         """Called when dialog gets focus."""

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -129,8 +129,12 @@ class ToplevelDialog(tk.Toplevel):
         if dlg := cls.get_dialog():
             dlg.deiconify()
             dlg.reset()
+            # On Linux, Window Managers stop dialogs being brought to the front by deiconify,
+            # or anything else. Destroying the dialog and recreating it gets round that.
+            if is_x11():
+                dlg.destroy()
         # Or do we need to create it?
-        else:
+        if not cls.get_dialog():
             dlg = cls(**kwargs)
         ToplevelDialog._toplevel_dialogs[dlg_name] = dlg
         return dlg


### PR DESCRIPTION
Allow user to press key with modifiers instead of using checkboxes to set the modifiers.

Should also allow use of option key on macOS.

Should address points 6 & 7 of #956 