### PR TITLE
Don't report `/*-------*/` in CSS style section

### DIFF
--- a/src/guiguts/tools/pphtml.py
+++ b/src/guiguts/tools/pphtml.py
@@ -986,10 +986,14 @@ class PPhtmlChecker:
 
     def misc_counts(self) -> None:
         """Miscellaneous counting checks"""
-        # "--" emdashes, ignoring HTML comments (typically from ppgen)
+        # "--" emdashes, ignoring CSS style section and HTML comments (typically from ppgen)
         count = 0
+        in_html = False
         for line in self.file_lines:
-            if "<!--" not in line and "-->" not in line and "--" in line:
+            if "</style>" in line:
+                in_html = True
+                continue
+            if in_html and "<!--" not in line and "-->" not in line and "--" in line:
                 count += 1
         self.output_subsection_errors(
             count == 0,

--- a/tests/expected/pphtml1.txt
+++ b/tests/expected/pphtml1.txt
@@ -35,7 +35,7 @@
 --- [pass] Classes defined but not used ---
 
 ===== Miscellaneous checks =====
---- *FAIL* Lines with "--" instead of "—" (should be 0): 98 ---
+--- [pass] Lines with "--" instead of "—" (should be 0): 0 ---
 --- *FAIL* Number of h2 tags (usually chapters; should be > 0): 0 ---
 --- [info] Number of h3 tags (usually sections): 0 ---
 --- [info] Number of tables: 0 ---


### PR DESCRIPTION
Wait until we've passed the `</style>` line before checking for double hyphens.

Note:
This minor edit caused one of the new tests to "fail" - not actually an error, but the test detected that the warning about double hyphens was no longer in one of the pphtml output test files.