### PR TITLE
Fix block markup/page break rewrap bug

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -2899,7 +2899,7 @@ class MainText(tk.Text):
 
                     # Find matching close markup within section being wrapped
                     if close_index := self.search(
-                        rf"^{PAGEMARK_PIN}*{re.escape(block_type)}/\s*$",
+                        rf"^{PAGEMARK_PIN}*{re.escape(block_type)}{PAGEMARK_PIN}*/[{PAGEMARK_PIN}\s]*$",
                         line_start,
                         stopindex=WRAP_END_MARK,
                         nocase=True,


### PR DESCRIPTION
When a page break occurred at the END of a closing markup (like `L/`) the markup wasn't detected, unlike when the page break was at the beginning of the line.

Fixes #963 

Testing notes: test file in linked issue. Try wrapping the first 50 lines.