### PR TITLE
Fix image viewer browse/load button

### DIFF
--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -1323,7 +1323,7 @@ class MainImage(tk.Frame):
         elif self.proj_filename != "":
             initial_dir = os.path.dirname(self.proj_filename)
         else:
-            return
+            initial_dir = None
         if filename := filedialog.askopenfilename(
             initialdir=initial_dir,
             title="Choose Image File",


### PR DESCRIPTION
If no filename, button did nothing. Now just opens a load dialog without specifying an initial directory, so should either open in a default place or the previous dir used in a similar dialog - will depend on OS behavior.

Fixes #1102 