### PR TITLE
Make curly quote exception optional

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -554,6 +554,7 @@ class Guiguts:
         preferences.set_default(PrefKey.SURROUND_WITH_AFTER_HISTORY, [])
         preferences.set_default(PrefKey.REGEX_TIMEOUT, 5)
         preferences.set_default(PrefKey.LEVENSHTEIN_DIGITS, True)
+        preferences.set_default(PrefKey.CURLY_DOUBLE_QUOTE_EXCEPTION, False)
 
         # Check all preferences have a default
         for pref_key in PrefKey:

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -708,14 +708,6 @@ class UnmatchedBracketDialog(UnmatchedCheckerDialog):
         super().__init__("Unmatched Bracket markup", **kwargs)
 
 
-class UnmatchedCurlyQuoteDialog(UnmatchedCheckerDialog):
-    """Unmatched Curly Quote dialog."""
-
-    def __init__(self, **kwargs: Any) -> None:
-        """Initialize Unmatched Curly Quote dialog."""
-        super().__init__("Unmatched Curly Quotes", **kwargs)
-
-
 class UnmatchedDPMarkupDialog(UnmatchedCheckerDialog):
     """Unmatched DP Markup dialog."""
 
@@ -2051,6 +2043,7 @@ class CurlyQuotesDialog(CheckerDialog):
             **kwargs,
         )
 
+        self.custom_frame.columnconfigure(0, weight=1)
         frame = ttk.Frame(self.custom_frame)
         frame.grid(column=0, row=1, sticky="NSEW", pady=5)
         frame.columnconfigure(3, weight=1)
@@ -2098,6 +2091,11 @@ class CurlyQuotesDialog(CheckerDialog):
             text=SQUOTES[1],
             command=lambda: insert_in_focus_widget(SQUOTES[1]),
         ).grid(column=8, row=0, sticky="NSE")
+        ttk.Checkbutton(
+            frame,
+            text='Allow "Next paragraph begins with quotes" exception',
+            variable=PersistentBoolean(PrefKey.CURLY_DOUBLE_QUOTE_EXCEPTION),
+        ).grid(column=0, row=1, columnspan=9, sticky="NSW", pady=(5, 0))
 
     def populate(self) -> None:
         """Populate list with suspect curly quotes."""
@@ -2220,7 +2218,11 @@ class CurlyQuotesDialog(CheckerDialog):
                 add_quote_entry("SINGLE QUOTE NOT CONVERTED: ")
             elif match_text == "":  # Blank line
                 # Expect dqtype == 0 unless next line starts with open double quote
-                if dqtype == 1 and maintext().get(f"{linebeg} +1l") != DQUOTES[0]:
+                # AND user has enabled that exception
+                if dqtype == 1 and (
+                    maintext().get(f"{linebeg} +1l") != DQUOTES[0]
+                    or not preferences.get(PrefKey.CURLY_DOUBLE_QUOTE_EXCEPTION)
+                ):
                     hilite_start = IndexRowCol(last_open_double_idx).col
                     self.add_entry(
                         maintext().get(

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -144,6 +144,7 @@ class PrefKey(StrEnum):
     SURROUND_WITH_AFTER_HISTORY = auto()
     REGEX_TIMEOUT = auto()
     LEVENSHTEIN_DIGITS = auto()
+    CURLY_DOUBLE_QUOTE_EXCEPTION = auto()
 
 
 class Preferences:


### PR DESCRIPTION
Previously if a closing curly quote was missing at the end of a paragraph, no error was output if there was an open quote at the start of the next paragraph. This was to avoid many false positives from this common occurrence. This feature is in PPWB's ppsmq, and in GG1.

However, it's not possible to know that the missing quote was missing at the END of the paragraph, e.g. `"Hello, he said.` So, this exception could cause
true errors to be omitted.

This commit makes the exception optional via a
Preference controlled by a checkbox in the Curly
Quote Check dialog.

Fixes #1052