### PR TITLE
Correct a few help links

### DIFF
--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -1258,7 +1258,7 @@ def unicode_normalize() -> None:
 class ProoferCommentCheckerDialog(CheckerDialog):
     """Proofer Comment Checker dialog."""
 
-    manual_page = "Navigation#Find_Proofer_Comments_(_[**notes]_)"
+    manual_page = "Search_Menu#Find_Proofer_Comments_(_[**_notes]_)"
 
     def __init__(self, **kwargs: Any) -> None:
         """Initialize Proofer Comment dialog."""
@@ -1384,7 +1384,7 @@ def asterisk_check() -> None:
     class AsteriskCheckerDialog(CheckerDialog):
         """Asterisk Checker Dialog."""
 
-        manual_page = "Navigation#Find_Asterisks_w/o_Slash"
+        manual_page = "Search_Menu#Find_Asterisks_w/o_Slash"
 
         def __init__(self, **kwargs: Any) -> None:
             """Initialize Asterisk Checker dialog."""

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -52,7 +52,7 @@ class SearchDialog(ToplevelDialog):
         selection: True to restrict counting, replacing, etc., to selected text.
     """
 
-    manual_page = "Searching"
+    manual_page = "Search_Menu#The_Search_&_Replace_Dialog"
     # Cannot be initialized here, since Tk root may not be created yet
     selection: tk.BooleanVar
 


### PR DESCRIPTION
Because manual page names have changed

Fixes pressing F1 (or Help->Dialog Manual Page) for the S/R dialog, Proofer Comments, and Asterisk Check, all of which are in the Search Menu

Fixes #1063 