### PR TITLE
Don't report non-lowercase he/be errors

### DIFF
--- a/tests/expected/jeebies1.txt
+++ b/tests/expected/jeebies1.txt
@@ -1,4 +1,4 @@
-  --> 'be' counted 37 times and 'he' counted 15 times in file.
+  --> 'be' counted 37 times and 'he' counted 13 times in file.
 
 238.20: Land, he must first be got back into the trench.)
 535.46: their way to some other part of the front and be

--- a/tests/expected/jeebies2.txt
+++ b/tests/expected/jeebies2.txt
@@ -1,4 +1,4 @@
-  --> 'be' counted 173 times and 'he' counted 47 times in file.
+  --> 'be' counted 172 times and 'he' counted 43 times in file.
 
  106.56: An explanation of the title of this essay will no doubt be looked for in
  628.23: my list. Though a book be anonymous so far as the title page informs us,


### PR DESCRIPTION
Since it is the lowercase forms that are easily misread by OCR, Jeebies shouldn't report "HE", "Be", etc.

Fixes #1277