### PR TITLE
Add "Two Words" as option in WF Hyphens

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -380,6 +380,7 @@ class Guiguts:
         preferences.set_default(PrefKey.CHECKERDIALOG_SUSPECTS_ONLY_DICT, {})
         preferences.set_default(PrefKey.WFDIALOG_ITALIC_THRESHOLD, ["4"])
         preferences.set_default(PrefKey.WFDIALOG_REGEX, [])
+        preferences.set_default(PrefKey.WFDIALOG_HYPHEN_TWO_WORDS, False)
         preferences.set_default(
             PrefKey.JEEBIES_PARANOIA_LEVEL, JeebiesParanoiaLevel.NORMAL
         )

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -42,6 +42,7 @@ class PrefKey(StrEnum):
     WFDIALOG_SORT_TYPE = auto()
     WFDIALOG_ITALIC_THRESHOLD = auto()
     WFDIALOG_REGEX = auto()
+    WFDIALOG_HYPHEN_TWO_WORDS = auto()
     CHECKERDIALOG_SORT_TYPE_DICT = auto()
     CHECKERDIALOG_SUSPECTS_ONLY_DICT = auto()
     DIALOG_GEOMETRY = auto()


### PR DESCRIPTION
In master, "Two Words" is always on, so "flash light" will be queried as a possible suspect with "flash-light".

This commit makes that optional, with a checkbox next to the Hyphens radiobutton in WF. This is similar to GG1, except there it is in the Prefs menu, not the WF dialog.

(Note "flashlight" as one word is always queried against "flash-light", and is unchanged by this commit.)

Fixes #925