### PR TITLE
Allow image viewer to be docked on left or right

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -573,6 +573,7 @@ class Guiguts:
         preferences.set_default(PrefKey.CUSTOM_MARKUP_ATTRIBUTE_2_HISTORY, [])
         preferences.set_default(PrefKey.CUSTOM_MARKUP_ATTRIBUTE_3_HISTORY, [])
         preferences.set_default(PrefKey.CUSTOMIZABLE_COLORS, {})
+        preferences.set_default(PrefKey.IMAGE_VIEWER_DOCK_SIDE, "right")
 
         # Check all preferences have a default
         for pref_key in PrefKey:

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -451,8 +451,8 @@ class MainImage(tk.Frame):
         self,
         parent: tk.PanedWindow,
         hide_func: Callable[[], None],
-        float_func: Callable[[Any], None],
-        dock_func: Callable[[Any], None],
+        float_func: Callable[[], None],
+        dock_func: Callable[[], None],
     ) -> None:
         """Initialize the MainImage to contain an empty Canvas with scrollbars.
 
@@ -1037,9 +1037,9 @@ class MainImage(tk.Frame):
     def set_image_docking(self) -> None:
         """Float/dock image depending on flag."""
         if preferences.get(PrefKey.IMAGE_WINDOW_DOCKED):
-            self.dock_func(None)
+            self.dock_func()
         else:
-            self.float_func(None)
+            self.float_func()
 
     def is_image_loaded(self) -> bool:
         """Return if an image is currently loaded."""
@@ -1514,7 +1514,7 @@ class MainWindow:
         self.paned_window.forget(mainimage())
         preferences.set(PrefKey.IMAGE_VIEWER_INTERNAL, False)
 
-    def float_image(self, _event: Optional[tk.Event] = None) -> None:
+    def float_image(self) -> None:
         """Float the image into a separate window"""
         mainimage().grid_remove()
         root().wm_manage(mainimage())
@@ -1530,10 +1530,17 @@ class MainWindow:
         # It is OK to save image viewer geometry from now on
         mainimage().enable_geometry_storage()
 
-    def dock_image(self, _event: Optional[tk.Event] = None) -> None:
+    def dock_image(self) -> None:
         """Dock the image back into the main window"""
         root().wm_forget(mainimage())  # type: ignore[arg-type]
-        self.paned_window.add(mainimage(), minsize=MIN_PANE_WIDTH)
+        self.paned_window.forget(mainimage())
+        self.paned_window.forget(self.paned_text_window)
+        if preferences.get(PrefKey.IMAGE_VIEWER_DOCK_SIDE) == "right":
+            self.paned_window.add(self.paned_text_window, minsize=MIN_PANE_WIDTH)
+            self.paned_window.add(mainimage(), minsize=MIN_PANE_WIDTH)
+        else:
+            self.paned_window.add(mainimage(), minsize=MIN_PANE_WIDTH)
+            self.paned_window.add(self.paned_text_window, minsize=MIN_PANE_WIDTH)
         self.paned_window.sash_place(
             0, preferences.get(PrefKey.IMAGE_DOCK_SASH_COORD), 0
         )

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -22,7 +22,7 @@ from guiguts.maintext import (
     ColorKey,
 )
 
-from guiguts.mainwindow import ScrolledReadOnlyText
+from guiguts.mainwindow import ScrolledReadOnlyText, mainimage
 from guiguts.preferences import (
     PrefKey,
     PersistentBoolean,
@@ -197,12 +197,33 @@ class PreferencesDialog(ToplevelDialog):
         image_viewer_frame.columnconfigure(0, weight=1)
         image_viewer_frame.columnconfigure(1, weight=1)
 
+        dock_side_frame = ttk.Frame(image_viewer_frame)
+        dock_side_frame.grid(column=0, row=0, sticky="NW", pady=5)
+        ttk.Label(dock_side_frame, text="Dock Image Viewer on: ").grid(
+            column=0, row=0, sticky="NW"
+        )
+        dock_side_textvariable = PersistentString(PrefKey.IMAGE_VIEWER_DOCK_SIDE)
+        ttk.Radiobutton(
+            dock_side_frame,
+            text="Left",
+            variable=dock_side_textvariable,
+            value="left",
+            command=lambda: mainimage().dock_func(),
+        ).grid(column=1, row=0, sticky="NW", padx=20)
+        ttk.Radiobutton(
+            dock_side_frame,
+            text="Right",
+            variable=dock_side_textvariable,
+            value="right",
+            command=lambda: mainimage().dock_func(),
+        ).grid(column=2, row=0, sticky="NW")
+
         iv_btn = ttk.Checkbutton(
             image_viewer_frame,
             text="Auto Img Reload Alert",
             variable=PersistentBoolean(PrefKey.IMAGE_VIEWER_ALERT),
         )
-        iv_btn.grid(column=0, row=0, sticky="NEW", pady=5)
+        iv_btn.grid(column=0, row=1, sticky="NEW", pady=5)
         ToolTip(
             iv_btn,
             "Whether to flash the border when Auto Img re-loads the\n"
@@ -212,9 +233,9 @@ class PreferencesDialog(ToplevelDialog):
             image_viewer_frame,
             text="Use External Viewer",
             variable=PersistentBoolean(PrefKey.IMAGE_VIEWER_EXTERNAL),
-        ).grid(column=0, row=1, sticky="NEW", pady=5)
+        ).grid(column=0, row=2, sticky="NEW", pady=5)
         file_name_frame = ttk.Frame(image_viewer_frame)
-        file_name_frame.grid(row=2, column=0, columnspan=2, sticky="NSEW")
+        file_name_frame.grid(row=3, column=0, columnspan=2, sticky="NSEW")
         file_name_frame.columnconfigure(0, weight=1)
         self.filename_textvariable = tk.StringVar(self, "")
         ttk.Entry(

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -154,6 +154,7 @@ class PrefKey(StrEnum):
     CUSTOM_MARKUP_ATTRIBUTE_2_HISTORY = auto()
     CUSTOM_MARKUP_ATTRIBUTE_3_HISTORY = auto()
     CUSTOMIZABLE_COLORS = auto()
+    IMAGE_VIEWER_DOCK_SIDE = auto()
 
 
 class Preferences:


### PR DESCRIPTION
In Preferences, Image Viewer tab, can switch between left and right. In order to give visual feedback, If user changes the setting, the viewer is displayed docked on the side they chose, even if it was previously
floating or hidden.

Fixes #484 