### PR TITLE
Allow Word Distance Check it ignore digit words

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -552,6 +552,7 @@ class Guiguts:
         preferences.set_default(PrefKey.SURROUND_WITH_AFTER, "")
         preferences.set_default(PrefKey.SURROUND_WITH_AFTER_HISTORY, [])
         preferences.set_default(PrefKey.REGEX_TIMEOUT, 5)
+        preferences.set_default(PrefKey.LEVENSHTEIN_DIGITS, True)
 
         # Check all preferences have a default
         for pref_key in PrefKey:

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -142,6 +142,7 @@ class PrefKey(StrEnum):
     SURROUND_WITH_AFTER = auto()
     SURROUND_WITH_AFTER_HISTORY = auto()
     REGEX_TIMEOUT = auto()
+    LEVENSHTEIN_DIGITS = auto()
 
 
 class Preferences:


### PR DESCRIPTION
Add checkbox to Word Distance Check dialog to control whether words that contain digits are included.

Fixes #985