### PR TITLE
Add advanced Home key behavior

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -3477,11 +3477,9 @@ class MainText(tk.Text):
     def go_home(self, event: tk.Event) -> str:
         """Handle the Home key. Either move to start of line, or if
         already there, move to first non-space on line."""
-        print(f"Entry: {event.state:x}", flush=True)
         if int(event.state) & 0x0004:
             return ""
         start = self.get_insert_index()
-        print(f"Start {start}", flush=True)
         # If already at home, move forward to first non-space
         if start.col == 0:
             idx = start.index()
@@ -3489,7 +3487,6 @@ class MainText(tk.Text):
             new = IndexRowCol(start.row, len(line) - len(line.lstrip(" ")))
         else:
             new = IndexRowCol(start.row, 0)
-        print(f"New {new}", flush=True)
         event.widget.mark_set(tk.INSERT, new.index())
         # If Shift key is held, need to adjust selection
         if int(event.state) & 0x0001:
@@ -3501,18 +3498,15 @@ class MainText(tk.Text):
                     sel.start = new
                 elif sel.end == start:
                     sel.end = new
-                print(f"Sel {sel.start.index()} {sel.end.index()}", flush=True)
                 # Ensure start of selection is before end
                 if self.compare(sel.start.index(), ">", sel.end.index()):
                     sel.start, sel.end = sel.end, sel.start
                 self.do_select(sel)
             # If no selection, select from start position to "Home"
             else:
-                print("Selecting new start", flush=True)
                 self.do_select(IndexRange(new, start))
         # If no Shift, just moving, so clear selection
         else:
-            print("Clearing selection", flush=True)
             self.clear_selection()
         return "break"
 

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -3473,9 +3473,11 @@ class MainText(tk.Text):
     def go_home(self, event: tk.Event) -> str:
         """Handle the Home key. Either move to start of line, or if
         already there, move to first non-space on line."""
+        print(f"Entry: {event.state:x}", flush=True)
         if int(event.state) & 0x0004:
             return ""
         start = self.get_insert_index()
+        print(f"Start {start}", flush=True)
         # If already at home, move forward to first non-space
         if start.col == 0:
             idx = start.index()
@@ -3483,6 +3485,7 @@ class MainText(tk.Text):
             new = IndexRowCol(start.row, len(line) - len(line.lstrip(" ")))
         else:
             new = IndexRowCol(start.row, 0)
+        print(f"New {new}", flush=True)
         event.widget.mark_set(tk.INSERT, new.index())
         # If Shift key is held, need to adjust selection
         if int(event.state) & 0x0001:
@@ -3494,15 +3497,18 @@ class MainText(tk.Text):
                     sel.start = new
                 elif sel.end == start:
                     sel.end = new
+                print(f"Sel {sel.start.index()} {sel.end.index()}", flush=True)
                 # Ensure start of selection is before end
                 if self.compare(sel.start.index(), ">", sel.end.index()):
                     sel.start, sel.end = sel.end, sel.start
                 self.do_select(sel)
             # If no selection, select from start position to "Home"
             else:
+                print("Selecting new start", flush=True)
                 self.do_select(IndexRange(new, start))
         # If no Shift, just moving, so clear selection
         else:
+            print("Clearing selection", flush=True)
             self.clear_selection()
         return "break"
 

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1041,6 +1041,11 @@ class MainText(tk.Text):
 
         self.bind_event("<Leave>", leave_event, add=True, bind_peer=True)
 
+        # Override "Home" behavior
+        self.bind_event("<Home>", self.go_home, add=True, bind_peer=True)
+        if is_mac():
+            self.bind_event("<Command-Left>", self.go_home, add=True, bind_peer=True)
+
         # get the current bind tags
         bindtags = list(self.bindtags())
 
@@ -3464,6 +3469,42 @@ class MainText(tk.Text):
         start = "1.0"
         while start := self.search(" +$", start, regexp=True):
             self.delete(start, f"{start} lineend")
+
+    def go_home(self, event: tk.Event) -> str:
+        """Handle the Home key. Either move to start of line, or if
+        already there, move to first non-space on line."""
+        if int(event.state) & 0x0004:
+            return ""
+        start = self.get_insert_index()
+        # If already at home, move forward to first non-space
+        if start.col == 0:
+            idx = start.index()
+            line = maintext().get(idx, f"{idx} lineend")
+            new = IndexRowCol(start.row, len(line) - len(line.lstrip(" ")))
+        else:
+            new = IndexRowCol(start.row, 0)
+        event.widget.mark_set(tk.INSERT, new.index())
+        # If Shift key is held, need to adjust selection
+        if int(event.state) & 0x0001:
+            # If there's already a selection range with start index as one of
+            # its boundaries, adjust that boundary to the new position
+            if selns := self.selected_ranges():
+                sel = selns[0]
+                if sel.start == start:
+                    sel.start = new
+                elif sel.end == start:
+                    sel.end = new
+                # Ensure start of selection is before end
+                if self.compare(sel.start.index(), ">", sel.end.index()):
+                    sel.start, sel.end = sel.end, sel.start
+                self.do_select(sel)
+            # If no selection, select from start position to "Home"
+            else:
+                self.do_select(IndexRange(new, start))
+        # If no Shift, just moving, so clear selection
+        else:
+            self.clear_selection()
+        return "break"
 
     def store_page_mark(self, mark: str) -> None:
         """Store a page mark for use when page marks are coincident.

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1043,8 +1043,12 @@ class MainText(tk.Text):
 
         # Override "Home" behavior
         self.bind_event("<Home>", self.go_home, add=True, bind_peer=True)
+        self.bind_event("<Shift-Home>", self.go_home, add=True, bind_peer=True)
         if is_mac():
             self.bind_event("<Command-Left>", self.go_home, add=True, bind_peer=True)
+            self.bind_event(
+                "<Shift-Command-Left>", self.go_home, add=True, bind_peer=True
+            )
 
         # get the current bind tags
         bindtags = list(self.bindtags())


### PR DESCRIPTION
If Home (or Cmd-Left) is pressed, go to start of line. If already at start of line, then go to first non-space on current line. If Shift is pressed then make selection or adjust start/end of existing selection to "home" position depending on where current insert position is.

Fixes #1160