### PR TITLE
Add regex timeout

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -544,6 +544,7 @@ class Guiguts:
         preferences.set_default(PrefKey.SURROUND_WITH_BEFORE_HISTORY, [])
         preferences.set_default(PrefKey.SURROUND_WITH_AFTER, "")
         preferences.set_default(PrefKey.SURROUND_WITH_AFTER_HISTORY, [])
+        preferences.set_default(PrefKey.REGEX_TIMEOUT, 5)
 
         # Check all preferences have a default
         for pref_key in PrefKey:

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -2643,7 +2643,21 @@ class MainText(tk.Text):
         if nocase:
             flags |= re.IGNORECASE
 
-        match = re.search(search_string, slurp_text, flags=flags)
+        try:
+            match = re.search(
+                search_string,
+                slurp_text,
+                flags=flags,
+                timeout=preferences.get(PrefKey.REGEX_TIMEOUT),
+            )
+        except TimeoutError:
+            logger.error(
+                "Regex timed out. Try changing the regex or flags;\n"
+                "or increase the timeout in the Preferences dialog, Advanced tab.\n\n"
+                "Search highlighting turned off temporarily."
+            )
+            self.highlight_search_deactivate()
+            return None, 0
         if match is None:
             return None, 0
 

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -362,12 +362,20 @@ class PreferencesDialog(ToplevelDialog):
             text="Show Tooltips",
             variable=PersistentBoolean(PrefKey.SHOW_TOOLTIPS),
         ).grid(column=0, row=5, sticky="NEW", pady=5)
+        add_label_spinbox(
+            advance_frame,
+            6,
+            "Regex timeout (seconds):",
+            PrefKey.REGEX_TIMEOUT,
+            "Longest time a regex search is allowed to take.\n"
+            "This can be increased, or the regex changed, if it keeps timing out.",
+        )
         ttk.Button(
             advance_frame,
             text="Reset shortcuts to default (change requires restart)",
             command=lambda: KeyboardShortcutsDict().reset(),
             takefocus=False,
-        ).grid(column=0, row=6, sticky="NSW", pady=5, columnspan=3)
+        ).grid(column=0, row=7, sticky="NSW", pady=5, columnspan=3)
 
         notebook.bind(
             "<<NotebookTabChanged>>",

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -141,6 +141,7 @@ class PrefKey(StrEnum):
     SURROUND_WITH_BEFORE_HISTORY = auto()
     SURROUND_WITH_AFTER = auto()
     SURROUND_WITH_AFTER_HISTORY = auto()
+    REGEX_TIMEOUT = auto()
 
 
 class Preferences:


### PR DESCRIPTION
Some regexes can take effectively for ever, so add a timeout, settable via an advanced Pref.

If regex times out during search, disable highlighting of search string temporarily, or it will keep trying to repeat the failing search.

Error message may appear twice, once for the search and once for the highlighting. I think this is an
acceptable price to pay - alternatives such as setting a flag telling searches to be ignored would run a
risk of breaking things. This is to fix a very rare occurrence in a way that doesn't risk breaking
other user searches or intra-code searching.