### PR TITLE
Don't break leading `/#` markup in HTML gen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,8 @@
 - Scan images that were stored as palettized or RGB files were never inverted
   in the image viewer
 - Illustration Fixup sometimes corrupted Illustration markup when attempting
-  to move an illo upwards past an illo block containing blank lines 
+  to move an illo upwards past an illo block containing blank lines
+- HTML generation exited with a fatal error if the file began with `/#` markup
 - Mousewheel scrolling in image viewer was broken for Mac users
 - PPhtml reported double hyphens in comments in the CSS style block
 - PPhtml did not recognize valid DOCTYPE declarations if case was unexpected

--- a/src/guiguts/html_convert.py
+++ b/src/guiguts/html_convert.py
@@ -224,7 +224,11 @@ def html_convert_title() -> None:
             maintext().insert(f"{step - 1}.end", "<br>")
             continue
         # Not in title yet, so skip blank lines, illos or block markup
-        if not selection or re.match(H1_SKIP_REGEX, selection, flags=re.IGNORECASE):
+        if (
+            not selection
+            or selection == "/#"
+            or re.match(H1_SKIP_REGEX, selection, flags=re.IGNORECASE)
+        ):
             continue
         # Found start of title
         in_title = True


### PR DESCRIPTION
If file begins with `/#` then HTML generation fails because the `/#` ends up on a line with other markup. Then later, this open markup is not recognized, and a fatal error occurs when the matching close markup is found.

This is a quick fix to let HTML generation continue, rather than causing a fatal error.

#1157 addresses the issue more fully.