### PR TITLE
Make WF ignore certain ppgen source lines

### DIFF
--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -40,6 +40,7 @@ _THE_WORD_LISTS = None
 
 RETURN_ARROW = "⏎"
 MARKUP_TYPES = "i|b|sc|f|g|u|cite|em|strong"
+PPGEN_IGNORE_REGEX = r"\.pn |\.bn |//"  # page number, binfile, comment
 
 
 class WFDisplayType(StrEnum):
@@ -95,7 +96,9 @@ class WFWordLists:
         if self.all_words:
             return
         for line, _ in maintext().get_lines():
-            if re.search(PAGE_SEPARATOR_REGEX, line):
+            if re.search(PAGE_SEPARATOR_REGEX, line) or re.match(
+                PPGEN_IGNORE_REGEX, line
+            ):
                 continue
             if preferences.get(PrefKey.WFDIALOG_IGNORE_CASE):
                 line = line.lower()


### PR DESCRIPTION
Word Frequency now ignores lines that begin with
`.bn ` (bin file command)
`.pn ` (page number command)
`//` (comment)

Fixes #1030