### PR TITLE
Remove unnecessary PersistentBool variables

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -438,7 +438,6 @@ class Guiguts:
         preferences.set_default(PrefKey.IMAGE_VIEWER_ALERT, True)
         preferences.set_default(PrefKey.HIGH_CONTRAST, False)
         preferences.set_callback(PrefKey.HIGH_CONTRAST, self.high_contrast_callback)
-        preferences.set_default(PrefKey.IMAGE_WINDOW_SHOW, False)
         preferences.set_default(PrefKey.IMAGE_VIEWER_EXTERNAL, False)
         preferences.set_default(PrefKey.IMAGE_VIEWER_EXTERNAL_PATH, "")
         preferences.set_default(PrefKey.IMAGE_VIEWER_INTERNAL, False)
@@ -747,17 +746,17 @@ class Guiguts:
         search_menu.add_separator()
         search_menu.add_checkbutton(
             "Highlight S~urrounding Quotes & Brackets",
-            root().highlight_quotbrac.pref_key,
+            PrefKey.HIGHLIGHT_QUOTBRAC,
         )
         search_menu.add_checkbutton(
             "Highlight Al~ignment Column",
-            maintext().aligncol_active.pref_key,
+            PrefKey.ALIGN_COL_ACTIVE,
             lambda: maintext().highlight_aligncol_callback(True),
             lambda: maintext().highlight_aligncol_callback(False),
         )
         search_menu.add_checkbutton(
             "Highlight ~Proofer Comments",
-            root().highlight_proofercomment.pref_key,
+            PrefKey.HIGHLIGHT_PROOFERCOMMENT,
         )
         search_menu.add_checkbutton(
             "Highlight ~HTML tags",
@@ -928,7 +927,7 @@ class Guiguts:
         view_menu = self.top_level_menu("~View")
         view_menu.add_checkbutton(
             "Split ~Text Window",
-            root().split_text_window.pref_key,
+            PrefKey.SPLIT_TEXT_WINDOW,
             lambda: maintext().show_peer(),
             lambda: maintext().hide_peer(),
             "Cmd/Ctrl+Shift+T",
@@ -942,18 +941,18 @@ class Guiguts:
         )
         view_menu.add_checkbutton(
             "~Dock Image Viewer",
-            root().image_window_docked_state.pref_key,
+            PrefKey.IMAGE_WINDOW_DOCKED,
             self.mainwindow.dock_image,
             self.mainwindow.float_image,
         )
         view_menu.add_checkbutton(
             "~Auto Image",
-            root().auto_image_state.pref_key,
+            PrefKey.AUTO_IMAGE,
         )
         view_menu.add_button("S~ee Image", self.see_image)
         view_menu.add_checkbutton(
             "~Invert Image",
-            root().invert_image_state.pref_key,
+            PrefKey.IMAGE_INVERT,
             mainimage().show_image,
             mainimage().show_image,
         )
@@ -963,7 +962,7 @@ class Guiguts:
         if not is_mac():  # Full Screen behaves oddly on Macs
             view_menu.add_checkbutton(
                 "~Full Screen",
-                root().full_screen_var.pref_key,
+                PrefKey.ROOT_GEOMETRY_FULL_SCREEN,
                 lambda: root().wm_attributes("-fullscreen", True),
                 lambda: root().wm_attributes("-fullscreen", False),
             )

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -12,7 +12,7 @@ import darkdetect  # type: ignore[import-untyped]
 
 import regex as re
 
-from guiguts.preferences import preferences, PrefKey, PersistentBoolean
+from guiguts.preferences import preferences, PrefKey
 from guiguts.utilities import (
     is_mac,
     is_x11,
@@ -707,7 +707,6 @@ class MainText(tk.Text):
         # alignment column
         self.aligncol = -1
         preferences.set(PrefKey.ALIGN_COL_ACTIVE, False)
-        self.aligncol_active = PersistentBoolean(PrefKey.ALIGN_COL_ACTIVE)
 
         # whether search highlights should be active
         self.search_highlight_active = tk.BooleanVar()
@@ -3690,7 +3689,7 @@ class MainText(tk.Text):
         # Check that alignment column is 0 or higher; there are no negative
         # columns in a textview. Since the column is decremented when align
         # highlight is turned on, it's possible that this value is set to -1.
-        if self.aligncol_active.get() and self.aligncol >= 0:
+        if preferences.get(PrefKey.ALIGN_COL_ACTIVE) and self.aligncol >= 0:
             self.tag_remove(HighlightTag.ALIGNCOL, "1.0", tk.END)
 
             self.highlight_aligncol_in_viewport(self)
@@ -3709,7 +3708,7 @@ class MainText(tk.Text):
                 logger.error(
                     "Can't create an alignment column at column 0. Choose another column."
                 )
-                self.aligncol_active.set(False)
+                preferences.set(PrefKey.ALIGN_COL_ACTIVE, False)
                 return
 
             # Highlight column immediately preceding cursor for consistency with ruler.

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -746,7 +746,7 @@ class MainImage(tk.Frame):
             text="Dock",
             takefocus=False,
             command=self.set_image_docking,
-            variable=root().image_window_docked_state,
+            variable=PersistentBoolean(PrefKey.IMAGE_WINDOW_DOCKED),
         )
         self.dock_btn.grid(row=0, column=8, sticky="NSEW", padx=(10, 0))
         ToolTip(

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -155,7 +155,7 @@ class PreferencesDialog(ToplevelDialog):
         ttk.Checkbutton(
             appearance_frame,
             text="Show Character Names in Status Bar",
-            variable=root().ordinal_names_state,
+            variable=PersistentBoolean(PrefKey.ORDINAL_NAMES),
         ).grid(column=0, row=6, sticky="NEW", pady=5)
         bell_frame = ttk.Frame(appearance_frame)
         bell_frame.grid(column=0, row=7, sticky="NEW", pady=(5, 0))

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -88,7 +88,6 @@ class PrefKey(StrEnum):
     IMAGE_SCALE_FACTOR = auto()
     IMAGE_VIEWER_ALERT = auto()
     HIGH_CONTRAST = auto()
-    IMAGE_WINDOW_SHOW = auto()
     IMAGE_VIEWER_EXTERNAL = auto()
     IMAGE_VIEWER_EXTERNAL_PATH = auto()
     IMAGE_VIEWER_INTERNAL = auto()

--- a/src/guiguts/root.py
+++ b/src/guiguts/root.py
@@ -8,7 +8,7 @@ import tkinter as tk
 from types import TracebackType
 from typing import Any
 
-from guiguts.preferences import preferences, PrefKey, PersistentBoolean
+from guiguts.preferences import preferences, PrefKey
 from guiguts.utilities import is_x11
 
 logger = logging.getLogger(__package__)
@@ -39,18 +39,7 @@ class Root(tk.Tk):
             PrefKey.ROOT_GEOMETRY_FULL_SCREEN,
             preferences.get(PrefKey.ROOT_GEOMETRY_STATE) == RootWindowState.FULLSCREEN,
         )
-        self.full_screen_var = PersistentBoolean(PrefKey.ROOT_GEOMETRY_FULL_SCREEN)
-        self.image_window_show = PersistentBoolean(PrefKey.IMAGE_WINDOW_SHOW)
-        self.image_window_docked_state = PersistentBoolean(PrefKey.IMAGE_WINDOW_DOCKED)
-        self.auto_image_state = PersistentBoolean(PrefKey.AUTO_IMAGE)
-        self.invert_image_state = PersistentBoolean(PrefKey.IMAGE_INVERT)
-        self.ordinal_names_state = PersistentBoolean(PrefKey.ORDINAL_NAMES)
         self.allow_config_saves = False
-        self.split_text_window = PersistentBoolean(PrefKey.SPLIT_TEXT_WINDOW)
-        self.highlight_quotbrac = PersistentBoolean(PrefKey.HIGHLIGHT_QUOTBRAC)
-        self.highlight_proofercomment = PersistentBoolean(
-            PrefKey.HIGHLIGHT_PROOFERCOMMENT
-        )
 
         self.option_add("*tearOff", preferences.get(PrefKey.TEAROFF_MENUS))
         self.rowconfigure(0, weight=1)
@@ -107,7 +96,6 @@ class Root(tk.Tk):
             )
             state = RootWindowState.ZOOMED if zoomed else RootWindowState.NORMAL
             fullscreen = root().wm_attributes("-fullscreen")
-            self.full_screen_var.set(fullscreen)
             if fullscreen:
                 state = RootWindowState.FULLSCREEN
             # Only save geometry if "normal". Then de-maximize should restore correct size and top-left.


### PR DESCRIPTION
Since the change to store menus differently so they can be created with new shortcuts, it's no longer
necessary to pass in a PersistentBoolean - just the Prefkey is sufficient. So several of these variables are no longer needed.

Things that might have broken:
Full Screen (already tested on Windows)
Show/Hide internal image viewer
Auto Image
Invert Image
Split Text Window
Highlight Proofer comment
Highlight quote/bracket
Show full character name in status bar
Highlight alignment column