### PR TITLE
Warn if if no blank line before block in HTML-gen

### DIFF
--- a/src/guiguts/html_convert.py
+++ b/src/guiguts/html_convert.py
@@ -361,8 +361,9 @@ def html_convert_body() -> None:
         "sc": False,
     }  # Flags to track open inline markup across lines
 
-    def check_illegal_nesting() -> None:
-        """Raise exception if already inside block markup."""
+    def check_valid_open_markup() -> None:
+        """Raise exception if already inside block markup, or if no blank line
+        immediately preceding."""
         if (
             pre_flag  # pylint: disable=too-many-boolean-expressions
             or front_flag
@@ -375,6 +376,14 @@ def html_convert_body() -> None:
             or index_flag
         ):
             raise SyntaxError(f"Line {step}: Illegally nested block markup")
+        if step == 1:  # OK if first line of file
+            return
+        prev_line = maintext().get(f"{step-1}.0", f"{step-1}.end")
+        # Previous line must be blank, or open block quote (div or blockquote)
+        if prev_line and not prev_line.startswith(("<div", "<blockquote")):
+            raise SyntaxError(
+                f"Line {step}: Open block markup must be preceded by blank line"
+            )
 
     def reset_ibs_dict() -> None:
         """Set the italic/bold/smcap flags to False when starting a new block."""
@@ -461,6 +470,7 @@ def html_convert_body() -> None:
 
         # "/f" --> center all paragraphs until we get "f/"
         if selection_lower == "/f":  # open
+            check_valid_open_markup()
             maintext().delete(line_start, line_end)
             front_flag = True
             markup_start = step
@@ -483,6 +493,7 @@ def html_convert_body() -> None:
 
         # "/p" --> poetry until we get "p/"
         if selection_lower == "/p":  # open
+            check_valid_open_markup()
             p_chapter_div_open = maybe_insert_chapter_div(line_start)
             poetry_flag = True
             markup_start = step
@@ -541,6 +552,7 @@ def html_convert_body() -> None:
 
         # "/l" --> list until we get "l/"
         if selection_lower == "/l":  # open
+            check_valid_open_markup()
             l_chapter_div_open = maybe_insert_chapter_div(line_start)
             maintext().replace(
                 line_start,
@@ -596,7 +608,7 @@ def html_convert_body() -> None:
 
         # "/$" --> nowrap until we get "$/"
         if selection == "/$":  # open
-            check_illegal_nesting()
+            check_valid_open_markup()
             d_chapter_div_open = maybe_insert_chapter_div(line_start)
             dollar_nowrap_flag = True
             markup_start = step
@@ -618,7 +630,7 @@ def html_convert_body() -> None:
             continue
         # "/*" --> nowrap until we get "*/"
         if selection == "/*":  # open
-            check_illegal_nesting()
+            check_valid_open_markup()
             a_chapter_div_open = maybe_insert_chapter_div(line_start)
             asterisk_nowrap_flag = True
             markup_start = step
@@ -655,7 +667,7 @@ def html_convert_body() -> None:
 
         # "/i" --> index until we get "i/"
         if selection_lower.startswith("/i"):  # open
-            check_illegal_nesting()
+            check_valid_open_markup()
             i_chapter_div_open = maybe_insert_chapter_div(line_start)
             index_flag = True
             markup_start = step
@@ -706,7 +718,7 @@ def html_convert_body() -> None:
 
         # "/c" --> center until we get "c/"
         if selection_lower == "/c":  # open
-            check_illegal_nesting()
+            check_valid_open_markup()
             c_chapter_div_open = maybe_insert_chapter_div(line_start)
             center_nowrap_flag = True
             markup_start = step
@@ -734,7 +746,7 @@ def html_convert_body() -> None:
 
         # "/r" --> right-align block until we get "r/"
         if selection_lower == "/r":  # open
-            check_illegal_nesting()
+            check_valid_open_markup()
             r_chapter_div_open = maybe_insert_chapter_div(line_start)
             right_nowrap_flag = True
             markup_start = step

--- a/src/guiguts/html_convert.py
+++ b/src/guiguts/html_convert.py
@@ -268,11 +268,15 @@ def html_convert_title() -> None:
         )
         # Work in reverse to avoid affecting index locations - add "</h1>" markup
         if block_markup_after:  # Markup after needs removing
-            maintext().replace(f"{end}+1l linestart", f"{end}+1l lineend", "</h1>")
+            maintext().replace(f"{end}+1l linestart", f"{end}+1l lineend", "</h1>\n")
         elif block_markup_before:  # Insert "before" markup after "</h1>"
-            maintext().insert(end, f"\n</h1>\n{prev_line}")
+            maintext().insert(end, f"\n</h1>\n\n{prev_line}")
+            # Remove blank line after inserted block markup
+            blank = f"{end} +4l"
+            if maintext().get(f"{blank} linestart", f"{blank} lineend") == "":
+                maintext().delete(f"{blank} linestart", f"{blank} +1l linestart")
         else:
-            maintext().insert(end, "\n</h1>")
+            maintext().insert(end, "\n</h1>\n")
         # Add "<br>" on  intervening lines
         for row in range(title_match.rowcol.row, end_row):
             maintext().insert(f"{row}.end", "<br>")


### PR DESCRIPTION
If block markup (p, f, l, $, *, i, c, r), check there is a blank line before it, or an open blockquote or div, because block markup is permitted immediately inside blockquote without a blank line before it. One type of block markup cannot be nested inside another.

Fixes #1329

Testing notes: variations on the text in the linked issue should give error if any block type doesn't have a blank line before it, unless it's at the start of blockquote markup.
