### PR TITLE
Downgrade error for cover > 1MB

### DIFF
--- a/src/guiguts/tools/pphtml.py
+++ b/src/guiguts/tools/pphtml.py
@@ -224,7 +224,7 @@ class PPhtmlChecker:
             reverse=True,
         )
         for fname, fsize in size_list:
-            if fsize > 1024 * 1024:
+            if fsize > 1024 * 1024 and not re.search(r"cover.(jpg|png)$", fname):
                 severity = "ERROR: "
                 test_passed = False
             elif fsize > 256 * 1024:


### PR DESCRIPTION
Just output a warning for a large cover, not an error, since there is no actual file size limit specified in the PPFAQ.

Fixes #1050 