### PR TITLE
Add up/down buttons to checker dialogs

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -14,6 +14,7 @@ import webbrowser
 import darkdetect  # type: ignore[import-untyped]
 
 from guiguts.ascii_tables import JustifyStyle
+from guiguts.checkers import CheckerDialog
 from guiguts.content_providing import (
     export_prep_text_files,
     import_prep_text_files,
@@ -1180,6 +1181,7 @@ class Guiguts:
 
     def init_command_palette_orphans(self) -> None:
         """Add "shadow" commands to command palette."""
+        CheckerDialog.add_checker_orphan_commands()
         PreferencesDialog.add_orphan_commands()
         CommandPaletteDialog.add_orphan_commands()
         SearchDialog.add_orphan_commands()


### PR DESCRIPTION
1. Up/down arrow buttons select prev/next message in any checker dialog (not WF)
2. Shadow commands added for up/down and fix/hide/etc buttons
3. Shadow command works for the checker dialog that currently has keyboard focus. Note that this means you can't use it directly from the Command Palette (because then the Command Palette has focus), so you have to set up a keyboard shortcut.
3. Keyboard shortcut should do the same as clicking the relevant button.
4. If you use a shortcut for a button that does not exist in that dialog, e.g. Spell Check doesn't have Fix buttons, then nothing should happen.

Fixes #1080 