### PR TITLE
Add variable multi-replace to SR dialog

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -395,6 +395,7 @@ class Guiguts:
         preferences.set_default(PrefKey.SEARCHDIALOG_WRAP, True)
         preferences.set_default(PrefKey.SEARCHDIALOG_REGEX, False)
         preferences.set_default(PrefKey.SEARCHDIALOG_MULTI_REPLACE, False)
+        preferences.set_default(PrefKey.SEARCHDIALOG_MULTI_ROWS, 3)
         preferences.set_default(PrefKey.DIALOG_GEOMETRY, {})
         preferences.set_default(PrefKey.ROOT_GEOMETRY, "800x400")
         preferences.set_default(PrefKey.ROOT_GEOMETRY_STATE, "normal")

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -1550,11 +1550,13 @@ class TextMarkupConvertorDialog(ToplevelDialog):
     @classmethod
     def manual_sc(cls) -> None:
         """Pop S/R dialog pre-populated to help user convert `<sc>` markup."""
-        dlg = SearchDialog.show_dialog()
         preferences.set(PrefKey.SEARCHDIALOG_MULTI_REPLACE, True)
+        if preferences.get(PrefKey.SEARCHDIALOG_MULTI_ROWS) < 3:
+            preferences.set(PrefKey.SEARCHDIALOG_MULTI_ROWS, 3)
         preferences.set(PrefKey.SEARCHDIALOG_REGEX, True)
         preferences.set(PrefKey.SEARCHDIALOG_MATCH_CASE, False)
         preferences.set(PrefKey.SEARCHDIALOG_WHOLE_WORD, False)
+        dlg = SearchDialog.show_dialog()
         dlg.search_box.set(r"<sc>([^<]+)</sc>")
         dlg.replace_box[0].set(r"\1")
         dlg.replace_box[1].set(r"\U\1\E")

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -36,6 +36,7 @@ class PrefKey(StrEnum):
     SEARCHDIALOG_WRAP = auto()
     SEARCHDIALOG_REGEX = auto()
     SEARCHDIALOG_MULTI_REPLACE = auto()
+    SEARCHDIALOG_MULTI_ROWS = auto()
     WFDIALOG_SUSPECTS_ONLY = auto()
     WFDIALOG_IGNORE_CASE = auto()
     WFDIALOG_DISPLAY_TYPE = auto()


### PR DESCRIPTION
User can now change the number of replace fields shown in the SR dialog between 2 and 10, default is 3.

Dialog should resize correctly, and setting is stored in prefs, so should be persistent.

Also fixed minor bug relating to multi-replace. In master, if a replacement string is used in replace field 1, for example, it doesn't appear in the drop down for replace field 2 until the dialog is closed and re-opened. With this commit, strings are added to drop-down history for all fields as soon as they are used in any field.

Fixes #792