### PR TITLE
Fix tabbing through statusbar/image viewer

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -956,7 +956,7 @@ class Guiguts:
         )
         view_menu.add_separator()
         view_menu.add_checkbutton(
-            "Image Viewer",
+            "Image ~Viewer",
             PrefKey.IMAGE_VIEWER_INTERNAL,
             self.show_image_viewer,
             self.hide_image_viewer,
@@ -1145,6 +1145,7 @@ class Guiguts:
             StatusBar.SHIFT_BTN_3,
             lambda: preferences.toggle(PrefKey.COLUMN_NUMBERS),
         )
+        the_statusbar.set_first_tab_behavior("rowcol")
 
         the_statusbar.add(
             "img",
@@ -1270,6 +1271,9 @@ class Guiguts:
         )
         the_statusbar.add_binding(
             "ordinal", StatusBar.SHIFT_BTN_3, UnicodeBlockDialog.show_unicode_dialog
+        )
+        the_statusbar.set_last_tab_behavior(
+            "ordinal", self.mainwindow.mainimage.prev_img_button
         )
 
     def logging_init(self) -> None:

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -27,8 +27,6 @@ from guiguts.widgets import (
     register_focus_widget,
     grab_focus,
     bind_mouse_wheel,
-    focus_next_widget,
-    focus_prev_widget,
 )
 
 logger = logging.getLogger(__package__)
@@ -856,10 +854,6 @@ class MainText(tk.Text):
         register_focus_widget(self.peer)
 
         self.paned_text_window.add(maintext().frame, minsize=PEER_MIN_SIZE)
-
-        # By default Tab is accepted by text widget, but we want it to move focus
-        self.bind_event("<Tab>", focus_next_widget, bind_peer=True)
-        self.bind_event("<Shift-Tab>", focus_prev_widget, bind_peer=True)
 
         # Column selection uses Alt key on Windows/Linux, Option key on macOS
         # Key Release is reported as Alt_L on all platforms


### PR DESCRIPTION
Fixes #1026

The order is main text, peer window (if visible), status bar, image viewer (if visible and docked), back to main text. If image viewer is floating, it is not included in the tab loop from the main window, but has its own tab loop. You need to Ctrl/Cmd+tab or click in the image viewer to get focus in the window, then tabbing will just cycle through the image viewer buttons. In short, the floating image viewer should behave like a dialog as far as tabbing is concerned.

Testing notes - there are 6 cases to test:
1. No split text or image viewer
2. Just split text
3. Just docked image viewer
4. Just undocked image viewer
5. Split text and docked image viewer 6 Split text and undocked image viewer

Transition between regions is the most likely place for things to go wrong, e.g. at beginning/end of
status bar, or beginning/end of image viewer.