### PR TITLE
Make Treeview keyboard navigation consistent

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1094,7 +1094,7 @@ class MainText(tk.Text):
         self.after_idle(lambda: grab_focus(self.root, self, True))
 
         # Whether we were on dark theme the last time we looked (bool)
-        self.dark_theme = self.is_dark_theme()
+        self.dark_theme = themed_style().is_dark_theme()
 
         # Initialize highlighting tags
         self.after_idle(lambda: self.highlight_configure_tags(first_run=True))
@@ -3339,12 +3339,6 @@ class MainText(tk.Text):
         if ontime != current:
             self.focus_widget().configure(insertontime=ontime)
 
-    def is_dark_theme(self) -> bool:
-        """Returns True if theme is set to awdark."""
-        if themed_style().theme_use() == "awdark":
-            return True
-        return False
-
     def _highlight_configure_tag(
         self, tag_name: str, tag_colors: dict[str, dict[str, str]]
     ) -> None:
@@ -3873,7 +3867,7 @@ class MainText(tk.Text):
         """
         colors_need_update = False
         order_needs_update = False
-        dark_theme = self.is_dark_theme()
+        dark_theme = themed_style().is_dark_theme()
 
         if first_run:
             colors_need_update = True

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -1039,7 +1039,7 @@ class MainImage(tk.Frame):
             size=(scaled_width, scaled_height), resample=Image.Resampling.LANCZOS
         )
         if not preferences.get(PrefKey.HIGH_CONTRAST):
-            alpha_value = 180 if maintext().is_dark_theme() else 200
+            alpha_value = 180 if themed_style().is_dark_theme() else 200
             image.putalpha(alpha_value)  # Adjust contrast using transparency
         self.imagetk = ImageTk.PhotoImage(image)
         if self.imageid:

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -38,6 +38,7 @@ from guiguts.widgets import (
     focus_next_widget,
     focus_prev_widget,
     ThemedStyle,
+    TreeviewList,
 )
 
 logger = logging.getLogger(__package__)
@@ -250,11 +251,9 @@ class CustomMenuDialog(ToplevelDialog):
         treeview_frame.grid(row=0, column=0, pady=5, padx=5, sticky="NSEW")
 
         # Treeview setup with scrollbar
-        self.list = ttk.Treeview(
+        self.list = TreeviewList(
             treeview_frame,
             columns=("Label", "Command"),
-            show="headings",
-            selectmode=tk.BROWSE,
         )
         self.list.heading("Label", text="Label")
         self.list.column("Label", minwidth=10, width=200)
@@ -357,6 +356,7 @@ e.g. $(s+5) would give 12 for the 5th png.
         self.list.bind("<Down>", lambda _: self.change_selection(1))
         self.list.bind("<Up>", lambda _: self.change_selection(-1))
         self.save_and_refresh()
+        self.list.focus_force()
 
     @classmethod
     def rewrite_custom_menu(cls, menu: MenuMetadata) -> None:
@@ -503,7 +503,7 @@ e.g. $(s+5) would give 12 for the 5th png.
                 self.menu_entries[index],
             )
             self.save_and_refresh()
-            self.select_and_focus(self.list.get_children()[index + direction])
+            self.list.select_and_focus_by_index(index + direction)
 
     def save_and_refresh(self) -> None:
         """Save entries in Prefs, reconfigure the Custom menu, and
@@ -520,8 +520,7 @@ e.g. $(s+5) would give 12 for the 5th png.
         if sel_index >= len(self.menu_entries):
             sel_index = len(self.menu_entries) - 1
         if sel_index >= 0:
-            iid = self.list.get_children()[sel_index]
-            self.select_and_focus(iid)
+            self.list.select_and_focus_by_index(sel_index)
 
         # Save to prefs file
         preferences.set(PrefKey.CUSTOM_MENU_ENTRIES, self.menu_entries)
@@ -530,18 +529,6 @@ e.g. $(s+5) would give 12 for the 5th png.
         self.rewrite_custom_menu(self.menu)
         assert CustomMenuDialog.recreate_menus_callback is not None
         CustomMenuDialog.recreate_menus_callback()  # pylint: disable=not-callable
-
-    def select_and_focus(self, item: str) -> None:
-        """Select and set focus to the given item. See page_details for
-        description of the need for this.
-
-        Args:
-            item: The item to be selected/focused.
-        """
-        self.list.focus_set()
-        self.list.selection_set(item)
-        self.list.focus(item)
-        self.list.see(item)
 
     def change_selection(self, direction: int) -> str:
         """Change which is the selected entry in the list.
@@ -555,7 +542,7 @@ e.g. $(s+5) would give 12 for the 5th png.
             current_index = self.list.index(current_selection[0])
             new_index = current_index + direction
             if 0 <= new_index < list_len:
-                self.select_and_focus(self.list.get_children()[new_index])
+                self.list.select_and_focus_by_index(new_index)
         return "break"
 
     def add_entry(self) -> None:

--- a/src/guiguts/page_details.py
+++ b/src/guiguts/page_details.py
@@ -129,7 +129,7 @@ class PageDetailsDialog(OkApplyCancelDialog):
                 [
                     "Click in style column (or press Return) to cycle Arabic/Roman/Ditto",
                     f"Click in number column (or press {cmd_ctrl_string()}+Return) to cycle +1/No Count/Set Number",
-                    f"Press Shift with above actions to cycle in reverse order",
+                    "Press Shift with above actions to cycle in reverse order",
                 ]
             ),
             use_pointer_pos=True,

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -25,6 +25,7 @@ from guiguts.widgets import (
     mouse_bind,
     register_focus_widget,
     Busy,
+    themed_style,
 )
 
 logger = logging.getLogger(__package__)
@@ -141,7 +142,7 @@ class SearchDialog(ToplevelDialog):
 
         # Search
         style = ttk.Style()
-        new_col = "#ff8080" if maintext().is_dark_theme() else "#e60000"
+        new_col = "#ff8080" if themed_style().is_dark_theme() else "#e60000"
         style.configure("BadRegex.TCombobox", foreground=new_col)
 
         self.font = tk_font.Font(

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -628,7 +628,22 @@ class TreeviewList(ttk.Treeview):
         if "height" not in kwargs:
             kwargs["height"] = 10
         kwargs["selectmode"] = tk.BROWSE
-        super().__init__(parent, *args, **kwargs)
+
+        # Use background color of selected row as the focus border color
+        bg_color = themed_style().lookup(
+            "Treeview", "background", ("selected", "focus")
+        )
+        # Fallback blues in case the above fails with some themes
+        # Fallbacks are based on awdark/light selected row background colors
+        if not bg_color:
+            bg_color = "#215d9c" if themed_style().is_dark_theme() else "#1a497c"
+        themed_style().map(
+            "Custom.Treeview",
+            bordercolor=[("focus", bg_color)],
+            relief=[("focus", "solid")],
+        )
+
+        super().__init__(parent, style="Custom.Treeview", *args, **kwargs)
         self.bind("<Home>", lambda _e: self.select_and_focus_by_index(0))
         self.bind("<End>", lambda _e: self.select_and_focus_by_index(-1))
         if is_mac():
@@ -959,6 +974,12 @@ class ThemedStyle(ttk.Style):
             return self.tk.call(self._name, "theme", "use")  # type:ignore[attr-defined]
         super().theme_use(themename)
         return None
+
+    def is_dark_theme(self) -> bool:
+        """Returns True if theme is set to awdark."""
+        if self.theme_use() == "awdark":
+            return True
+        return False
 
 
 def themed_style(style: Optional[ThemedStyle] = None) -> ThemedStyle:


### PR DESCRIPTION
1. Home (Cmd+Up) to go to top
2. End (Cmd+Down) to go to bottom
3. Return to "execute" (where appropriate)
4. Shift/Ctrl/Return for alternative execution
5. Tooltips describe possibilities for each Treeview

Treeviews affected:
Custom Menu, Customize dialog;
Page Details (Shift-click Lbl in status bar)
Tools Unicode Search dialog
Command Palette
Help Compose Key Sequences

Fixes #1020