### PR TITLE
Make checker dialog colors configurable

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -38,10 +38,10 @@ from guiguts.maintext import (
     SeparatorMetadata,
     ButtonMetadata,
     CheckbuttonMetadata,
+    Menu,
 )
 from guiguts.mainwindow import (
     MainWindow,
-    Menu,
     menubar,
     StatusBar,
     statusbar,

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -7,7 +7,7 @@ from typing import Any, Optional, Callable
 
 import regex as re
 
-from guiguts.maintext import maintext
+from guiguts.maintext import maintext, HighlightTag
 from guiguts.mainwindow import ScrolledReadOnlyText
 from guiguts.preferences import PrefKey, preferences, PersistentBoolean
 from guiguts.root import root
@@ -21,8 +21,6 @@ from guiguts.utilities import (
 from guiguts.widgets import ToplevelDialog, TlDlg, mouse_bind, Busy, ToolTip
 
 MARK_ENTRY_TO_SELECT = "MarkEntryToSelect"
-HILITE_TAG_NAME = "chk_hilite"
-ERROR_PREFIX_TAG_NAME = "chk_error_prefix"
 REFRESH_MESSAGE = "Click this message to refresh after Undo/Redo"
 
 
@@ -571,12 +569,6 @@ class CheckerDialog(ToplevelDialog):
         self.process_command = process_command
         self.rowcol_key = sort_key_rowcol or CheckerDialog.sort_key_rowcol
         self.alpha_key = sort_key_alpha or CheckerDialog.sort_key_alpha
-        self.text.tag_configure(
-            HILITE_TAG_NAME,
-            background=maintext()["selectbackground"],
-            foreground=maintext()["selectforeground"],
-        )
-        self.text.tag_configure(ERROR_PREFIX_TAG_NAME, foreground="red")
 
         def do_clear_on_undo_redo() -> None:
             """If undo/redo operation should trigger user to Re-run tool, clear dialog."""
@@ -914,7 +906,9 @@ class CheckerDialog(ToplevelDialog):
                     entry.hilite_end + len(rowcol_str) + len(entry.error_prefix),
                 )
                 self.text.tag_add(
-                    HILITE_TAG_NAME, start_rowcol.index(), end_rowcol.index()
+                    HighlightTag.CHECKER_HIGHLIGHT,
+                    start_rowcol.index(),
+                    end_rowcol.index(),
                 )
             if entry.error_prefix:
                 start_rowcol = IndexRowCol(self.text.index(tk.END + "-2line"))
@@ -923,7 +917,9 @@ class CheckerDialog(ToplevelDialog):
                     start_rowcol.row, len(rowcol_str) + len(entry.error_prefix)
                 )
                 self.text.tag_add(
-                    ERROR_PREFIX_TAG_NAME, start_rowcol.index(), end_rowcol.index()
+                    HighlightTag.CHECKER_ERROR_PREFIX,
+                    start_rowcol.index(),
+                    end_rowcol.index(),
                 )
         # Output "Check complete", so user knows it's done
         if complete_msg:

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -33,7 +33,7 @@ from guiguts.widgets import (
     focus_prev_widget,
     bind_shift_tab,
     mouse_bind,
-    ToplevelDialog
+    ToplevelDialog,
 )
 
 logger = logging.getLogger(__package__)
@@ -3953,16 +3953,21 @@ class MainText(tk.Text):
             )
 
         def update_checker_tag(key: ColorKey) -> None:
-            """Update all checker dialogs' text widgets' tag with new settings."""
+            """Update all checker dialogs' text widget's tag with new settings."""
             c_color = maintext().colors[key]
             assert c_color.tag
-            for dlg in ToplevelDialog._toplevel_dialogs.values():
+            for dlg in ToplevelDialog.toplevel_dialogs.values():
                 try:
-                    dlg.text.tag_configure(
+                    dlg.text.tag_configure(  # type:ignore[attr-defined]
                         c_color.tag,
-                        c_color.dark if themed_style().is_dark_theme() else c_color.light,
+                        (
+                            c_color.dark
+                            if themed_style().is_dark_theme()
+                            else c_color.light
+                        ),
                     )
-                except Exception:
+                except AttributeError:
+                    # Ignore dialogs that don't have a "text" widget or that have been closed
                     pass
 
         # Temporarily create a Text to get the default select bg & fg colors

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -33,6 +33,7 @@ from guiguts.widgets import (
     focus_prev_widget,
     bind_shift_tab,
     mouse_bind,
+    ToplevelDialog
 )
 
 logger = logging.getLogger(__package__)
@@ -3951,6 +3952,19 @@ class MainText(tk.Text):
                 c_color.dark if themed_style().is_dark_theme() else c_color.light,
             )
 
+        def update_checker_tag(key: ColorKey) -> None:
+            """Update all checker dialogs' text widgets' tag with new settings."""
+            c_color = maintext().colors[key]
+            assert c_color.tag
+            for dlg in ToplevelDialog._toplevel_dialogs.values():
+                try:
+                    dlg.text.tag_configure(
+                        c_color.tag,
+                        c_color.dark if themed_style().is_dark_theme() else c_color.light,
+                    )
+                except Exception:
+                    pass
+
         # Temporarily create a Text to get the default select bg & fg colors
         # which may be a name like "SystemHighlightText" so convert it to rgb
         temp_text = tk.Text()
@@ -4219,7 +4233,7 @@ class MainText(tk.Text):
                 "Checker selected line",
                 {"background": "#dddddd", "foreground": "black"},
                 {"background": "#dddddd", "foreground": "black"},
-                None,
+                update_checker_tag,
             ),
             ColorKey.CHECKER_HIGHLIGHT: ConfigurableColor(
                 HighlightTag.CHECKER_HIGHLIGHT,
@@ -4232,14 +4246,14 @@ class MainText(tk.Text):
                     "background": sel_bg,
                     "foreground": sel_fg,
                 },
-                None,
+                update_checker_tag,
             ),
             ColorKey.CHECKER_ERROR_PREFIX: ConfigurableColor(
                 HighlightTag.CHECKER_ERROR_PREFIX,
                 "Checker error prefix",
                 {"background": "", "foreground": "red"},
                 {"background": "", "foreground": "red"},
-                None,
+                update_checker_tag,
             ),
         }
 

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -514,12 +514,15 @@ class PreferencesDialog(ToplevelDialog):
 
             # Colorpicker bindings
             def click_callback(
-                attr: str,
+                attr: Literal["foreground", "background"],
                 key: ColorKey = key,
                 widget: tk.Text = desc,
                 style_dict: StyleDict = style_dict,
             ) -> None:
                 current = str(style_dict.get(attr, "#000000"))
+                if current == "":
+                    logger.error(f"Cannot set {attr} for this color")
+                    return
                 color = colorchooser.askcolor(
                     color=current, parent=self, title=f"Choose {attr} color"
                 )[1]

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -486,6 +486,11 @@ class PreferencesDialog(ToplevelDialog):
             desc = tk.Text(
                 self.colors_frame,
                 background=maintext()["background"],
+                foreground=(
+                    maintext()["selectforeground"]
+                    if key == ColorKey.MAIN_SELECT_INACTIVE
+                    else maintext()["foreground"]
+                ),
                 font=maintext()["font"],
                 width=25,
                 height=1,

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -506,6 +506,10 @@ class PreferencesDialog(ToplevelDialog):
             )
             desc.tag_configure(sample_tag_name, style_dict)
             desc.tag_add(sample_tag_name, "1.0", "1.end")
+            desc.tag_configure(
+                "sel", foreground=desc["foreground"], background=desc["background"]
+            )
+            desc.config(inactiveselectbackground=desc["background"])
             desc.config(state="disabled")
             tooltip = ""
             if style_dict.get("foreground", "#000000") != "":

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -507,10 +507,12 @@ class PreferencesDialog(ToplevelDialog):
             desc.tag_configure(sample_tag_name, style_dict)
             desc.tag_add(sample_tag_name, "1.0", "1.end")
             desc.config(state="disabled")
-            ToolTip(
-                desc,
-                "Left-click to set text color. Right-click or Shift-left-click to set background",
-            )
+            tooltip = ""
+            if style_dict.get("foreground", "#000000") != "":
+                tooltip += "Left-click to set text color. "
+            if style_dict.get("background", "#000000") != "":
+                tooltip += "Right-click or Shift-left-click to set background"
+            ToolTip(desc, tooltip)
 
             # Colorpicker bindings
             def click_callback(
@@ -521,7 +523,7 @@ class PreferencesDialog(ToplevelDialog):
             ) -> None:
                 current = str(style_dict.get(attr, "#000000"))
                 if current == "":
-                    logger.error(f"Cannot set {attr} for this color")
+                    logger.error(f"{attr.capitalize()} color is not configurable")
                     return
                 color = colorchooser.askcolor(
                     color=current, parent=self, title=f"Choose {attr} color"

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -35,7 +35,7 @@ class ToplevelDialog(tk.Toplevel):
 
     # Dictionary of ToplevelDialog objects, keyed by class name.
     # Used to ensure only one instance of any dialog is created.
-    _toplevel_dialogs: dict[str, "ToplevelDialog"] = {}
+    toplevel_dialogs: dict[str, "ToplevelDialog"] = {}
 
     # Location of manual page for most recently focused dialog
     context_help = ""
@@ -132,7 +132,7 @@ class ToplevelDialog(tk.Toplevel):
         # Or do we need to create it?
         if not cls.get_dialog():
             dlg = cls(**kwargs)
-        ToplevelDialog._toplevel_dialogs[dlg_name] = dlg
+        ToplevelDialog.toplevel_dialogs[dlg_name] = dlg
         dlg.grab_focus()
         return dlg
 
@@ -145,10 +145,10 @@ class ToplevelDialog(tk.Toplevel):
         """
         dlg_name = cls.get_dlg_name()
         if (
-            dlg_name in ToplevelDialog._toplevel_dialogs
-            and ToplevelDialog._toplevel_dialogs[dlg_name].winfo_exists()
+            dlg_name in ToplevelDialog.toplevel_dialogs
+            and ToplevelDialog.toplevel_dialogs[dlg_name].winfo_exists()
         ):
-            return ToplevelDialog._toplevel_dialogs[dlg_name]  # type: ignore[return-value]
+            return ToplevelDialog.toplevel_dialogs[dlg_name]  # type: ignore[return-value]
         return None
 
     @classmethod
@@ -209,11 +209,11 @@ class ToplevelDialog(tk.Toplevel):
     @classmethod
     def close_all(cls) -> None:
         """Close all open ToplevelDialogs."""
-        for dlg in ToplevelDialog._toplevel_dialogs.values():
+        for dlg in ToplevelDialog.toplevel_dialogs.values():
             if dlg.winfo_exists():
                 dlg.destroy()
                 dlg.reset()
-        ToplevelDialog._toplevel_dialogs.clear()
+        ToplevelDialog.toplevel_dialogs.clear()
 
     def _do_config(self) -> None:
         """Configure the geometry of the ToplevelDialog.

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -2,9 +2,15 @@
 
 from guiguts.application import Guiguts
 from guiguts.file import File
-from guiguts.mainwindow import process_label, process_accel
 from guiguts.preferences import preferences, PrefKey
-from guiguts.utilities import is_mac, is_windows, is_x11, _is_system
+from guiguts.utilities import (
+    is_mac,
+    is_windows,
+    is_x11,
+    _is_system,
+    process_label,
+    process_accel,
+)
 
 
 def test_which_os(guiguts_app: Guiguts) -> None:  # pylint: disable=unused-argument


### PR DESCRIPTION
1. Current line in checker list of messages
2. Highlighted word in message, e.g. "he" in Jeebies message
3. Error prefix, e.g. type of error in Curly Quote Check

Doesn't let you configure bg or fg of a color if it would have no effect, e.g. error prefix is fg only, and main window selected color when window not focused (inactive) is bg only.

Also miscellaneous code re-org, some of which was needed, and some just to improve it.

Fixes #1111 