### PR TITLE
Make main text menu Undo/Ctrl-Z refresh current separator in the Page Separator Fixup dialog

### DIFF
--- a/src/guiguts/ascii_tables.py
+++ b/src/guiguts/ascii_tables.py
@@ -139,8 +139,8 @@ class ASCIITableDialog(ToplevelDialog):
         """Initialize ASCII Table dialog."""
         super().__init__("ASCII Table Special Effects", resize_x=False, resize_y=False)
 
-        self.start_mark_name = ASCIITableDialog.get_mark_prefix() + "Start"
-        self.end_mark_name = ASCIITableDialog.get_mark_prefix() + "End"
+        self.start_mark_name = ASCIITableDialog.get_dlg_name() + "Start"
+        self.end_mark_name = ASCIITableDialog.get_dlg_name() + "End"
 
         self.selected_column = -1
 
@@ -450,7 +450,7 @@ class ASCIITableDialog(ToplevelDialog):
         )
         # Also, if user does undo/redo, we want to refresh the table display
         maintext().add_undo_redo_callback(
-            self.__class__.__name__, self.refresh_table_display
+            self.get_dlg_name(), self.refresh_table_display
         )
 
         self.selected_col_width_label = ttk.Label(adjust_col_row2_frame)
@@ -468,7 +468,7 @@ class ASCIITableDialog(ToplevelDialog):
             return
         self.table_deselect()
         self.refresh_table_display()
-        maintext().remove_undo_redo_callback(self.__class__.__name__)
+        maintext().remove_undo_redo_callback(self.get_dlg_name())
 
     def justify_update(self) -> None:
         """Update controls to be active/disabled depending on whether justify is on."""

--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -167,7 +167,7 @@ class FootnoteChecker:
         The mark will now be positioned before the blank line we just
         added.
         """
-        mark_prefix = self.checker_dialog.get_mark_prefix()
+        mark_prefix = self.checker_dialog.get_dlg_name()
         # Note the index of current end of file.
         old_end_of_file = maintext().end().index()
         blank_line_inserted = False
@@ -191,7 +191,7 @@ class FootnoteChecker:
 
     def change_gravity_right_to_left(self) -> None:
         """Change gravity of a FN-end Checker mark to tk.LEFT."""
-        mark_prefix = self.checker_dialog.get_mark_prefix()
+        mark_prefix = self.checker_dialog.get_dlg_name()
         fn_records = self.get_fn_records()
         for fn_record in fn_records:
             fn_cur_end = fn_record.end.index()
@@ -210,7 +210,7 @@ class FootnoteChecker:
 
     def change_gravity_left_to_right(self) -> None:
         """Change gravity of a FN-end Checker mark to tk.RIGHT."""
-        mark_prefix = self.checker_dialog.get_mark_prefix()
+        mark_prefix = self.checker_dialog.get_dlg_name()
         fn_records = self.get_fn_records()
         for fn_record in fn_records:
             fn_cur_end = fn_record.end.index()
@@ -829,7 +829,7 @@ def move_footnotes_to_paragraphs() -> None:
     # at the start of the Page Marker. Those two locations are the same.
 
     mark_prefix = (
-        _THE_FOOTNOTE_CHECKER.checker_dialog.get_mark_prefix() + INSERTION_MARK_PREFIX
+        _THE_FOOTNOTE_CHECKER.checker_dialog.get_dlg_name() + INSERTION_MARK_PREFIX
     )
     file_end = maintext().end().index()
     match_regex = r"^$"

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -1608,7 +1608,7 @@ class SurroundWithDialog(OkApplyCancelDialog):
             ranges = [
                 IndexRange(maintext().get_insert_index(), maintext().get_insert_index())
             ]
-        end_mark = self.get_mark_prefix() + "endpoint"
+        end_mark = self.get_dlg_name() + "endpoint"
         maintext().mark_set(end_mark, ranges[-1].end.index())
         before = preferences.get(PrefKey.SURROUND_WITH_BEFORE).replace(r"\n", "\n")
         after = preferences.get(PrefKey.SURROUND_WITH_AFTER).replace(r"\n", "\n")

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -109,7 +109,7 @@ class ToplevelDialog(tk.Toplevel):
     def __new__(cls, *args: Any, **kwargs: Any) -> "ToplevelDialog":
         """Ensure ToplevelDialogs are not instantiated directly."""
         if cls is ToplevelDialog:
-            raise TypeError(f"only children of '{cls.__name__}' may be instantiated")
+            raise NotImplementedError
         return object.__new__(cls)
 
     @classmethod
@@ -124,7 +124,7 @@ class ToplevelDialog(tk.Toplevel):
             kwargs: Optional kwargs to pass to dialog constructor.
         """
         # If dialog already exists, deiconify it
-        dlg_name = cls.__name__
+        dlg_name = cls.get_dlg_name()
         # Can we just deiconify dialog & reset it?
         if dlg := cls.get_dialog():
             dlg.deiconify()
@@ -143,7 +143,7 @@ class ToplevelDialog(tk.Toplevel):
         Returns:
             The one instance of this dialog type, or None if it's not currently shown.
         """
-        dlg_name = cls.__name__
+        dlg_name = cls.get_dlg_name()
         if (
             dlg_name in ToplevelDialog._toplevel_dialogs
             and ToplevelDialog._toplevel_dialogs[dlg_name].winfo_exists()
@@ -152,10 +152,9 @@ class ToplevelDialog(tk.Toplevel):
         return None
 
     @classmethod
-    def get_mark_prefix(cls) -> str:
-        """Use reduced dialog name for common part of mark names.
-        This ensures each dialog uses unique mark names and does not clash
-        with another dialog.
+    def get_dlg_name(cls) -> str:
+        """Get reduced dialog name where a unique identifier for a dialog type is needed,
+        such as prefix for mark names, keys in dictionaries, etc.
         """
         return cls.__name__.removesuffix("Dialog")
 
@@ -309,7 +308,7 @@ class ToplevelDialog(tk.Toplevel):
             value: New value for preference.
         """
         config_dict = preferences.get(key)
-        config_dict[self.__class__.__name__] = value
+        config_dict[self.get_dlg_name()] = value
         preferences.set(key, config_dict)
 
     def get_dialog_pref(self, key: PrefKey) -> Any:
@@ -326,7 +325,7 @@ class ToplevelDialog(tk.Toplevel):
         """
         config_dict = preferences.get(key)
         try:
-            return config_dict[self.__class__.__name__]
+            return config_dict[self.get_dlg_name()]
         except KeyError:
             return None
 
@@ -352,9 +351,7 @@ class ToplevelDialog(tk.Toplevel):
             if dlg := cls.get_dialog():
                 getattr(dlg, method_name)(*args, **kwargs)
 
-        assert hasattr(
-            cls, method_name
-        ), f"{cls.__name__} does not have method '{method_name}'"
+        assert hasattr(cls, method_name)
         return wrapper
 
 


### PR DESCRIPTION
When Page Sep dialog is being used, the Undo/Redo
buttons in the dialog (and dialog shortcuts) not only
performed undo/redo, but also refreshed the display
to show the current page separator. However, using
Undo/Redo from the main Edit menu, or Ctrl-Z, etc.
when focused in maintext did not do the refresh.

This commit fixes that, so that however the Undo is
activated, the Refresh will happen. Once the dialog is
closed, the additional refresh will no longer occur.

Fixes [#938](https://github.com/DistributedProofreaders/guiguts-py/issues/938)