### PR TITLE
Don't report "Page_nn" ids as unused anchors

### DIFF
--- a/src/guiguts/html_tools.py
+++ b/src/guiguts/html_tools.py
@@ -1072,7 +1072,8 @@ class HTMLLinkChecker:
         unused_header = False
         rgx = r"""id *= *["'][^'"]*["']"""
         for id_name, id_pos in ids.items():
-            if id_pos.used:
+            # Don't report used anchors or page numbers - they shouldn't be removed anyway
+            if id_pos.used or re.fullmatch(r"Page_[ivxlc\d]+", id_name):
                 continue
             if not unused_header:
                 self.dialog.add_header("")


### PR DESCRIPTION
Since the PPer wouldn't/shouldn't be removing these, even if they are unused, i.e. not linked to within the file, the HTML Link Checker shouldn't report them, since they mask true positives.

Fixes #1136