### PR TITLE
Update Linux install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ previous version of GG2).
 Python needs to be version 3.11 or above, and GG has been tested in
 versions up to 3.13.
 
-1. Install python, pipx, and Tk. Note that on some Linux distributions, the version number for `idle-python3.12` may differ slightly.
+1. Install python, pipx, and Tk. Note that on some Linux distributions, the version number for `idle-python3.12` may differ slightly, e.g. as of this writing Debian 12 would require `idle-python3.11`.
 
     a. `apt-get update`
 
@@ -269,7 +269,6 @@ poetry env use /usr/local/bin/python3
      ## Test that Tk will work
      python3.11 -m tkinter
      ```
-   * If this does not work, try using `pipx` in place of `pip` in the above commands.
    * The last line above tests that Tk is working with Python. It should open a small
      window on your screen. Click the `Click me!` button to test mouse clicks, and
      `QUIT` to close the window, ending the test.

--- a/README.md
+++ b/README.md
@@ -45,25 +45,17 @@ previous version of GG2).
 Python needs to be version 3.11 or above, and GG has been tested in
 versions up to 3.13.
 
-1. Install python, pip3, and Tk:
+1. Install python, pipx, and Tk. Note that on some Linux distributions, the version number for `idle-python3.12` may differ slightly.
 
     a. `apt-get update`
 
-    b. `apt-get install -y python3 python3-pip python3-tk idle-python3.12`
+    b. `apt-get install -y python3 python3-pip python3-tk idle-python3.12 pipx`
 
-2. Type `pip3 install guiguts` (or `pip3 install guiguts --upgrade`
-to upgrade from a previous version of GG2).
+2. Type `pipx install guiguts` (or `pipx upgrade guiguts` to upgrade from a previous version of GG2).
 
-3. Type `guiguts` to run GG2.
+3. Add `$HOME/.local/bin` to your `$PATH` if it isn't already. Restart your shell / terminal window to refresh the path.
 
-4. If the above does not work, then 
-
-    a. Install pipx: `apt-get install -y python3-pipx`
-
-    b. Type `pipx install guiguts` (or `pipx install guiguts --upgrade`
-       to upgrade from a previous version of GG2).
-
-    c. Type `guiguts` to run GG2.
+4. Type `guiguts` to run GG2.
 
 ### Chromebook (after enabling Linux)
 
@@ -272,8 +264,8 @@ poetry env use /usr/local/bin/python3
    * Example from Ubuntu 22.04 -- adapt to your own Linux distro. Python should
      be version 3.11 or above, and GG has been tested in versions up to 3.13.
      ```bash
-     sudo apt install python3.11 python3-pip python3-tk idle-python3.11 git
-     sudo python3.11 -m pip install poetry
+     sudo apt install python3.11 python3-pip python3-tk idle-python3.11 git pipx
+     sudo pipx install poetry
      ## Test that Tk will work
      python3.11 -m tkinter
      ```


### PR DESCRIPTION
At least some Linux distributions won't let you do global installs with `pip` so as to avoid conflict with the system packaging machinery. Using pipx works around this by auto-managing a virtual environment. In my research it seems to be the case that for commands you install to run (such as guiguts), this is the preferred approach on modern Linuxes like Ubuntu 24.