### PR TITLE
Add sizegrip to ScrolledReadonlyTexts

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -4503,7 +4503,7 @@ class ScrolledReadOnlyText(tk.Text):
         vscroll = ttk.Scrollbar(self.frame, orient=tk.VERTICAL, command=self.yview)
         vscroll.grid(column=1, row=0, sticky="NSEW")
         self["yscrollcommand"] = vscroll.set
-        ttk.Sizegrip(self.frame).grid(row=1, column=1, sticky="SE")        
+        ttk.Sizegrip(self.frame).grid(row=1, column=1, sticky="SE")
 
         self["cursor"] = "arrow"
 

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -4503,6 +4503,7 @@ class ScrolledReadOnlyText(tk.Text):
         vscroll = ttk.Scrollbar(self.frame, orient=tk.VERTICAL, command=self.yview)
         vscroll.grid(column=1, row=0, sticky="NSEW")
         self["yscrollcommand"] = vscroll.set
+        ttk.Sizegrip(self.frame).grid(row=1, column=1, sticky="SE")        
 
         self["cursor"] = "arrow"
 


### PR DESCRIPTION
These are used for checkers, WF, Help About and Message Log.

Fixes #1260