### PR TITLE
Add keystroke character search to WF & checkers

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -415,6 +415,7 @@ class Guiguts:
         preferences.set_default(PrefKey.WFDIALOG_SORT_TYPE, WFSortType.ALPHABETIC)
         preferences.set_default(PrefKey.CHECKERDIALOG_SORT_TYPE_DICT, {})
         preferences.set_default(PrefKey.CHECKERDIALOG_SUSPECTS_ONLY_DICT, {})
+        preferences.set_default(PrefKey.CHECKERDIALOG_FULL_SEARCH, False)
         preferences.set_default(PrefKey.WFDIALOG_ITALIC_THRESHOLD, ["4"])
         preferences.set_default(PrefKey.WFDIALOG_REGEX, [])
         preferences.set_default(PrefKey.WFDIALOG_HYPHEN_TWO_WORDS, False)

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -525,18 +525,29 @@ class CheckerDialog(ToplevelDialog):
         updown_frame = ttk.Frame(self.message_controls_frame)
         updown_frame.grid(row=0, column=6, sticky="NSE")
         updown_frame.rowconfigure(0, weight=1)
+        full_search_btn = ttk.Checkbutton(
+            updown_frame,
+            text="Full🔎",
+            variable=PersistentBoolean(PrefKey.CHECKERDIALOG_FULL_SEARCH),
+            command=lambda: self.select_entry_by_arrow(0),
+        )
+        full_search_btn.grid(row=0, column=0, sticky="NS", padx=5)
+        ToolTip(
+            full_search_btn,
+            "When checked, typing will match against full message text, not just start",
+        )
         ttk.Button(
             updown_frame,
             text="⇑",
             width=2,
             command=lambda: self.select_entry_by_arrow(-1),
-        ).grid(row=0, column=0, sticky="NS", padx=(5, 0))
+        ).grid(row=0, column=1, sticky="NS")
         ttk.Button(
             updown_frame,
             text="⇓",
             width=2,
             command=lambda: self.select_entry_by_arrow(1),
-        ).grid(row=0, column=1, sticky="NS")
+        ).grid(row=0, column=2, sticky="NS")
 
         self.view_options_dialog: Optional[CheckerViewOptionsDialog] = None
 
@@ -1256,6 +1267,7 @@ class CheckerDialog(ToplevelDialog):
 
         n_entries = len(self.entries)
         self.search_buffer += low_char
+        full_search = preferences.get(PrefKey.CHECKERDIALOG_FULL_SEARCH)
         # If nothing selected, pretend last item was selected
         selected = self.current_entry_index() or n_entries - 1
         # If first keypress, start from next entry, so we don't re-find selected one
@@ -1267,7 +1279,12 @@ class CheckerDialog(ToplevelDialog):
             entry = self.entries[idx]
             if self.skip_entry(entry):
                 continue
-            if entry.text.lower().startswith(self.search_buffer):
+            low_text = entry.text.lower()
+            if full_search:
+                found = self.search_buffer in low_text
+            else:
+                found = low_text.startswith(self.search_buffer)
+            if found:
                 self.select_entry_by_index(idx, focus=False)
                 return "break"
         return ""

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -619,6 +619,11 @@ class CheckerDialog(ToplevelDialog):
                 lambda _e: self.select_entry_by_index(len(self.entries) - 1),
             )
 
+        # Bind keystrokes to search function
+        self.text.bind("<Key>", self.select_entry_by_letters)
+        self.search_buffer = ""
+        self.reset_timer_id = ""
+
         self.process_command = process_command
         self.rowcol_key = sort_key_rowcol or CheckerDialog.sort_key_rowcol
         self.alpha_key = sort_key_alpha or CheckerDialog.sort_key_alpha
@@ -1219,6 +1224,53 @@ class CheckerDialog(ToplevelDialog):
             return "break"
         self.select_entry_by_index(entry_index)
         return "break"
+
+    def select_entry_by_letters(self, event: tk.Event) -> str:
+        """Go to first occurrence of word beginning with typed character(s).
+
+        Args:
+            event: Event containing keystroke.
+
+        Returns:
+            "break" to stop further processing of events if valid character
+        """
+        if not event.char or not event.char.isprintable():
+            return ""
+        # If modifiers other than Shift & Caps Lock, don't goto word - allow default processing
+        if int(event.state) & ~(0x0001 | 0x0002) != 0:
+            return ""
+        low_char = event.char.lower()
+
+        def reset_buffer() -> None:
+            """Reset the search buffer and the reset timer"""
+            self.reset_timer_id = ""
+            self.search_buffer = ""
+
+        # If timer running, cancel it - new one is started below
+        if self.reset_timer_id:
+            self.after_cancel(self.reset_timer_id)
+            self.reset_timer_id = ""
+
+        # If user doesn't press another key within 1 second, reset the search buffer
+        self.reset_timer_id = self.after(1000, reset_buffer)
+
+        n_entries = len(self.entries)
+        self.search_buffer += low_char
+        # If nothing selected, pretend last item was selected
+        selected = self.current_entry_index() or n_entries - 1
+        # If first keypress, start from next entry, so we don't re-find selected one
+        if len(self.search_buffer) == 1:
+            selected = selected + 1
+        # Search from selected to end of list & wrap to beginning
+        for loop in range(n_entries):
+            idx = (selected + loop) % n_entries
+            entry = self.entries[idx]
+            if self.skip_entry(entry):
+                continue
+            if entry.text.lower().startswith(self.search_buffer):
+                self.select_entry_by_index(idx, focus=False)
+                return "break"
+        return ""
 
     def process_entry_by_click(
         self, event: tk.Event, all_matching: bool = False

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -180,6 +180,7 @@ class PrefKey(StrEnum):
     PPTXT_HTML_CHECK = auto()
     PPTXT_UNICODE_NUMERIC_CHARACTER_CHECK = auto()
     PPTXT_SPECIALS_CHECK = auto()
+    CHECKERDIALOG_FULL_SEARCH = auto()
 
 
 class Preferences:


### PR DESCRIPTION
Typing a single key searched for the first occurrence of a
word beginning with the letter. Extend this to checker
dialogs. Also, if multiple keys typed less than 1 second apart,
search for message beginning with whole string, like an
incremental search.

Since checkers often contain longer messages than WF,
e.g. context of error, as well as headings, add a "Full search"
option (next to up/down arrows) that searches whole of
message text (not row/col, nor red error type) rather than
only matching at the start of the text.

Example: running pptxt, type "ellipsis" to jump to section
describing ellipsis checks.