### PR TITLE
Fix column select exception

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -2016,8 +2016,14 @@ class MainText(tk.Text):
         Args:
             event: Event containing mouse coordinates.
         """
-        anchor_rowcol = self.rowcol(TK_ANCHOR_MARK)
         cur_rowcol = self.rowcol(f"@{event.x},{event.y}")
+        # In case we get here without ever having clicked (can happen if user tries
+        # to extend column selection as first action this run of the program)
+        try:
+            anchor_rowcol = self.rowcol(TK_ANCHOR_MARK)
+        except tk.TclError:
+            anchor_rowcol = cur_rowcol
+            self.mark_set(TK_ANCHOR_MARK, cur_rowcol.index())  # Reasonable fallback
         # Find longest visible line between start of selection and current mouse location
         minrow = min(anchor_rowcol.row, cur_rowcol.row)
         # No point starting before first line of screen


### PR DESCRIPTION
If user tries to extend column selection using
Shift+Alt+click & drag (Shift+Cmd[**Option] on Mac) as the
first action after starting the program, the `tk::anchor1` mark was unset, causing an exception.

Doesn't make sense for user to do that, but we don't want exceptions.

Fixes #982 

Testing notes:
Contrary to initial report in #982, it's not plain column select, but Shift+column select that causes the exception.