### PR TITLE
Investigate tk9 Mac scroll

### DIFF
--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -822,6 +822,13 @@ class MainImage(tk.Frame):
             _, cm = process_accel("Cmd/Ctrl+MouseWheel")
             self.canvas.bind(cm, self.wheel_zoom)
             self.canvas.bind("<MouseWheel>", self.wheel_scroll)
+            try:
+                self.canvas.bind(
+                    "<TouchpadScroll>",
+                    lambda e: print(f"Touchpad: {e.delta}", flush=True),
+                )
+            except tk.TclError:
+                print("Failed to bind TouchpadScroll", flush=True)
 
         self.image_scale = float(preferences.get(PrefKey.IMAGE_SCALE_FACTOR))
         self.scale_delta = 1.1
@@ -1044,6 +1051,7 @@ class MainImage(tk.Frame):
 
     def wheel_scroll(self, evt: tk.Event) -> None:
         """Scroll image up/down using mouse wheel"""
+        print(f"delta: {evt.delta}", flush=True)
         if evt.state == 0:
             if is_mac():
                 self.canvas.yview_scroll(int(-1 * evt.delta), "units")

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -1075,7 +1075,7 @@ class MainImage(tk.Frame):
             return
         absy = abs(yscr)
         absx = abs(xscr)
-        wiggle_tolerance = 1
+        wiggle_tolerance = 2
         # To try to avoid slight wiggling while attempting unidirectional scroll,
         # only scroll bidirectionally if lesser change is more than wiggle_tolerance.
         # Also scroll bidirectionally if x & y change equal

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -1063,8 +1063,12 @@ class MainImage(tk.Frame):
 
     def touchpad_scroll(self, evt: tk.Event) -> None:
         """Scroll image using touchpad."""
-        xscr = (evt.delta >> 16) & 0xFFFF
-        yscr = evt.delta & 0xFFFF
+
+        def to_signed_16(n: int) -> int:
+            return n if n < 0x8000 else n - 0x10000
+
+        xscr = to_signed_16((evt.delta >> 16) & 0xFFFF)
+        yscr = to_signed_16(evt.delta & 0xFFFF)
         print(f"Touchpad X:{xscr} Y:{yscr}", flush=True)
         self.canvas.xview_scroll(-xscr, "units")
         self.canvas.yview_scroll(-yscr, "units")

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -1069,9 +1069,16 @@ class MainImage(tk.Frame):
 
         xscr = to_signed_16((evt.delta >> 16) & 0xFFFF)
         yscr = to_signed_16(evt.delta & 0xFFFF)
-        print(f"Touchpad X:{xscr} Y:{yscr}", flush=True)
-        self.canvas.xview_scroll(-xscr, "units")
-        self.canvas.yview_scroll(-yscr, "units")
+        print(f"Touchpad X:{xscr} Y:{yscr} Serial:{evt.serial}", flush=True)
+        # Only act on the given fraction of events
+        scroll_rate_numerator = 1
+        scroll_rate_denominator = 2
+        if evt.serial % scroll_rate_denominator >= scroll_rate_numerator:
+            return
+        if evt.state == 1:
+            self.canvas.xview_scroll(-xscr, "units")
+        else:
+            self.canvas.yview_scroll(-yscr, "units")
 
     def load_image(self, filename: Optional[str] = None) -> bool:
         """Load or clear the given image file.


### PR DESCRIPTION
Testing notes:

In Tk8, you should see a debug print "Failed to bind TouchpadScroll". It would be interesting to know if Tk9 gives the same message.

In Tk8 and Tk9, attempt to scroll the minimum amount in the image viewer, using the mousewheel.
You should see a debug print `delta: <nn>` in the shell window. When I scroll the mouse wheel one notch, I get a delta of +/- 120.
In Tk8, I think you should get a delta of +/- 1.
It would be interesting to know what Tk9 gives.

It's possible that using touchpad scrolling will give lots of messages `Touchpad: <nn>`. Again, it would be interesting to know what happens there. I wouldn't expect the touchpad to do any scrolling, just output debug messages at the moment.