### PR TITLE
Wrap footnotes when tidying them

### DIFF
--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -963,10 +963,12 @@ class File:
         if ranges[0].end.col > 0:
             ranges[0].end.col = 0
             ranges[0].end.row += 1
+        maintext().undo_block_begin()
         self.rewrap_section(ranges[0])
 
     def rewrap_all(self) -> None:
         """Wrap whole text."""
+        maintext().undo_block_begin()
         self.rewrap_section(IndexRange("1.0", maintext().index(tk.END)))
 
     def rewrap_section(self, section_range: IndexRange) -> None:
@@ -976,7 +978,6 @@ class File:
             section_range: Range of text to be wrapped.
         """
         maintext().selection_ranges_store_with_marks()
-        maintext().undo_block_begin()
 
         # Dummy insert & delete, so that if user undoes the wrap, the insert
         # cursor returns to its previous point, not the first pin page mark position.

--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -9,6 +9,7 @@ import regex as re
 import roman  # type: ignore[import-untyped]
 
 from guiguts.checkers import CheckerDialog, CheckerEntry
+from guiguts.file import the_file
 from guiguts.maintext import maintext
 from guiguts.misc_tools import tool_save
 from guiguts.preferences import (
@@ -1144,8 +1145,10 @@ def tidy_footnotes() -> None:
             f"{fn_cur_start} +10c", f"{fn_cur_end} -1c"
         )
         fn_label_and_text_part = re.sub(r"(^.+?):", r"[\1]", fn_label_and_text_part)
-        maintext().delete(fn_cur_start, fn_cur_end)
-        maintext().insert(fn_cur_start, fn_label_and_text_part)
+        maintext().replace(fn_cur_start, fn_cur_end, fn_label_and_text_part)
+        the_file().rewrap_section(
+            IndexRange(maintext().rowcol(fn_cur_start), maintext().rowcol(fn_cur_end))
+        )
     # As there are no longer any '[Footnote ...' style records in the file
     # the effect of invoking run_check() here will be to clear the dialog
     # as there are no footnotes to report.


### PR DESCRIPTION
Fixes #964

Testing notes: Example file in linked issue. In master after using Tidy Footnotes in the FN dialog, the footnote is not rewrapped, and has a short line. 