### PR TITLE
Avoid exception with Cmd-w and pulldown menu

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -341,7 +341,10 @@ class Guiguts:
     def close_command(self) -> None:
         """Close top-level dialog with focus, or close the file if it's
         the main window."""
-        focus_widget = maintext().focus_get()
+        try:
+            focus_widget = maintext().focus_get()
+        except KeyError:  # Weird stuff allowed to happen if dialog being closed
+            focus_widget = None
         if focus_widget is None:
             return
         focus_tl = focus_widget.winfo_toplevel()


### PR DESCRIPTION
This fix should stop the exception, though it may mean that Cmd-w doesn't close the expected window if a pulldown is open - I don't see a way round that.

Fixes #1280