### PR TITLE
Add user-defined prefsfile name

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -195,6 +195,11 @@ class Guiguts:
             help="Number of 'Recent File' to be loaded: 1 is most recent",
         )
         parser.add_argument(
+            "-p",
+            "--prefsfile",
+            help="Basename of prefs file (default `GGprefs`)",
+        )
+        parser.add_argument(
             "-d",
             "--debug",
             action="store_true",
@@ -554,7 +559,7 @@ class Guiguts:
 
         # If `--nohome` argument given, Prefs are not loaded & saved in Prefs file
         preferences.set_permanent(not self.args.nohome)
-        preferences.load()
+        preferences.load(self.args.prefsfile)
 
     # Lay out menus
     def init_menus(self) -> None:


### PR DESCRIPTION
Arguments `-p` or `--prefsfile` can be used to provide a basename in place of the default `GGprefs`.

Example, to use `myprefs.json` instead of `GGprefs.json`. `guiguts -p myprefs`
`guiguts -pmyprefs`
`guiguts --prefsfile myprefs`

Dedicated to testers everywhere