### PR TITLE
Restore "Ctrl+K" feature as shadow command

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -1195,6 +1195,9 @@ class Guiguts:
         menubar_metadata().add_button_orphan(
             "Switch Text Window", lambda: maintext().switch_text_peer()
         )
+        menubar_metadata().add_button_orphan(
+            "Delete To End Of Line", lambda: maintext().delete_to_end_of_line()
+        )
 
     def init_statusbar(self, the_statusbar: StatusBar) -> None:
         """Add labels to initialize the statusbar.

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -4369,6 +4369,17 @@ class MainText(tk.Text):
             self.delete(f"{match_index}", f"{match_index} lineend")
             search_range = IndexRange(match.rowcol, self.end())
 
+    def delete_to_end_of_line(self) -> None:
+        """Delete from current cursor position to end of line, as Ctrl+K does
+        by default in Text widgets. If at end of line, delete newline character."""
+        self.undo_block_begin()
+        ins_idx = self.get_insert_index().index()
+        ins_end = f"{ins_idx} lineend"
+        if self.compare(ins_idx, "==", ins_end):
+            self.delete(ins_idx)
+        else:
+            self.delete(ins_idx, f"{ins_idx} lineend")
+
 
 def img_from_page_mark(mark: str) -> str:
     """Get base image name from page mark, e.g. "Pg027" gives "027".


### PR DESCRIPTION
Ctrl+K deletes to end of line by default in Tk Text widgets. We disable this because it's dangerous.

Restore it as a shadow command "Delete to end of line"

Fixes #1190

Testing notes:
This only adds the shadow command - it doesn't bind it to Ctrl+K.
PPers who are used to that behavior can do that.