### PR TITLE
Disable tools' file-saved check if debug

### DIFF
--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -34,6 +34,7 @@ from guiguts.utilities import (
     is_mac,
     sound_bell,
     load_dict_from_json,
+    is_debug,
 )
 from guiguts.widgets import (
     ToplevelDialog,
@@ -78,7 +79,7 @@ def tool_save() -> bool:
     Returns:
         True if OK to continue with intended operation.
     """
-    if the_file().filename:
+    if the_file().filename or is_debug():
         return True
 
     save = messagebox.askokcancel(

--- a/src/guiguts/utilities.py
+++ b/src/guiguts/utilities.py
@@ -751,3 +751,8 @@ class TextWrapper:
         if paragraph[-1] != "\n":
             rewrapped_para = rewrapped_para.rstrip("\n")
         return rewrapped_para
+
+
+def is_debug() -> bool:
+    """Return whether in debug mode, specifically if error logging level is debug."""
+    return logger.getEffectiveLevel() == logging.DEBUG


### PR DESCRIPTION
When `-d` command line argument is given, don't
insist on the file having a filename. Use at own risk!

To make checking of a quickly-typed or -pasted file easier during testing.