### PR TITLE
Allow user to drag selected text to another place

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -2135,6 +2135,8 @@ class MainText(tk.Text):
 
     def cancel_drag_sel(self) -> None:
         """Cancel dragging selected text."""
+        if not self.dragging:
+            return
         self.dragging = False
         self._delete_drag_window()
         self.config(cursor="")
@@ -2176,9 +2178,11 @@ class MainText(tk.Text):
         self.drag_window.geometry(f"+{x}+{y}")
         assert self.drag_copy_label is not None
         if self._is_copy_mode(event):
-            self.drag_copy_label.grid()  # Show "+" label when copying
+            self.drag_copy_label.grid()  # Show "+" label/cursor when copying
+            event.widget.config(cursor="cross")
         else:
-            self.drag_copy_label.grid_remove()  # Hide "+" label when moving
+            self.drag_copy_label.grid_remove()  # Hide "+" label & use 4-way arrow cursor when moving
+            event.widget.config(cursor="fleur")
 
     def _delete_drag_window(self) -> None:
         """Delete the drag preview window."""


### PR DESCRIPTION
Initial commit to gather feedback...

1. Only drags the first bit of a column selection - one possibility instead would be to disable dragging if there's a column selection
2. If you drag below the bottom of the screen, it still works, but appears to select all the intervening text until you release the mouse, when the dragged text should appear in the correct place. Again, may be possible to fix.
3. Dropping should drop immediately before the character the mouse is released over, unless at the very right of that character, in which case it should go to the right.

Testing:
Drag small bits of text left and right, as well as larger chunks up or down.