### PR TITLE
Extend bookmarks to also save current selection

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -897,12 +897,13 @@ class Guiguts:
                 f"Ctrl+Shift+Key-{keys[kbd]}",
             )
 
-        for bm in range(1, 6):
+        for bm in range(1, len(shortcuts) + 1):
             bookmark_menu.add_button(
                 f"Go To Bookmark ~{bm}",
                 lambda num=bm: self.file.goto_bookmark(num),  # type:ignore[misc]
                 f"Ctrl+Key-{bm}",
             )
+        bookmark_menu.add_separator()
 
     def init_tools_menu(self) -> None:
         """Create the Tools menu."""

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -44,7 +44,6 @@ INDEX_END_MARK = "IndexEnd"
 INDEX_NEXT_LINE_MARK = "IndexLineStart"
 WRAP_END_MARK = "WrapSectionEnd"
 PAGEMARK_PIN = "\x7f"  # Temp char to pin page mark locations
-BOOKMARK_TAG = "Bookmark"
 PAGEMARK_PREFIX = "Pg"
 REPLACE_END_MARK = "ReplaceEnd"
 SELECTION_MARK_START = "SelectionMarkStart"
@@ -1688,6 +1687,7 @@ class MainText(tk.Text):
         elif len(ranges) > 1:
             col_range = IndexRange(ranges[0].start, ranges[-1].end)
             self.do_column_select(col_range)
+        self.focus()
 
     def selection_ranges_store_with_marks(self) -> None:
         """Set marks at start and end of selection range(s).
@@ -3884,13 +3884,13 @@ class MainText(tk.Text):
         # ** THE ORDER MATTERS HERE **
         #
         for tag in (
+            HighlightTag.BOOKMARK_TAG,
             HighlightTag.CHAR_STR_REGEX,
             HighlightTag.QUOTEMARK,
             HighlightTag.SPOTLIGHT,
             HighlightTag.PROOFERCOMMENT,
             HighlightTag.SEARCH,
             HighlightTag.PAGE_FLAG_TAG,
-            HighlightTag.BOOKMARK_TAG,
             HighlightTag.PAREN,
             HighlightTag.CURLY_BRACKET,
             HighlightTag.SQUARE_BRACKET,


### PR DESCRIPTION
When user sets bookmark, if there is a selection, also mark and save that.
When user restores such a bookmark, the selection will also be restored.

Also, highlighting of bookmarks (brief flash of green) was broken in master, so fixed as well.

Also, ensure focus is in main text after using the "restore selection" button in the toolbar

Fixes #1225 