### PR TITLE
Fix HTML hanging

### DIFF
--- a/src/guiguts/html_convert.py
+++ b/src/guiguts/html_convert.py
@@ -1320,7 +1320,7 @@ def html_add_chapter_divs() -> None:
             h2_start,
             f'\n\n<hr class="chap x-ebookmaker-drop">\n<div class="chapter">\n{extra_nl}',
         )
-        h2_end = maintext().index(f"{h2_end}+3l")
+        h2_end = maintext().index(f"{h2_end}+5l")
 
 
 def html_wrap_long_lines() -> None:


### PR DESCRIPTION
Minor HTML prettifying bug where it inserted 5 newline characters but only advanced its current location by 3 lines, thus checking the same line for adding the chapter div over and over again.

Fixes #1207 