### PR TITLE
Add sorting to the Compose Help dialog

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -445,6 +445,8 @@ class Guiguts:
         preferences.set_callback(PrefKey.THEME_NAME, self.theme_name_callback)
         preferences.set_default(PrefKey.TEAROFF_MENUS, False)
         preferences.set_default(PrefKey.COMPOSE_HISTORY, [])
+        preferences.set_default(PrefKey.COMPOSE_HELP_SORT, 1)
+        preferences.set_default(PrefKey.COMPOSE_HELP_HISTORY, [])
         # Since fonts aren't available until Tk has initialized, set default font family
         # to be empty string here, and set the true default later in MainText.
         preferences.set_default(PrefKey.TEXT_FONT_FAMILY, "")

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -73,6 +73,8 @@ class PrefKey(StrEnum):
     THEME_NAME = auto()
     TEAROFF_MENUS = auto()
     COMPOSE_HISTORY = auto()
+    COMPOSE_HELP_SORT = auto()
+    COMPOSE_HELP_HISTORY = auto()
     TEXT_FONT_FAMILY = auto()
     TEXT_FONT_SIZE = auto()
     GLOBAL_FONT_FAMILY = auto()


### PR DESCRIPTION
1. Display an arrow in the header of the dialog to show how the list is sorted.
2. Click in the header to sort by that column
3. Click again to reverse sort
4. Sort method is stored in prefs file, so persistent across runs of the program

Fixes #1021

I don't think a help dialog warrants a search field and button as I suggested in point 2 of the issue. It's very quick to find any character if you sort the list by character name. The GG1 equivalent is just a list. In GG2, we now have sorting, and you can click on items in the list to insert the character, but its main purpose is to help if you can't remember the compose sequence for a character you want.