### PR TITLE
Improve HTML autogeneration

### DIFF
--- a/tests/expected/htmlconvert1.txt
+++ b/tests/expected/htmlconvert1.txt
@@ -304,7 +304,7 @@ img.w100 {width: 100%;}
   <span class="smcap">London</span>.
 </p>
 </div>
-——-File: 005.png————————————————————————————-
+<p>——-File: 005.png————————————————————————————-</p>
 
 <hr class="chap x-ebookmaker-drop">
 <div class="chapter">

--- a/tests/expected/htmlconvert1.txt
+++ b/tests/expected/htmlconvert1.txt
@@ -294,13 +294,17 @@ img.w100 {width: 100%;}
 </p>
 <p>——-File: 004.png————————————————————————————-</p>
 
+<hr class="chap x-ebookmaker-drop">
+
+<div class="chapter">
 <p>
   Printed in Great Britain by<br>
   <span class="smcap">The Avenue Press</span><br>
   (<span class="smcap">L. Upcott Gill &amp; Son, Ltd.</span>),<br>
   <span class="smcap">London</span>.
 </p>
-<p>——-File: 005.png————————————————————————————-</p>
+</div>
+——-File: 005.png————————————————————————————-
 
 <hr class="chap x-ebookmaker-drop">
 <div class="chapter">

--- a/tests/expected/htmlconvert2.txt
+++ b/tests/expected/htmlconvert2.txt
@@ -271,6 +271,9 @@ CHERRY-BLOSSOMS
 </p>
 <p>]</p>
 
+<hr class="chap x-ebookmaker-drop">
+
+<div class="chapter">
 <p>
   <i>Copyright, 1896</i>,<br>
   <span class="smcap">By Dodd, Mead and Company</span>.<br>
@@ -281,11 +284,16 @@ CHERRY-BLOSSOMS
   University Press:<br>
   <span class="smcap">John Wilson and Son, Cambridge, U.S.A.</span>
 </p>
+</div>
 
+<hr class="chap x-ebookmaker-drop">
+
+<div class="chapter">
 <p>
   TO<br>
   MY HUSBAND.
 </p>
+</div>
 
 <p>[Illustration: Clad in native costume]</p>
 


### PR DESCRIPTION
Remove/preserve block markup surrounding the book
title as appropriate.
1. If block markup only surrounds title, remove it.
2. If title at start of block markup, move it up outside the block markup
3. If title at end of block markup, move if down outside the block markup
4. If title in middle of block markup, just let it add h1 markup inside the HTML that the block markup generates. May be incorrect HTML if markup and title are giving autogenerate contradictory instructions

Also, add chapter div around block markup that has 4 or more blank lines before it, e.g. verso page.

Fixes #1307