### PR TITLE
Add Convert & Find Next to Auto-Illus dialog

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -1013,14 +1013,14 @@ class Guiguts:
         html_menu.add_button("HTML ~Generator...", HTMLGeneratorDialog.show_dialog)
         html_menu.add_button(
             "Auto-~Illustrations...",
-            lambda: HTMLImageDialog(auto_illus=True).show_dialog,
+            lambda: HTMLImageDialog.show_dialog(auto_illus=True),
         )
         html_menu.add_button("Auto-~Table...", HTMLAutoTableDialog.show_dialog)
         html_menu.add_separator()
         html_menu.add_button("HTML ~Markup...", HTMLMarkupDialog.show_dialog)
         html_menu.add_button("HTML ~Links/Anchors...", HTMLLinksDialog.show_dialog)
         html_menu.add_button(
-            "HTML Image~s...", lambda: HTMLImageDialog(auto_illus=False).show_dialog
+            "HTML Image~s...", lambda: HTMLImageDialog.show_dialog(auto_illus=False)
         )
         html_menu.add_separator()
         html_menu.add_button("~Unmatched HTML Tags", unmatched_html_markup)

--- a/src/guiguts/html_tools.py
+++ b/src/guiguts/html_tools.py
@@ -258,10 +258,16 @@ class HTMLImageDialog(ToplevelDialog):
         if auto_illus:
             ttk.Button(
                 btn_frame,
+                text="Convert & Find Next",
+                command=self.convert_and_advance,
+                width=18,
+            ).grid(row=0, column=1, sticky="NSEW", padx=2)
+            ttk.Button(
+                btn_frame,
                 text="Find [Illustration]",
                 command=self.find_illo_markup,
                 width=18,
-            ).grid(row=0, column=1, sticky="NSEW", padx=2)
+            ).grid(row=0, column=2, sticky="NSEW", padx=2)
 
         if auto_illus:
             self.find_illo_markup()
@@ -420,6 +426,11 @@ class HTMLImageDialog(ToplevelDialog):
         self.alt_textvariable.set("")
         self.next_file()
         self.lift()
+
+    def convert_and_advance(self) -> None:
+        """Add markup to HTML & find next illo markup."""
+        self.convert_to_html(auto_illus=True)
+        self.find_illo_markup()
 
     def convert_to_html(self, auto_illus: bool) -> None:
         """Add illustration markup to HTML.


### PR DESCRIPTION
Fixes #1233

Also, fix minor bug - when a new file is loaded, all dialogs are destroyed (to avoid leaving old data showing). This wasn't happening with Auto-illus and HTML Images dialog, so when a new text file was loaded the dialog remained in existence.