### PR TITLE
PPtxt improvements

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -14,14 +14,14 @@ files = [
 
 [[package]]
 name = "astroid"
-version = "3.3.9"
+version = "3.3.10"
 description = "An abstract syntax tree for Python with inference support."
 optional = false
 python-versions = ">=3.9.0"
 groups = ["dev"]
 files = [
-    {file = "astroid-3.3.9-py3-none-any.whl", hash = "sha256:d05bfd0acba96a7bd43e222828b7d9bc1e138aaeb0649707908d3702a9831248"},
-    {file = "astroid-3.3.9.tar.gz", hash = "sha256:622cc8e3048684aa42c820d9d218978021c3c3d174fb03a9f0d615921744f550"},
+    {file = "astroid-3.3.10-py3-none-any.whl", hash = "sha256:104fb9cb9b27ea95e847a94c003be03a9e039334a8ebca5ee27dafaf5c5711eb"},
+    {file = "astroid-3.3.10.tar.gz", hash = "sha256:c332157953060c6deb9caa57303ae0d20b0fbdb2e59b4a4f2a6ba49d0a7961ce"},
 ]
 
 [[package]]
@@ -224,14 +224,14 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.2.1"
 description = "Composable command line interface toolkit"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
-    {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
+    {file = "click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"},
+    {file = "click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202"},
 ]
 
 [package.dependencies]
@@ -781,19 +781,19 @@ type = ["mypy (>=1.14.1)"]
 
 [[package]]
 name = "pluggy"
-version = "1.5.0"
+version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
-    {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
 ]
 
 [package.extras]
 dev = ["pre-commit", "tox"]
-testing = ["pytest", "pytest-benchmark"]
+testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pycodestyle"
@@ -1185,14 +1185,14 @@ test = ["pytest (>=8)"]
 
 [[package]]
 name = "snowballstemmer"
-version = "3.0.0.1"
+version = "3.0.1"
 description = "This package provides 32 stemmers for 30 languages generated from Snowball algorithms."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*"
 groups = ["dev"]
 files = [
-    {file = "snowballstemmer-3.0.0.1-py3-none-any.whl", hash = "sha256:d1cdabc06fb492e80620d9e2c44d39e67cfda290b2aaef8718b0691079443b10"},
-    {file = "snowballstemmer-3.0.0.1.tar.gz", hash = "sha256:1d09493a5ecc85fb5b433674e9c83fcd41c6739b6979ce4b54e81a40ec078342"},
+    {file = "snowballstemmer-3.0.1-py3-none-any.whl", hash = "sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064"},
+    {file = "snowballstemmer-3.0.1.tar.gz", hash = "sha256:6d5eeeec8e9f84d4d56b847692bacf79bc2c8e90c7f80ca4444ff8b6f2e52895"},
 ]
 
 [[package]]
@@ -1357,14 +1357,14 @@ files = [
 
 [[package]]
 name = "types-requests"
-version = "2.32.0.20250328"
+version = "2.32.0.20250515"
 description = "Typing stubs for requests"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "types_requests-2.32.0.20250328-py3-none-any.whl", hash = "sha256:72ff80f84b15eb3aa7a8e2625fffb6a93f2ad5a0c20215fc1dcfa61117bcb2a2"},
-    {file = "types_requests-2.32.0.20250328.tar.gz", hash = "sha256:c9e67228ea103bd811c96984fac36ed2ae8da87a36a633964a21f199d60baf32"},
+    {file = "types_requests-2.32.0.20250515-py3-none-any.whl", hash = "sha256:f8eba93b3a892beee32643ff836993f15a785816acca21ea0ffa006f05ef0fb2"},
+    {file = "types_requests-2.32.0.20250515.tar.gz", hash = "sha256:09c8b63c11318cb2460813871aaa48b671002e59fda67ca909e9883777787581"},
 ]
 
 [package.dependencies]

--- a/src/guiguts/tools/pptxt.py
+++ b/src/guiguts/tools/pptxt.py
@@ -469,6 +469,7 @@ def repeated_words_check() -> None:
                 )
             else:
                 # "Duplicate" message - amend build message to cover whole relevant range
+                assert build_msg is not None
                 build_msg.text_range.end = msg_info.text_range.end
                 build_msg.hilite_end = msg_info.hilite_end
             prev_msg_info = msg_info

--- a/src/guiguts/tools/pptxt.py
+++ b/src/guiguts/tools/pptxt.py
@@ -398,8 +398,8 @@ def repeated_words_check() -> None:
             word = no_numbers_words_on_line[-1]
             # If last word on current line is same as first word on next line then
             # this is also an instance of repeated words.
-            regx1 = f"(\\b{word}$)"
-            regx2 = f"(^{word}\\b)"
+            regx1 = f"(\\b{word} *$)"
+            regx2 = f"(^ *{word}\\b)"
             if (res1 := re.search(regx1, book[rec_num])) and (
                 res2 := re.search(regx2, book[rec_num + 1])
             ):

--- a/src/guiguts/tools/pptxt.py
+++ b/src/guiguts/tools/pptxt.py
@@ -318,6 +318,10 @@ def repeated_words_check() -> None:
     # in that case are not counted as repeated words. The regex search on that line
     # will determine whether such repeats are counted as 'repeated words' or not.
 
+    # NOTE: This could potentially be simplified/improved using `findall` to get all
+    # non-overlapping matches of "word word" on the line after adding the first word
+    # of the next line. Or maybe slurp whole file, then search for "word \1".
+
     @dataclass
     class MsgInfo:
         """Class to store info for potential message."""


### PR DESCRIPTION
Fixes #761 (see issue for example files)

1. Suppress multiple identical repeated word errors - if a line contains a word several times, e.g. in a table heading, we only want one report per line if the same word is repeated in each column heading
2. Catch repeated word at line start with spaces - Repeated words are reported if the first is at the end of a line, and the second is at the start of the next line. However, the regex didn't allow the second word to have spaces before it, which it might for indented piece of text, e.g. blockquote.
3. Fix repeated words bug - A line with two distinct repeats, e.g.
`dog dog cat dog dog`
was reported as having 3 repeats, due to a bug in the way the first word in each double match was cleared to avoid re-finding it.
4. Don't report spaced close curly quotes if dittos - If close curly quote has 2 spaces on each side (start/end
of line also counts as 2 spaces) it's ditto mark, not a badly spaced quote.
5. Treat '----' similarly to '--': if '--` occurs more than 5 times, a message was output that future occurrences won't be reported. The same has now been added for `----`
6. Improve reporting of standalone 0 & 1 - E.g. don't report ` .0` or `0.234`. Also, consolidate repeated "special situations checks",
for example don't report each spaced period individually in `. . . . . . . . . . .` (similar to point 1, but for a different type of check).
