### PR TITLE
Don't report pptxt straight quotes if all straight

### DIFF
--- a/src/guiguts/tools/pptxt.py
+++ b/src/guiguts/tools/pptxt.py
@@ -642,15 +642,18 @@ def weird_characters() -> None:
     weirdos_lines_dictionary: Dict[str, list[int]] = {}
     weirdos_counts_dictionary: Dict[str, int] = {}
 
+    # If no curly quotes in file, don't consider straight quotes to be weirdos
+    straight_quotes = "\"'" if csq + cdq == 0 else ""
+    weirdo_regex = r"[^A-Za-z0-9\s.,:;?!&\\\-_—–=“”‘’\[\]\(\){}" + straight_quotes + "]"
+
     # Build dictionary of unusual characters ('weirdos'). The key is a
     # weirdo and the value a list of line numbers on which that character
     # appears.
-
     for line_number, line in enumerate(book, start=1):
         if non_text_line(line):
             continue
         # Get list of weirdos on this line. That means any character NOT in the regex.
-        weirdos_list = re.findall(r"[^A-Za-z0-9\s.,:;?!&\\\-_—–=“”‘’\[\]\(\){}]", line)
+        weirdos_list = re.findall(weirdo_regex, line)
         # Update dictionary with the weirdos from the line.
         for weirdo in weirdos_list:
             # Skip exceptions

--- a/tests/expected/pptxt1.txt
+++ b/tests/expected/pptxt1.txt
@@ -93,25 +93,6 @@ Hyphen-minus (single keyboard '-')
  686.13: <i>Tempest</i>--
   ...more
 
-'"' (24)
-  86.0:  "racing polish" is put on a boat's crew which has
-  86.14: "racing polish" is put on a boat's crew which has
-  88.18: compared with the "post-graduate courses" in
-  88.40: compared with the "post-graduate courses" in
- 100.41: himself and endanger the enemy. They are "put
- 101.10: through it" in the ordinary parade movements in
- 156.0:  "picture targets" in the indispensable art of
- 156.16: "picture targets" in the indispensable art of
-  ...more
-
-''' (29)
-  86.32: "racing polish" is put on a boat's crew which has
- 140.47: gas to be met in actual warfare. But if the man's
- 159.26: course the Indian soldiers' firm balance of the body
- 179.34: exercise"--as one out of a soldier's many forms
- 237.41: trench. (If he has been wounded in No Man's
-  ...more
-
 'ô' (8)
  119.24: quarters at the base depôt[**Add circumflex above o?] camp of the division to
  476.24: having only one base depôt of petrol. At each of


### PR DESCRIPTION
If all quotes are straight this is reported near the top of the pptxt output. If that happens, then it's not necessary to also report straight quotes in the "Character Checks" section later, since they are expected characters, not unusual/surprising ones

Fixes #1130