### PR TITLE
Improve WF whole-word searching

### DIFF
--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -631,6 +631,9 @@ class WordFrequencyDialog(ToplevelDialog):
         """
         if not event.char:
             return ""
+        # If modifiers other than Shift & Caps Lock, don't goto word - allow default processing
+        if int(event.state) & ~(0x0001 | 0x0002) != 0:
+            return ""
         low_char = event.char.lower()
         for idx, entry in enumerate(self.entries):
             if entry.word.lower().startswith(low_char):


### PR DESCRIPTION
If `Gaume` and `Gaume's` both appear in a text, they are
reported in WF as separate words. However, when `Gaume`
is clicked, it also matched `Gaume's` in the text (due to
regex wordchar/non-wordchar inconsistencices).

This commit improves on that behavior. Now, clicking
`Gaume` will find `Gaume` and `Gaume'` (closing straight
quote) and `Gaume’` (closing curly quote), but will
not match `Gaume's` or `Gaume’s` (possessive apostrophes).
Apostrophes at the start of the word are treated similarly,
i.e.  it will no longer match `O'Gaume` or `O’Gaume`.

Fixes [#1185](https://github.com/DistributedProofreaders/guiguts-py/issues/1185)
