### PR TITLE
Fix exception caused by searching for bad regex

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -2615,6 +2615,13 @@ class MainText(tk.Text):
             )
             self.highlight_search_deactivate()
             return None, 0
+        except re.error as e:
+            logger.error(
+                f"Regex error: {str(e)}\n\n"
+                "Search highlighting turned off temporarily."
+            )
+            self.highlight_search_deactivate()
+            return None, 0
         if match is None:
             return None, 0
 


### PR DESCRIPTION
If the user ignored the red regex warning and searches anyway, the search match highlighting code raised an exception.

Treat like the regex timeout situation - output a single error and turn off match highlights until the user does another search.

Fixes #1318