### PR TITLE
Report correct location of unused CSS

### DIFF
--- a/src/guiguts/tools/pphtml.py
+++ b/src/guiguts/tools/pphtml.py
@@ -951,10 +951,11 @@ class PPhtmlChecker:
     def find_defined_class(self, css_class: str) -> Optional[IndexRange]:
         """Return index range of first occurrence of css_class in file."""
         if idx := maintext().search(
-            rf"\y{css_class}\y", "1.0", self.end_css, regexp=True
+            rf"\.{css_class}\y", "1.0", self.end_css, regexp=True
         ):
-            end_idx = maintext().rowcol(f"{idx}+{len(css_class)}c")
-            return IndexRange(IndexRowCol(idx), end_idx)
+            beg_idx = maintext().rowcol(f"{idx}+1c")
+            end_idx = maintext().rowcol(f"{idx}+{len(css_class) + 1}c")
+            return IndexRange(beg_idx, end_idx)
         return None
 
     def resolve_css(self) -> None:


### PR DESCRIPTION
It was finding the first occurrence of the class name as a word, e.g. "right", which could occur in other places. Changed to search for ".right" instead

Fixes #1296