### PR TITLE
Report WARN not FAIL in PPhtml for multiple links

### DIFF
--- a/src/guiguts/tools/pphtml.py
+++ b/src/guiguts/tools/pphtml.py
@@ -449,6 +449,7 @@ class PPhtmlChecker:
                 test_passed,
                 "Check for IDs targeted by multiple links",
                 errors,
+                fail_string="*WARN*",
             )
         else:
             self.output_subsection_errors(


### PR DESCRIPTION
It can be perfectly valid for several links to point to the same ID, so should be a warning (for PPer to check they haven't mis-linked in the ToC, for example) rather than an error.

Fixes #1301