### PR TITLE
Alternative apply

### DIFF
--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -887,7 +887,7 @@ class ComposeHelpDialog(ToplevelDialog):
         )
         ToolTip(
             self.help,
-            "Click (or press Return) to insert character",
+            "Click (or press Space or Return) to insert character",
             use_pointer_pos=True,
         )
         for col, column in enumerate(self.column_headings):
@@ -913,6 +913,7 @@ class ComposeHelpDialog(ToplevelDialog):
 
         mouse_bind(self.help, "1", self.insert_char)
         self.bind("<Return>", lambda _: self.insert_char(None))
+        self.bind("<space>", lambda _: self.insert_char(None))
         self.help.focus_force()
 
         init_compose_dict()
@@ -1927,8 +1928,8 @@ class UnicodeSearchDialog(ToplevelDialog):
             self.list,
             "\n".join(
                 [
-                    f"Click in {UnicodeSearchDialog.CHAR_COL_HEAD},  {UnicodeSearchDialog.CODEPOINT_COL_HEAD} or {UnicodeSearchDialog.NAME_COL_HEAD} column (or press Return) to insert character",
-                    f"Click in {UnicodeSearchDialog.BLOCK_COL_HEAD} column (or press Shift+Return) to open Unicode Block dialog",
+                    f"Click in {UnicodeSearchDialog.CHAR_COL_HEAD},  {UnicodeSearchDialog.CODEPOINT_COL_HEAD} or {UnicodeSearchDialog.NAME_COL_HEAD} column (or press Space or Return) to insert character",
+                    f"Click in {UnicodeSearchDialog.BLOCK_COL_HEAD} column (or press Shift+Space or Shift+Return) to open Unicode Block dialog",
                     "(⚠\ufe0f before a character's name means it was added more recently - use with caution)",
                 ]
             ),
@@ -1956,7 +1957,9 @@ class UnicodeSearchDialog(ToplevelDialog):
         self.scrollbar.grid(row=1, column=1, sticky=tk.NS)
         mouse_bind(self.list, "1", self.item_clicked)
         self.list.bind("<Return>", self.insert_character)
+        self.list.bind("<space>", self.insert_character)
         self.list.bind("<Shift-Return>", self.open_block)
+        self.list.bind("<Shift-space>", self.open_block)
 
         char = maintext().selected_text()
         if len(char) == 1 and not char.isspace():

--- a/src/guiguts/page_details.py
+++ b/src/guiguts/page_details.py
@@ -195,6 +195,7 @@ class PageDetailsDialog(OkApplyCancelDialog):
                     break
 
         self.list.focus_set()
+        self.enable_ok_apply(False)
 
     def populate_list(self, details: PageDetails, see_index: int = 0) -> None:
         """Populate the page details list from the given details.
@@ -272,6 +273,7 @@ class PageDetailsDialog(OkApplyCancelDialog):
         self.populate_list(self.details, self.list.index(row_id))
         self.list.focus_force()
         self.changed = True
+        self.enable_ok_apply(True)
         return "break"
 
     def apply_changes(self) -> bool:
@@ -279,4 +281,5 @@ class PageDetailsDialog(OkApplyCancelDialog):
         if self.changed:
             self.master_details.copy_details_from(self.details)
             maintext().set_modified(True)
+            self.enable_ok_apply(False)
         return True

--- a/src/guiguts/page_details.py
+++ b/src/guiguts/page_details.py
@@ -127,8 +127,8 @@ class PageDetailsDialog(OkApplyCancelDialog):
             self.list,
             "\n".join(
                 [
-                    "Click in style column (or press Return) to cycle Arabic/Roman/Ditto",
-                    f"Click in number column (or press {cmd_ctrl_string()}+Return) to cycle +1/No Count/Set Number",
+                    "Click in style column (or press Space) to cycle Arabic/Roman/Ditto",
+                    f"Click in number column (or press {cmd_ctrl_string()}+Space) to cycle +1/No Count/Set Number",
                     "Press Shift with above actions to cycle in reverse order",
                 ]
             ),
@@ -151,17 +151,17 @@ class PageDetailsDialog(OkApplyCancelDialog):
             self.list, "Shift+1", lambda event: self.item_clicked(event, reverse=True)
         )
         self.list.bind(
-            "<Return>", lambda _: self.item_clicked(STYLE_COLUMN, reverse=False)
+            "<space>", lambda _: self.item_clicked(STYLE_COLUMN, reverse=False)
         )
         self.list.bind(
-            "<Shift-Return>", lambda _: self.item_clicked(STYLE_COLUMN, reverse=True)
+            "<Shift-space>", lambda _: self.item_clicked(STYLE_COLUMN, reverse=True)
         )
         self.list.bind(
-            process_accel("Cmd/Ctrl+Return")[1],
+            process_accel("Cmd/Ctrl+space")[1],
             lambda _: self.item_clicked(NUMBER_COLUMN, reverse=False),
         )
         self.list.bind(
-            process_accel("Cmd/Ctrl+Shift+Return")[1],
+            process_accel("Cmd/Ctrl+Shift+space")[1],
             lambda _: self.item_clicked(NUMBER_COLUMN, reverse=True),
         )
 

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -369,27 +369,30 @@ class OkApplyCancelDialog(ToplevelDialog):
             display_apply: Set to False if Apply button not required.
         """
         super().__init__(title, **kwargs)
+        self.display_apply = display_apply
         outer_button_frame = ttk.Frame(self, padding=5)
         outer_button_frame.grid(row=1, column=0, sticky="NSEW")
         outer_button_frame.columnconfigure(0, weight=1)
         button_frame = ttk.Frame(outer_button_frame)
         button_frame.grid(row=1, column=0)
         column = 0
-        ttk.Button(
+        self.ok_btn = ttk.Button(
             button_frame,
             text="OK",
             default="active",
             command=self.ok_pressed,
-        ).grid(row=0, column=column, padx=5)
+        )
+        self.ok_btn.grid(row=0, column=column, padx=5)
         self.bind("<Return>", lambda event: self.ok_pressed())
-        if display_apply:
+        if self.display_apply:
             column += 1
-            ttk.Button(
+            self.apply_btn = ttk.Button(
                 button_frame,
                 text="Apply",
                 default="normal",
                 command=self.apply_changes,
-            ).grid(row=0, column=column, padx=5)
+            )
+            self.apply_btn.grid(row=0, column=column, padx=5)
             self.bind("<Shift-Return>", lambda event: self.apply_changes())
         column += 1
         ttk.Button(
@@ -399,6 +402,12 @@ class OkApplyCancelDialog(ToplevelDialog):
             command=self.cancel_pressed,
         ).grid(row=0, column=column, padx=5)
         self.bind("<Escape>", lambda event: self.cancel_pressed())
+
+    def enable_ok_apply(self, enable: bool) -> None:
+        """Enable/disable the OK/Apply buttons."""
+        state = "normal" if enable else "disable"
+        self.ok_btn["state"] = state
+        self.apply_btn["state"] = state
 
     def apply_changes(self) -> bool:
         """Complete processing needed when Apply/OK are pressed, e.g. storing


### PR DESCRIPTION
Switch to space to activate some Treeviews

In Page Labels, use Space instead of Return.
In Unicode Search allow Space or Return.

Only enable Apply/OK in Page Labels when needed
