### PR TITLE
Mark file state dirty when setting bookmark

### DIFF
--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -1072,6 +1072,7 @@ class File:
             f"{BOOKMARK_BASE}{bm_num}", maintext().get_insert_index()
         )
         self.highlight_bookmark(bm_num)
+        maintext().set_modified(True)
 
     def goto_bookmark(self, bm_num: int) -> None:
         """Set the insert position to the location of the given bookmark.


### PR DESCRIPTION
Setting a bookmark didn't mark the file as edited; therefore you could close or quit the file without saving (or being asked if you want to save) and lose the bookmark permanently.

Testing notes:
- On `master`, set a bookmark and then close or quit without saving. The bookmark should be lost on next startup.
- On this branch, set a bookmark and then close or quit without saving; you should be asked if you want to save.

Fixes #989