### PR TITLE
Improvements to Stealth Scannos

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -82,6 +82,7 @@ from guiguts.misc_tools import (
     convert_to_curly_quotes,
     check_curly_quotes,
     indent_selection,
+    ScannoCheckerDialog,
 )
 from guiguts.page_details import PageDetailsDialog
 from guiguts.preferences import preferences, PrefKey, PersistentBoolean
@@ -1104,6 +1105,7 @@ class Guiguts:
         PreferencesDialog.add_orphan_commands()
         CommandPaletteDialog.add_orphan_commands()
         SearchDialog.add_orphan_commands()
+        ScannoCheckerDialog.add_orphan_commands()
         mainimage().add_orphan_commands()
         menubar_metadata().add_button_orphan(
             "Quit Without Saving File", lambda: root().quit()

--- a/src/guiguts/data/scannos/regex.json
+++ b/src/guiguts/data/scannos/regex.json
@@ -106,27 +106,27 @@
 "hint": "Find repeated words or word sequences and remove one"
 },
 {
-"match": "\\bhl",
+"match": "\\bhl(?=\\w)",
 "replacement": "bl",
 "hint": "Find a string that starts with hl and change it to bl"
 },
 {
-"match": "\\bhr",
+"match": "\\bhr(?=\\w)",
 "replacement": "br",
 "hint": "Find a string that starts with hr and change it to br"
 },
 {
-"match": "\\brn",
+"match": "\\brn(?=\\w)",
 "replacement": "m",
 "hint": "Find a string that starts with rn and change it to m"
 },
 {
-"match": "\\btb",
+"match": "\\btb(?=\\w)",
 "replacement": "th",
 "hint": "Find a string that starts with tb and change it to th"
 },
 {
-"match": "\\btli",
+"match": "\\btli(?=\\w)",
 "replacement": "th",
 "hint": "Find a string that starts with tli and change it to th"
 },

--- a/src/guiguts/data/scannos/regex.json
+++ b/src/guiguts/data/scannos/regex.json
@@ -201,7 +201,7 @@
 "hint": "Find a word that contains rnb, rnm or rnp and change it to mb, mm or mp, respectively"
 },
 {
-"match": "tb",
+"match": "(?<=\\w)tb|tb(?=\\w)",
 "replacement": "th",
 "hint": "Find a word that contains tb and change it to th"
 },

--- a/src/guiguts/data/scannos/regex.json
+++ b/src/guiguts/data/scannos/regex.json
@@ -31,9 +31,9 @@
 "hint": "Find character strings that end with j and change the j to a semicolon"
 },
 {
-"match": "([^gG])uess",
+"match": "([^gGq])uess",
 "replacement": "\\1ness",
-"hint": "Find the string 'uess' not preceded by a g and change it to 'ness'"
+"hint": "Find the string 'uess' not preceded by a g or q and change it to 'ness'"
 },
 {
 "match": "([abimou])hl([ie])",
@@ -49,6 +49,11 @@
 "match": "(\\b[A-Z])\\. ([A-Z])\\.",
 "replacement": "\\1.\\2.",
 "hint": "Find initials with a space between them and remove the space"
+},
+{
+"match": "(\\b[A-Z])\\.([A-Z])\\.",
+"replacement": "\\1. \\2.",
+"hint": "Find initials without a space between them and add the space"
 },
 {
 "match": ",(\"?\\n *\"?\\p{Upper})",
@@ -86,14 +91,14 @@
 "hint": "Find a period with the following word starting with a lower case character and change the period to a comma"
 },
 {
-"match": "\\.( \\p{IsLower})",
+"match": "(?<!\\.\\.)\\.( \\p{IsLower})",
 "replacement": ",\\1",
 "hint": "Find a period followed by a space and a lower-case letter and replace it with a comma"
 },
 {
-"match": "\\Bii",
+"match": "(?<=[aeou])ii",
 "replacement": "ll",
-"hint": "Find the string ii not at the beginning of a word and change it to ll"
+"hint": "Find the string ii preceded by a vowel and change it to ll"
 },
 {
 "match": "\\b([csw])li([aeiou])",
@@ -161,7 +166,7 @@
 "hint": "Find long lines in the text"
 },
 {
-"match": "^[!;:,.?]",
+"match": "^(?!\\.\\.\\.)[!;:,.?]",
 "replacement": "",
 "hint": "Find a line that starts with punctuation and remove the punctuation"
 },
@@ -209,11 +214,6 @@
 "match": "tli",
 "replacement": "th",
 "hint": "Find a word that contains tli and change it to th"
-},
-{
-"match": "uess\\b",
-"replacement": "ness",
-"hint": "Find a word that ends with uess and change it to ness"
 },
 {
 "match": "v(?<!\\p{Alpha})",

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -1574,6 +1574,8 @@ class ScannoCheckerDialog(CheckerDialog):
                     "Right click: Hide occurrence of scanno in list",
                     f"{cmd_ctrl_string()} left click: Fix this occurrence of scanno",
                     f"{cmd_ctrl_string()} right click: Fix this occurrence and remove from list",
+                    f"Shift {cmd_ctrl_string()} left click: Fix all occurrences of scanno",
+                    f"Shift {cmd_ctrl_string()} right click: Fix all occurrences and remove from list",
                 ]
             ),
             **kwargs,

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -19,7 +19,7 @@ from guiguts.checkers import (
 )
 from guiguts.data import scannos
 from guiguts.file import the_file
-from guiguts.maintext import maintext
+from guiguts.maintext import maintext, menubar_metadata
 from guiguts.preferences import (
     PrefKey,
     PersistentString,
@@ -1670,6 +1670,33 @@ class ScannoCheckerDialog(CheckerDialog):
         self.scanno_list: list[Scanno] = []
         self.whole_word = False
         self.scanno_number = 0
+
+    @classmethod
+    def add_orphan_commands(cls) -> None:
+        """Add orphan commands to command palette."""
+
+        menubar_metadata().add_checkbutton_orphan(
+            "Stealth Scannos, Auto Advance", PrefKey.SCANNOS_AUTO_ADVANCE
+        )
+        menubar_metadata().add_button_orphan(
+            "Stealth Scannos, Previous Scanno",
+            cls.orphan_wrapper("prev_next_scanno", prev=True),
+        )
+        menubar_metadata().add_button_orphan(
+            "Stealth Scannos, Next Scanno",
+            cls.orphan_wrapper("prev_next_scanno", prev=False),
+        )
+        menubar_metadata().add_button_orphan(
+            "Stealth Scannos, Swap Terms", cls.orphan_wrapper("swap_terms")
+        )
+        menubar_metadata().add_button_orphan(
+            "Stealth Scannos, Replace",
+            cls.orphan_wrapper("process_entry_current", all_matching=False),
+        )
+        menubar_metadata().add_button_orphan(
+            "Stealth Scannos, Replace All",
+            cls.orphan_wrapper("process_entry_current", all_matching=True),
+        )
 
     def choose_file(self) -> None:
         """Choose & load a scannos file."""


### PR DESCRIPTION
1. Five scannos with hints "Find a string that starts with xx and change it to yy" are better with a lookahead to check there is a character after it. This stops them matching "tb" (thought break) or "hr" (horizontal rule).
2. Scannos dialog tooltip now includes "Shift" actions
3. Various "Stealth Scannos" shadow commands added, including Replace, Replace All, Prev Scanno, Next Scanno.
4. "guess" exception extended to  include "(mar)quess"
5. Punct at start of line no longer triggered by ellipsis
6. "ii" now only suspected "ll" if preceded by a, e, o, u.
7. Ellipsis followed by lower case no longer reported