### PR TITLE
Add buttons for cross-platform consistency

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -643,9 +643,8 @@ class Guiguts:
         file_menu.add_button("~Close", self.close_command, "Cmd+W" if is_mac() else "")
         self.init_file_project_menu(file_menu)
         self.init_file_content_menu(file_menu)
-        if not is_mac():
-            file_menu.add_separator()
-            file_menu.add_button("E~xit", self.quit_program, "")
+        file_menu.add_separator()
+        file_menu.add_button("~Quit", self.quit_program)
 
     def init_file_recent_menu(self, parent: MenuMetadata) -> None:
         """Create the Recent Documents menu."""
@@ -771,9 +770,8 @@ class Guiguts:
             "~Surround selected text with RLM...LRM markers",
             maintext().surround_rtl,
         )
-        if not is_mac():
-            edit_menu.add_separator()
-            edit_menu.add_button("~Settings...", PreferencesDialog.show_dialog)
+        edit_menu.add_separator()
+        edit_menu.add_button("~Settings...", PreferencesDialog.show_dialog)
 
     def init_search_menu(self) -> None:
         """Create the Search menu."""

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -644,7 +644,7 @@ class Guiguts:
         self.init_file_project_menu(file_menu)
         self.init_file_content_menu(file_menu)
         file_menu.add_separator()
-        file_menu.add_button("~Quit", self.quit_program)
+        file_menu.add_button("~Quit", self.quit_program, "Cmd+Q" if is_mac() else "")
 
     def init_file_recent_menu(self, parent: MenuMetadata) -> None:
         """Create the Recent Documents menu."""
@@ -771,7 +771,9 @@ class Guiguts:
             maintext().surround_rtl,
         )
         edit_menu.add_separator()
-        edit_menu.add_button("~Settings...", PreferencesDialog.show_dialog)
+        edit_menu.add_button(
+            "~Settings...", PreferencesDialog.show_dialog, "Cmd+," if is_mac() else ""
+        )
 
     def init_search_menu(self) -> None:
         """Create the Search menu."""

--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -644,7 +644,7 @@ class Guiguts:
         self.init_file_project_menu(file_menu)
         self.init_file_content_menu(file_menu)
         file_menu.add_separator()
-        file_menu.add_button("~Quit", self.quit_program, "Cmd+Q" if is_mac() else "")
+        file_menu.add_button("~Quit", self.quit_program)
 
     def init_file_recent_menu(self, parent: MenuMetadata) -> None:
         """Create the Recent Documents menu."""
@@ -771,9 +771,7 @@ class Guiguts:
             maintext().surround_rtl,
         )
         edit_menu.add_separator()
-        edit_menu.add_button(
-            "~Settings...", PreferencesDialog.show_dialog, "Cmd+," if is_mac() else ""
-        )
+        edit_menu.add_button("~Settings...", PreferencesDialog.show_dialog)
 
     def init_search_menu(self) -> None:
         """Create the Search menu."""


### PR DESCRIPTION
Add "Settings" to end of Edit menu, and "Quit" to
end of File menu on Macs.
On Windows/Linux, "Preferences" was changed to
"Settings" by #1205. This PR changes "Exit" to "Quit"