### PR TITLE
Warn if nested bracket confuses Footnote Fixup

### DIFF
--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -1377,6 +1377,12 @@ def display_footnote_entries(auto_select_line: bool = True) -> None:
                     error_prefix = "CONTINUATION: "
                 else:
                     error_prefix = "NO ANCHOR: "
+            # If "[Footnote" found within footnote, something's wrong, probably relating
+            # to nested or broken markup
+            elif "[Footnote" in maintext().get(
+                f"{fn_record.start.index()}+10c", fn_record.end.index()
+            ):
+                error_prefix = "NESTED/BROKEN MARKUP: "
             else:
                 an_record = an_records[fn_record.an_index]
                 # Check that no other footnote has the same anchor as this one


### PR DESCRIPTION
A nested square bracket within a continued footnote can cause Footnote Fixup to combine two footnotes into one.

This is a simple fix to report this situation by detecting that and unexpected `[Footnote` appears within the text of a footnote.

A more robust search method or fix may transpire when the work is done for #515, but this will at least alert PPers. This is quite a rare event, but if it happens, the PPer can either copy/paste the continuation text into the correct place, or close the nested square bracket temporarily until footnote fixup is complete.

Fixes #1155