### PR TITLE
Add Commonly Used Chars to Unicode menu

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -882,7 +882,13 @@ class Guiguts:
         unicode_menu.add_button(
             "Unicode ~Search/Entry", UnicodeSearchDialog.show_dialog
         )
-        unicode_menu.add_button("Unicode ~Blocks", UnicodeBlockDialog.show_dialog)
+        unicode_menu.add_button(
+            "Unicode ~Blocks", UnicodeBlockDialog.show_unicode_dialog
+        )
+        unicode_menu.add_button(
+            "C~ommonly Used Characters",
+            UnicodeBlockDialog.show_common_dialog,
+        )
         unicode_menu.add_button(
             "~Normalize Selected Characters",
             unicode_normalize,
@@ -1240,10 +1246,18 @@ class Guiguts:
 
         the_statusbar.add(
             "ordinal",
-            tooltip="Character after the cursor\nClick to toggle name display",
+            tooltip="Character after the cursor\nClick to toggle name display\n"
+            "Shift left click to show Commonly Used Characters dialog\n"
+            "Shift right click to show Unicode Blocks dialog",
             update=ordinal_str,
         )
         the_statusbar.add_binding("ordinal", "ButtonRelease-1", ordinal_name_display)
+        the_statusbar.add_binding(
+            "ordinal", "Shift-ButtonRelease-1", UnicodeBlockDialog.show_common_dialog
+        )
+        the_statusbar.add_binding(
+            "ordinal", "Shift-ButtonRelease-3", UnicodeBlockDialog.show_unicode_dialog
+        )
 
     def logging_init(self) -> None:
         """Set up basic logger until GUI is ready."""

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -1292,7 +1292,7 @@ class StatusBar(ttk.Frame):
                 self.set(key, func())
         self.after(200, self._update)
 
-    def add_binding(self, key: str, event: str, callback: Callable[[], None]) -> None:
+    def add_binding(self, key: str, event: str, callback: Callable[[], Any]) -> None:
         """Add an action to be executed when the given event occurs
 
         Args:

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -171,7 +171,7 @@ class ToplevelDialog(tk.Toplevel):
 
     def register_tooltip(self, tooltip: "ToolTip") -> None:
         """Register a tooltip as being attached to a widget in this
-        TopleveDialog so it can be destroyed when the dialog is destroyed.
+        ToplevelDialog so it can be destroyed when the dialog is destroyed.
 
         Args:
             tooltip - the ToolTip widget to register"""


### PR DESCRIPTION
It's really the Unicode Block dialog, but with the dropdown block selection set to Commonly Used
Chars.

If you change blocks, it will be stored in the pref, and when you next do Unicode Block, it will show
that block, but if you do Common Chars, it will
force to that. If you change the block to be
Common Chars, that will be stored in the pref,
and that's what you'll get next time you do pop
Unicode Block.

Also added Shift left/right click to status bar, where the character name is shown - instructions in tooltip.

Fixes #975 