### PR TITLE
Change menu button from Preferences to Settings

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -773,7 +773,7 @@ class Guiguts:
         )
         if not is_mac():
             edit_menu.add_separator()
-            edit_menu.add_button("Pre~ferences...", PreferencesDialog.show_dialog)
+            edit_menu.add_button("~Settings...", PreferencesDialog.show_dialog)
 
     def init_search_menu(self) -> None:
         """Create the Search menu."""


### PR DESCRIPTION
To reduce differences across platforms.
"Settings" is an acceptable name for Windows, and is the standard word for macOS.