### PR TITLE
Fix WF tooltip

### DIFF
--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -454,7 +454,7 @@ class WordFrequencyDialog(ToplevelDialog):
             "\n".join(
                 [
                     "Left click: Find first match; click again for next match",
-                    "Shift Left click: Find last match; click again for previous match"
+                    "Shift Left click: Find last match; click again for previous match",
                     f"{cmd_ctrl_string()}-left click: Find using Search dialog",
                 ]
             ),


### PR DESCRIPTION
Missing comma led to strings being concatenated, rather than joined with newline between