### PR TITLE
Improve footnote sorting

### DIFF
--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -495,16 +495,13 @@ class FootnoteChecker:
 
 def sort_key_type(
     entry: CheckerEntry,
-) -> tuple[int, int, int]:
-    """Sort key function to sort Footnote entries by type (footnote/anchor), then rowcol.
-
-    Types are distinguished lazily - anchors have a short highlit text, "[1]"
-    """
+) -> tuple[bool, bool, str, int, int]:
+    """Sort key function to sort Footnote entries by type (footnote/anchor), error_prefix, then rowcol."""
     assert entry.text_range is not None
-    assert entry.hilite_start is not None
-    assert entry.hilite_end is not None
     return (
-        entry.hilite_end - entry.hilite_start,
+        "[Footnote" not in entry.text,
+        entry.error_prefix == "",
+        entry.error_prefix,
         entry.text_range.start.row,
         entry.text_range.start.col,
     )


### PR DESCRIPTION
Previously Alpha/Type sorting put all the anchors first, then the footnotes, and sorted within those categories by row.col

Now, put footnotes before anchors,; put those with errors before those without; sort error types alphabetically; sort within types by rowcol

Fixes #1200