### PR TITLE
Add less strict curly quote conversion

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -585,6 +585,7 @@ class Guiguts:
         preferences.set_default(PrefKey.REGEX_TIMEOUT, 5)
         preferences.set_default(PrefKey.LEVENSHTEIN_DIGITS, True)
         preferences.set_default(PrefKey.CURLY_DOUBLE_QUOTE_EXCEPTION, False)
+        preferences.set_default(PrefKey.CURLY_SINGLE_QUOTE_STRICT, True)
         preferences.set_default(PrefKey.CUSTOM_MARKUP_ATTRIBUTE_0, "")
         preferences.set_default(PrefKey.CUSTOM_MARKUP_ATTRIBUTE_1, "")
         preferences.set_default(PrefKey.CUSTOM_MARKUP_ATTRIBUTE_2, "")

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -402,9 +402,20 @@ class PreferencesDialog(ToplevelDialog):
             text="Show Tooltips",
             variable=PersistentBoolean(PrefKey.SHOW_TOOLTIPS),
         ).grid(column=0, row=5, sticky="NEW", pady=5)
+        cqc = ttk.Checkbutton(
+            advance_frame,
+            text="Strict Single Curly Quote Conversion",
+            variable=PersistentBoolean(PrefKey.CURLY_SINGLE_QUOTE_STRICT),
+        )
+        cqc.grid(column=0, row=6, sticky="NEW", pady=5)
+        ToolTip(
+            cqc,
+            "On - only convert straight single quotes to curly if certain\n"
+            "Off - convert some straight single quotes inside double quotes to apostrophes",
+        )
         add_label_spinbox(
             advance_frame,
-            6,
+            7,
             "Regex timeout (seconds):",
             PrefKey.REGEX_TIMEOUT,
             "Longest time a regex search is allowed to take.\n"
@@ -414,7 +425,7 @@ class PreferencesDialog(ToplevelDialog):
             advance_frame,
             text="Reset shortcuts to default (change requires restart)",
             command=lambda: KeyboardShortcutsDict().reset(),
-        ).grid(column=0, row=7, sticky="NSW", pady=5, columnspan=3)
+        ).grid(column=0, row=8, sticky="NSW", pady=5, columnspan=3)
 
         notebook.bind(
             "<<NotebookTabChanged>>",

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -2061,7 +2061,7 @@ def convert_to_curly_quotes() -> None:
                     in_double_quotes = False
                 elif in_double_quotes and ch == "'":
                     # If single quote at start of line or start of word, assume it is an apostrophe
-                    if (idx == 0 or chars[idx - 1].isspace()) and (
+                    if (idx == 0 or chars[idx - 1] in " “>") and (
                         idx + 1 < len(chars) and chars[idx + 1].isalpha()
                     ):
                         chars[idx] = "’"

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -1999,6 +1999,7 @@ def convert_to_curly_quotes() -> None:
         if line == "":
             dqtype = 0  # Reset double quotes at paragraph break
             continue
+        start_line_dqtype = dqtype  # Needed for single quote conversion later
 
         # Apart from special cases, alternate open/close double quotes through each paragraph
         # Ditto marks first - surrounded by double-space. Also permit 0/1 space
@@ -2047,6 +2048,25 @@ def convert_to_curly_quotes() -> None:
             line, count = re.subn(regex, SQUOTES[1], line)
             if count:
                 edited = True
+        # If PPer has enabled it, convert straight quote at start of word to
+        # apostrophe if it's inside double quotes
+        if not preferences.get(PrefKey.CURLY_SINGLE_QUOTE_STRICT) and "'" in line:
+            chars = list(line)
+            # Begin with situation at start of line
+            in_double_quotes = bool(start_line_dqtype)
+            for idx, ch in enumerate(chars):
+                if ch == "“":
+                    in_double_quotes = True
+                elif ch == "”":
+                    in_double_quotes = False
+                elif in_double_quotes and ch == "'":
+                    # If single quote at start of line or start of word, assume it is an apostrophe
+                    if (idx == 0 or chars[idx - 1].isspace()) and (
+                        idx + 1 < len(chars) and chars[idx + 1].isalpha()
+                    ):
+                        chars[idx] = "’"
+                        edited = True
+            line = "".join(chars)
 
         if edited:
             maintext().replace(lstart, lend, line)

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -146,6 +146,7 @@ class PrefKey(StrEnum):
     REGEX_TIMEOUT = auto()
     LEVENSHTEIN_DIGITS = auto()
     CURLY_DOUBLE_QUOTE_EXCEPTION = auto()
+    CURLY_SINGLE_QUOTE_STRICT = auto()
     CUSTOM_MARKUP_ATTRIBUTE_0 = auto()
     CUSTOM_MARKUP_ATTRIBUTE_1 = auto()
     CUSTOM_MARKUP_ATTRIBUTE_2 = auto()


### PR DESCRIPTION
Add a preference to the Settings, Advanced Tab, for single quote conversion to be "strict" (i.e like `master`) or not.

If not, and a single quote is found within double quotes in the same paragraph, and the single quote as at the start of a word, it is assumed to be an apostrophe and converted to a curly one.

Fixes #671