### PR TITLE
Fix Illo Fixup move bug

### DIFF
--- a/src/guiguts/illo_sn_fixup.py
+++ b/src/guiguts/illo_sn_fixup.py
@@ -481,8 +481,13 @@ def move_selection_up(tag_type: str) -> None:
         # What is on this line?
         line_txt = maintext().get(line_num, f"{line_num} lineend")
 
-        # If closing ] - skip to first line of this item
-        if line_txt and line_txt[-1] == "]":
+        # If closing ] - skip to first line of this item unless single line [...]
+        if (
+            line_txt
+            and line_txt[-1] == "]"
+            and line_txt[0] != "["
+            and line_txt[0:1] != "*["
+        ):
             while True:
                 line_num = maintext().index(f"{line_num}-1l")
                 line_txt = maintext().get(line_num, f"{line_num} lineend")

--- a/src/guiguts/illo_sn_fixup.py
+++ b/src/guiguts/illo_sn_fixup.py
@@ -477,11 +477,20 @@ def move_selection_up(tag_type: str) -> None:
     # the) selected Illo or SN record. NB We may not be able to move the record at all if
     # it means skipping over another tag of the same type.
     line_num = maintext().index(f"{first_line_num}-1l")
-    while (
-        line_num != "0.0"
-    ):  # NB That index does not exist but see at end of while loop.
+    while True:
         # What is on this line?
         line_txt = maintext().get(line_num, f"{line_num} lineend")
+
+        # If closing ] - skip to first line of this item
+        if line_txt and line_txt[-1] == "]":
+            while True:
+                line_num = maintext().index(f"{line_num}-1l")
+                line_txt = maintext().get(line_num, f"{line_num} lineend")
+                if line_txt and line_txt[0] == "[" or line_txt[0:1] == "*[":
+                    break
+                if line_num == "1.0":  # Hit top of file before tag start
+                    return
+
         # Is it a tag of the same type as the selected one?
         if tag_type == "Sidenote" and (
             line_txt[0:10] == "[Sidenote:" or line_txt[0:11] == "*[Sidenote:"
@@ -534,13 +543,11 @@ def move_selection_up(tag_type: str) -> None:
             )
             checker.update_after_move(tag_type, selected_illosn_index)
             return
-        # If we have reached the top of the file, and it is not a blank line, then we
-        # have to 'create' non-existent line number '0.0' to terminate the while-loop.
+        # If we have reached the top of the file, return.
         if line_num == "1.0":
-            line_num = "0.0"
-        else:
-            # Decrement line_num normally.
-            line_num = maintext().index(f"{line_num}-1l")
+            return
+        # Decrement line_num normally.
+        line_num = maintext().index(f"{line_num}-1l")
     return
 
 

--- a/src/guiguts/illo_sn_fixup.py
+++ b/src/guiguts/illo_sn_fixup.py
@@ -483,6 +483,7 @@ def move_selection_up(tag_type: str) -> None:
             if not line_num:  # Hit top of file before tag start
                 sound_bell()
                 return
+            line_num = maintext().index(f"{line_num} linestart")
             line_txt = maintext().get(line_num, f"{line_num} lineend")
 
         # Is it a tag of the same type as the selected one?


### PR DESCRIPTION
If two illos are adjacent (one blank line between) and the upper one has blank lines, i.e. multi paragraph, and the user tries to move the lower one upwards, it is supposed to do nothing because you can't move illos past one another, but if finds the blank line in the upper illo and tries to move it in there, potentially losing lines in the process.

This fix makes it detect the end of illo markup, then it tracks back to find the start of illo markup, before beginning the search process. If indeed it was an illo, it will do nothing, but if it was a sidenote, it can move the illo above the sidenote.

Hopefully fixes #1143