### PR TITLE
Improve keyboard support for "Apply"

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -1111,6 +1111,7 @@ class Guiguts:
         CommandPaletteDialog.add_orphan_commands()
         SearchDialog.add_orphan_commands()
         ScannoCheckerDialog.add_orphan_commands()
+        SurroundWithDialog.add_orphan_commands()
         mainimage().add_orphan_commands()
         menubar_metadata().add_button_orphan(
             "Quit Without Saving File", lambda: root().quit()

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -1583,6 +1583,15 @@ class SurroundWithDialog(OkApplyCancelDialog):
         self.after_entry.grid(row=1, column=2)
         ToolTip(self.after_entry, r'Use "\n" for newline')
 
+    @classmethod
+    def add_orphan_commands(cls) -> None:
+        """Add orphan commands to surround with dialog."""
+
+        menubar_metadata().add_button_orphan(
+            "Surround Selection With, Apply",
+            cls.orphan_wrapper("apply_changes"),
+        )
+
     def apply_changes(self) -> bool:
         """Overridden method to apply surrounding text."""
         maintext().undo_block_begin()

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -381,6 +381,7 @@ class OkApplyCancelDialog(ToplevelDialog):
             default="active",
             command=self.ok_pressed,
         ).grid(row=0, column=column, padx=5)
+        self.bind("<Return>", lambda event: self.ok_pressed())
         if display_apply:
             column += 1
             ttk.Button(
@@ -389,6 +390,7 @@ class OkApplyCancelDialog(ToplevelDialog):
                 default="normal",
                 command=self.apply_changes,
             ).grid(row=0, column=column, padx=5)
+            self.bind("<Shift-Return>", lambda event: self.apply_changes())
         column += 1
         ttk.Button(
             button_frame,
@@ -396,7 +398,6 @@ class OkApplyCancelDialog(ToplevelDialog):
             default="normal",
             command=self.cancel_pressed,
         ).grid(row=0, column=column, padx=5)
-        self.bind("<Return>", lambda event: self.ok_pressed())
         self.bind("<Escape>", lambda event: self.cancel_pressed())
 
     def apply_changes(self) -> bool:


### PR DESCRIPTION
Bind "Shift+Return" to "Apply" button in an
Ok, Apply, Cancel dialog, in the same way as "Return" activates the "OK" button, and "Escape" activates
the "Cancel" button.

Also, add "Apply" in Surround Selection With" as a shadow command, so it can be activated when the
dialog doesn't have focus (because user has just
selected the text they want to surround).
This latter bit fixes #1007