### PR TITLE
Fix mousewheel scrolling in image

### DIFF
--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -1089,12 +1089,12 @@ class MainImage(tk.Frame):
     def wheel_scroll(self, evt: tk.Event) -> None:
         """Scroll image up/down using mouse wheel."""
         if evt.state == 0:
-            if is_mac() and tk.TkVersion < 3.7:
+            if is_mac() and tk.TkVersion < 8.7:
                 self.canvas.yview_scroll(int(-1 * evt.delta), "units")
             else:
                 self.canvas.yview_scroll(int(-1 * (evt.delta / 120)), "units")
         if evt.state == 1:
-            if is_mac() and tk.TkVersion < 3.7:
+            if is_mac() and tk.TkVersion < 8.7:
                 self.canvas.xview_scroll(int(-1 * evt.delta), "units")
             else:
                 self.canvas.xview_scroll(int(-1 * (evt.delta / 120)), "units")


### PR DESCRIPTION
Broken for Mac users in #1005 by comparing Tk version to 3.7 instead of 8.7!

Testing notes: this won't make it any smoother than before, nor fix any other problems, but should revert to the "basically works" situation pre-#1005. Apologies for the typo!