### PR TITLE
Miscellaneous theme changes

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -738,6 +738,7 @@ class MainText(tk.Text):
             spacing1=self["spacing1"],
             insertwidth=self["insertwidth"],
             wrap=self["wrap"],
+            padx=self["padx"],
         )
         self.peer.bind(
             "<<ThemeChanged>>",

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1065,7 +1065,8 @@ class MainText(tk.Text):
         widget.configure(style_dict)
         widget.configure(
             insertbackground=str(style_dict["foreground"]),
-            highlightbackground=str(style_dict["foreground"]),
+            highlightbackground=str(style_dict["background"]),
+            highlightcolor=str(style_dict["foreground"]),
             selectbackground=str(sel_dict["background"]),
             selectforeground=str(sel_dict["foreground"]),
             inactiveselectbackground=str(in_sel_dict["background"]),

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -1756,6 +1756,7 @@ class MainWindow:
             autoseparators=True,
             maxundo=-1,
             highlightthickness=2,
+            padx=5,
         )
 
         self.paned_window.add(self.paned_text_window, minsize=MIN_PANE_WIDTH)

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -994,6 +994,12 @@ class ThemedStyle(ttk.Style):
             # so replaced with line below as suggested in above comment.
             return self.tk.call(self._name, "theme", "use")  # type:ignore[attr-defined]
         super().theme_use(themename)
+        fg = self.lookup("TButton", "foreground")
+        self.map("TButton", focuscolor=[("focus", fg)])
+        self.map("TCheckbutton", focuscolor=[("focus", fg)])
+        self.map("TRadiobutton", focuscolor=[("focus", fg)])
+        self.map("TCombobox", focuscolor=[("focus", fg)])
+        self.map("TEntry", focuscolor=[("focus", fg)])
         return None
 
     def is_dark_theme(self) -> bool:


### PR DESCRIPTION
1. Main and peer text border highlighting was reversed - now highlights correctly when focused
2. Added some padding to left and right for text window
3. Made focus highlight color more obvious (i.e. light for dark theme, dark for light theme) - test by tabbing to, or clicking on, a button.

Fixes #1116 
