### PR TITLE
Stop checker exception if closed while running

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -1458,6 +1458,8 @@ class CheckerDialog(ToplevelDialog):
         Args:
             event: Event object containing mouse click position.
         """
+        if not self.text.winfo_exists():
+            return
         linenum = self.linenum_from_entry_index(entry_index)
         self.text.select_line(linenum)
         self.text.mark_set(tk.INSERT, f"{linenum}.0")


### PR DESCRIPTION
Specific example found was with the illo fixup, but I think it could happen with other checkers. I don't think it's related to undo/redo.

To reproduce, duplicate enough copies of the text of a file inside the file, so that illo fixup takes a few seconds to run. While it is running or re-running, close the checker dialog.

Fixes #1255