### PR TITLE
Add shadow commands for image zoom

### DIFF
--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -879,6 +879,9 @@ class MainImage(tk.Frame):
             "Image Zoom In", lambda: self.image_zoom(zoom_in=True), "Cmd/Ctrl+plus"
         )
         menubar_metadata().add_button_orphan(
+            "Image Zoom In ", lambda: self.image_zoom(zoom_in=True), "Cmd/Ctrl+equal"
+        )
+        menubar_metadata().add_button_orphan(
             "Image Zoom Out", lambda: self.image_zoom(zoom_in=False), "Cmd/Ctrl+minus"
         )
         menubar_metadata().add_button_orphan(

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -802,17 +802,6 @@ class MainImage(tk.Frame):
         maintext().peer.bind("<Tab>", focus_next_widget)
         maintext().peer.bind("<Shift-Tab>", peer_reverse_tab)
 
-        # Separate bindings needed for docked (root) and floated (self) states
-        for widget in (root(), self):
-            _, cp = process_accel("Cmd/Ctrl+plus")
-            _, ce = process_accel("Cmd/Ctrl+equal")
-            _, cm = process_accel("Cmd/Ctrl+minus")
-            _, c0 = process_accel("Cmd/Ctrl+0")
-            widget.bind(cp, lambda _: self.image_zoom(zoom_in=True))
-            widget.bind(ce, lambda _: self.image_zoom(zoom_in=True))
-            widget.bind(cm, lambda _: self.image_zoom(zoom_in=False))
-            widget.bind(c0, lambda _: self.image_zoom_to_height(disable_autofit=True))
-
         self.hbar = ttk.Scrollbar(top_frame, orient=tk.HORIZONTAL)
         self.hbar.grid(row=3, column=0, sticky="EW")
         self.hbar.configure(command=self.scroll_x)
@@ -864,26 +853,38 @@ class MainImage(tk.Frame):
     def add_orphan_commands(self) -> None:
         """Add orphan (i.e. not in menu) commands to command palette."""
         menubar_metadata().add_checkbutton_orphan(
-            "Image Fit ←→", PrefKey.IMAGE_AUTOFIT_WIDTH
+            "Image AutoFit ←→", PrefKey.IMAGE_AUTOFIT_WIDTH
         )
         menubar_metadata().add_checkbutton_orphan(
-            "Image Fit ↑↓", PrefKey.IMAGE_AUTOFIT_HEIGHT
+            "Image AutoFit ↑↓",
+            PrefKey.IMAGE_AUTOFIT_HEIGHT,
         )
         menubar_metadata().add_button_orphan(
-            "Scroll Image ↑",
+            "Image Scroll ↑",
             lambda: self.canvas.yview_scroll(1, "units"),
         )
         menubar_metadata().add_button_orphan(
-            "Scroll Image ↓",
+            "Image Scroll ↓",
             lambda: self.canvas.yview_scroll(-1, "units"),
         )
         menubar_metadata().add_button_orphan(
-            "Scroll Image ←",
+            "Image Scroll ←",
             lambda: self.canvas.xview_scroll(1, "units"),
         )
         menubar_metadata().add_button_orphan(
-            "Scroll Image →",
+            "Image Scroll →",
             lambda: self.canvas.xview_scroll(-1, "units"),
+        )
+        menubar_metadata().add_button_orphan(
+            "Image Zoom In", lambda: self.image_zoom(zoom_in=True), "Cmd/Ctrl+plus"
+        )
+        menubar_metadata().add_button_orphan(
+            "Image Zoom Out", lambda: self.image_zoom(zoom_in=False), "Cmd/Ctrl+minus"
+        )
+        menubar_metadata().add_button_orphan(
+            "Image Fit ↑↓",
+            lambda: self.image_zoom_to_height(disable_autofit=True),
+            "Cmd/Ctrl+0",
         )
 
     def scroll_y(self, *args: Any, **kwargs: Any) -> None:

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -1001,6 +1001,9 @@ class CommandEditDialog(OkCancelDialog):
         "Option_R": "Option",
     }
 
+    # On macOS, "Cmd+-" or "Cmd+Key--" causes problems, so use name
+    KEY_NAMES = {"-": "minus"}
+
     def __init__(self, command_dlg: "CommandPaletteDialog") -> None:
         """Initialize the command edit window."""
         super().__init__(
@@ -1221,6 +1224,8 @@ class CommandEditDialog(OkCancelDialog):
         else:
             # Combine the current modifiers with the key
             mods = sorted(set(self.MODIFIER_KEYS[kk] for kk in self.pressed_modifiers))
+            # Substitute any keys that cause problems if just the key character is used
+            keysym = CommandEditDialog.KEY_NAMES.get(keysym, keysym)
             # Regular character key
             if len(keysym) == 1:
                 keysym = f"Key-{keysym.upper()}"


### PR DESCRIPTION
See all the "Image" shadows by typing "Image" into Command Palette.

This adds zoom in/out (Ctrl/Cmd-plus/minus) and
fit to height (but not autofit) (Ctrl/Cmd-zero).
Those were the default shortcuts we already had, but this adds them as shadow commands, so the user can reassign them.

Test in docked and undocked state, and when image
is not shown.