### PR TITLE
Don't trap GG shortcut sequences in WF

### DIFF
--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -631,6 +631,9 @@ class WordFrequencyDialog(ToplevelDialog):
         """
         if not event.char:
             return ""
+        # If modifiers other than Shift & Caps Lock, don't goto word - allow default processing
+        if int(event.state) & ~(0x0001 | 0x0002) != 0:
+            return ""
         low_char = event.char.lower()
         for idx, entry in enumerate(self.entries):
             if entry.word.lower().startswith(low_char):


### PR DESCRIPTION
Simple keystrokes navigate the WF list, e.g. "x" goes to the first word beginning with "x".

It was also trapping combinations like "Alt-d" and "Cmd-s". Allow these to pass through for default handling.

Fixes #1184


Testing notes:
1. Edit the main text so that file is modifed and needs saving.
2. Run WF - all words, and see how key strokes navigate up & down the list.
3. With focus still in WF, press Cmd+s to save file

