### PR TITLE
Fix Curly Quote View Options

### DIFF
--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -62,9 +62,13 @@ DEFAULT_MISSPELLED_SCANNOS = "misspelled.json"
 
 CURLY_QUOTES_CHECKER_FILTERS = [
     CheckerFilterErrorPrefix("Double quote not converted", "DQ not converted: "),
-    CheckerFilterErrorPrefix("Other double quote errors", "(Open|Close) DQ.*"),
+    CheckerFilterErrorPrefix(
+        "Other double quote errors", "(Open|Close) DQ.*|DQ not closed: "
+    ),
     CheckerFilterErrorPrefix("Single quote not converted", "SQ not converted: "),
-    CheckerFilterErrorPrefix("Other single open quote errors", "Open SQ.*"),
+    CheckerFilterErrorPrefix(
+        "Other single open quote errors", "Open SQ.*|SQ not closed: "
+    ),
     CheckerFilterErrorPrefix(
         "Other single close quote errors (may be apostrophes)", "Close SQ.*"
     ),


### PR DESCRIPTION
"DQ not converted" is now included in "Other double quote errors, and similarly for single quotes.

Fixes #1215