### PR TITLE
Update scrollwheel/trackpad scroll in image pane

### DIFF
--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -1088,17 +1088,18 @@ class MainImage(tk.Frame):
 
     def wheel_scroll(self, evt: tk.Event) -> None:
         """Scroll image up/down using mouse wheel."""
+        # This event seems to lock up the UI in Linux; unsupported.
+        if is_x11():
+            return
+
+        if is_mac() and tk.TkVersion < 8.7:
+            scroll_amount = int(-1 * evt.delta)
+        else:
+            scroll_amount = int(-1 * (evt.delta / 120))
         if evt.state == 0:
-            if is_mac() and tk.TkVersion < 8.7:
-                self.canvas.yview_scroll(int(-1 * evt.delta), "units")
-            else:
-                self.canvas.yview_scroll(int(-1 * (evt.delta / 120)), "units")
+            self.canvas.yview_scroll(scroll_amount, "units")
         if evt.state == 1:
-            if is_mac() and tk.TkVersion < 8.7:
-                self.canvas.xview_scroll(int(-1 * evt.delta), "units")
-            else:
-                self.canvas.xview_scroll(int(-1 * (evt.delta / 120)), "units")
-        self.show_image()
+            self.canvas.xview_scroll(scroll_amount, "units")
 
     def touchpad_scroll(self, evt: tk.Event) -> None:
         """Scroll image using touchpad."""


### PR DESCRIPTION
Improve image pane scrolling speed and responsiveness when using the trackpad or mouse wheel.

On Linux, ignore this event. It causes the UI to seize up, even if only temporarily, and even after releasing, the image still doesn't scroll.

Testing notes:
- First try scrolling the image pane with trackpad and/or mousewheel on `master` to get a baseline
- Then try again on this branch; it will hopefully be fairly smooth
- Should work to scroll both horizontally and vertically.

I refactored the routine, but it turned out that a major key was to not call `show_image()`. It appears to be unnecessary and was probably the source of most of the slowness.