### PR TITLE
Don't switch focus to maintext from checkers

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -595,7 +595,7 @@ class CheckerDialog(ToplevelDialog):
             )
 
         if switch_focus_when_clicked is None:
-            switch_focus_when_clicked = not is_mac()
+            switch_focus_when_clicked = False
         self.switch_focus_when_clicked = switch_focus_when_clicked
 
         self.match_on_highlight = match_on_highlight


### PR DESCRIPTION
Previously on Macs only, focus remained in checker dialog when user clicked a message, whereas on
other platforms, focus switched to main text.

This commit makes all platforms behave like Mac.

Fixes #966