### PR TITLE
Show "working"/busy cursor when file is saved

### DIFF
--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -40,7 +40,7 @@ from guiguts.utilities import (
     folder_dir_str,
     is_test,
 )
-from guiguts.widgets import grab_focus, ToplevelDialog
+from guiguts.widgets import grab_focus, ToplevelDialog, Busy
 
 logger = logging.getLogger(__package__)
 
@@ -308,6 +308,7 @@ class File:
             """Get backup names for filename and bin file."""
             return f"{self.filename}{ext}", f"{bin_name(self.filename)}{ext}"
 
+        Busy.busy()
         binfile_name = bin_name(self.filename)
         try:
             if autosave:
@@ -354,6 +355,8 @@ class File:
                 f"Error details:\n{str(exc)}"
             )
         self.reset_autosave()
+        # May be too quick for user to see without a delay
+        root().after(Busy.BUSY_DELAY, Busy.unbusy)
         return self.filename
 
     def save_as_file(self) -> str:

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -1107,6 +1107,7 @@ class Busy:
     2. Change the mouse cursor to "watch" (widgets registered via `busy_cursor_setup`).
     """
 
+    BUSY_DELAY = 500  # Suggested time delay before setting unbusy
     _busy_widget: Optional[ttk.Label] = None
     _busy_widget_cursors: dict[tk.Widget | tk.Tk | tk.Toplevel, str] = {}
 


### PR DESCRIPTION
Most tools show the red "working" label in the bottom right and change the cursor to an watch or hourglass (OS-dependent) when the tool is busy. However, saving a file didn't do this, so this PR adds it. When the file is saved the "working" label should flash briefly (about 1/2 second) and the cursor should change for the same length of time.

