### PR TITLE
Catch more hyphen queries in PPtxt

### DIFF
--- a/src/guiguts/tools/pptxt.py
+++ b/src/guiguts/tools/pptxt.py
@@ -133,6 +133,9 @@ def get_words_on_line(line: str) -> list[str]:
     # Newcastle-upon-Tyne
     line = re.sub(r"(\p{L})-(\p{L})", r"\1①\2", line)
     line = re.sub(r"(\p{L})-(\p{L})", r"\1①\2", line)
+    # paring- or -in (hyphen followed/preceded by whitespace)
+    line = re.sub(r"(\p{L})-( |$)", r"\1①\2", line)
+    line = re.sub(r"( |^)-(\p{L})", r"\1①\2", line)
     # fo’c’s’le
     line = re.sub(r"(\p{L})’(\p{L})", r"\1②\2", line)
     line = re.sub(r"(\p{L})’(\p{L})", r"\1②\2", line)


### PR DESCRIPTION
Cases like `paring- or skiving-knife`, where the hyphen is followed by a space/line-end, and the word `paring` also appears without a hyphen are caught by online PPtxt, but not GG2's version. Similarly when the hyphen is at the start of the word or line-start.

Fixes #981