### PR TITLE
Image rotation

### DIFF
--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -54,6 +54,7 @@ BINFILE_KEY_IMAGEDIR: Final = "imagedir"
 BINFILE_KEY_PROJECTID: Final = "projectid"
 BINFILE_KEY_LANGUAGES: Final = "languages"
 BINFILE_KEY_BOOKMARKS: Final = "bookmarks"
+BINFILE_KEY_IMAGEROTATE: Final = "imagerotate"
 
 PAGE_FLAGS_NONE = 0
 PAGE_FLAGS_SOME = 1
@@ -87,6 +88,7 @@ class BinDict(TypedDict):
     projectid: str
     languages: str
     bookmarks: dict[str, str]
+    imagerotate: dict[str, int]
 
 
 class File:
@@ -247,6 +249,7 @@ class File:
             return
         maintext().set_insert_index(IndexRowCol(1, 0))
         self.languages = preferences.get(PrefKey.DEFAULT_LANGUAGES)
+        mainimage().reset_rotation_details()
         bin_matches_file = self.load_bin(filename)
         self.mark_page_boundaries()
         flags_found = (
@@ -508,6 +511,9 @@ class File:
         if bookmarks := bin_dict.get(BINFILE_KEY_BOOKMARKS):
             for key, value in bookmarks.items():
                 self.set_bookmark_index(key, value)
+        image_rotations: Optional[dict[str, int]]
+        if image_rotations := bin_dict.get(BINFILE_KEY_IMAGEROTATE):
+            mainimage().rotation_details = image_rotations
 
         md5checksum = bin_dict.get(BINFILE_KEY_MD5CHECKSUM)
         return not md5checksum or md5checksum == self.get_md5_checksum()
@@ -529,6 +535,7 @@ class File:
             BINFILE_KEY_PROJECTID: self.project_id,
             BINFILE_KEY_LANGUAGES: self.languages,
             BINFILE_KEY_BOOKMARKS: self.get_bookmarks(),
+            BINFILE_KEY_IMAGEROTATE: mainimage().rotation_details,
         }
         return bin_dict
 


### PR DESCRIPTION
Adds a button to the image viewer control frame to rotate the image by 90º counter-clockwise. If an image has been rotated, the rotation will be stored in the JSON file to persist across restarts. Images that haven't been rotated aren't stored in this data and assumed to be rotated 0º.

Testing notes:
- Load a project with images
- Rotate some images however you like
- Navigate away and back again; the rotation should be remembered
- Save the file and restart; the rotations should be remembered
- Rotate more images, without saving, and try to close the file. It should ask you to save.

There's a new key in the JSON file called `imagerotate` that stores the data. By default, images aren't in this data. Once an image has been rotated, it gets added and tracked.

Fixes #953