### PR TITLE
Don't mark ppgen files as edited when loaded

### DIFF
--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -914,7 +914,6 @@ class File:
             # Subsequent pages are same style as first, page numbers increment
             style = STYLE_DITTO
             number = NUMBER_INCREMENT
-        maintext().set_modified(True)
         return True
 
     def add_good_and_bad_words(self) -> None:


### PR DESCRIPTION
This was mostly an artifact of re-using the page marker flags method of updating page positions. Not required and was annoying to users.

Fixes #961

Testing notes: Load a ppgen master file, e.g. the one from the linked issue. It should not show "edited" until a further edit is made.