### PR TITLE
Remove extra space when deleting proofer comment

### DIFF
--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -1383,6 +1383,11 @@ class ProoferCommentChecker:
         )
         maintext().undo_block_begin()
         maintext().delete(start_mark, end_mark)
+        # If this leaves exactly a double space, remove one of them
+        if re.fullmatch(
+            "[^ ]  [^ ]", maintext().get(f"{start_mark}-2c", f"{end_mark}+2c")
+        ):
+            maintext().delete(start_mark)
 
 
 def asterisk_check() -> None:


### PR DESCRIPTION
If deleting the proofer comment leaves exactly 2 spaces, one which preceded it and one which followed it, remove one of them.

It does not attempt to correct triple spaces, not where both spaces were before or after the proofer comment, since these are likely to relate to table spacing or some similar deliberate spacing. This is only for the case where the proofer put a space between the word they were querying and the proofer comment, and there would
also be a space after the comment. Note also that a left-behind end-of-line space is not removed. They are automatically removed on file saving.

Fixes #1168