### PR TITLE
Fix Tk9 Comboboxes

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -1295,7 +1295,11 @@ class Guiguts:
         updating application theme if necessary."""
         if preferences.get(PrefKey.THEME_NAME) == "Default":
             os_mode = darkdetect.theme()
-            tk_theme = themed_style().theme_use()
+            # Calling themed_style.theme_use() with no args fails on Tk9
+            # Fix below from comment in ttk.py:
+            # | Starting on Tk 8.6, checking this global is no longer needed
+            # | since it allows doing self.tk.call(self._name, "theme", "use")
+            tk_theme = themed_style().tk.call(themed_style()._name, "theme", "use")  # type: ignore[attr-defined] # pylint: disable=protected-access
 
             if os_mode == "Light" and tk_theme != "awlight":
                 themed_style().theme_use("awlight")

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -463,7 +463,10 @@ class Combobox(ttk.Combobox):
         #   grab (create a new one or get existing) popdown
         popdown = self.tk.eval(f"ttk::combobox::PopdownWindow {self}")
         #   configure popdown font
-        self.tk.call(f"{popdown}.f.l", "configure", "-font", self["font"])
+        try:  # Tk8 structure
+            self.tk.call(f"{popdown}.f.l", "configure", "-font", self["font"])
+        except tk.TclError:  # Tk9 structure
+            self.tk.call(f"{popdown}.menu", "configure", "-font", self["font"])
 
     def configure(  # type:ignore[override] # pylint: disable=signature-differs
         self, cnf: dict[str, Any], **kw: dict[str, Any]


### PR DESCRIPTION
Use alternative internal name `.menu` if `.f.l` fails.