### PR TITLE
Shadow command to replace Ctrl-D

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -1243,6 +1243,9 @@ class Guiguts:
         menubar_metadata().add_button_orphan(
             "Delete To End Of Line", lambda: maintext().delete_to_end_of_line()
         )
+        menubar_metadata().add_button_orphan(
+            "Delete Next Character", lambda: maintext().delete_next_character()
+        )
 
         def open_file_number(fn: int) -> None:
             """Open recent file number `fn`."""

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -4391,6 +4391,12 @@ class MainText(tk.Text):
         else:
             self.delete(ins_idx, f"{ins_idx} lineend")
 
+    def delete_next_character(self) -> None:
+        """Delete character to right of current cursor position, as Ctrl+D does
+        by default in Text widgets. If at end of line, delete newline character."""
+        self.undo_block_begin()
+        self.delete(self.get_insert_index().index())
+
 
 def img_from_page_mark(mark: str) -> str:
     """Get base image name from page mark, e.g. "Pg027" gives "027".

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -4395,7 +4395,12 @@ class MainText(tk.Text):
         """Delete character to right of current cursor position, as Ctrl+D does
         by default in Text widgets. If at end of line, delete newline character."""
         self.undo_block_begin()
-        self.delete(self.get_insert_index().index())
+        ranges = maintext().selected_ranges()
+        if ranges:
+            for _range in ranges:
+                self.delete(_range.start.index(), _range.end.index())
+        else:
+            self.delete(self.get_insert_index().index())
 
 
 def img_from_page_mark(mark: str) -> str:

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -4394,7 +4394,7 @@ class MainText(tk.Text):
     def delete_next_character(self) -> None:
         """Delete character to right of current cursor position, as Ctrl+D does
         by default in Text widgets. If at end of line, delete newline character."""
-        self.undo_block_begin()
+        # undo_block_begin is intentionally NOT used here
         ranges = maintext().selected_ranges()
         if ranges:
             for _range in ranges:


### PR DESCRIPTION
Implements a shadow command to replace the disabled Ctrl-D binding. Deletes the character at the cursor position, meaning the character to the right. If at end of line, it deletes the newline, causing the next line to come up and join with the current line.

Testing notes:
- This can technically be tested from the command palette, but it's meant to be used as a keyboard binding.
- Load or add any text, then use the binding to delete the character to the right of the cursor
- Go to end of line; deleting there should bring the next line up due to deleting the newline.