### PR TITLE
Add Go Back and Go Forward to Search menu

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -842,6 +842,14 @@ class Guiguts:
             replace_matched_string,
         )
         search_menu.add_separator()
+        search_menu.add_button(
+            "Go ~Back",
+            lambda: maintext().go_back(),
+        )
+        search_menu.add_button(
+            "Go ~Forward",
+            lambda: maintext().go_forward(),
+        )
         self.init_search_goto_menu(search_menu)
         search_menu.add_separator()
         search_menu.add_button(

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -18,6 +18,8 @@ from guiguts.maintext import (
     PAGEMARK_PIN,
     img_from_page_mark,
     page_mark_from_img,
+    MainText,
+    TextPeer,
 )
 from guiguts.page_details import (
     PageDetail,
@@ -277,6 +279,7 @@ class File:
         self.languages = preferences.get(PrefKey.DEFAULT_LANGUAGES)
         mainimage().reset_rotation_details()
         bin_matches_file = self.load_bin(filename)
+        maintext().go_clear()
         self.mark_page_boundaries()
         flags_found = (
             self.update_page_marks_from_flags() or self.update_page_marks_from_ppgen()
@@ -633,7 +636,9 @@ class File:
                 mark = page_mark_from_img(img)
                 maintext().set_mark_position(mark, IndexRowCol(detail["index"]))
 
-    def set_initial_position(self, index: str | None, widget: tk.Text) -> None:
+    def set_initial_position(
+        self, index: str | None, widget: MainText | TextPeer
+    ) -> None:
         """Set initial cursor position after file is loaded.
 
         Args:


### PR DESCRIPTION
When GG jumps to a location and displays it roughly in the center of the screen, e.g. through a Search or clicking on a Checker message (not with arrow keys or similar movements) the location (BEFORE jumping) is pushed on a stack. Go Back and Go Forward navigate through that stack, in a similar way to an Undo/Redo stack.

Fixes #916 (Buttons to be added to toolbar in #1342)

### Testing notes:

Note that as stated above, the location that is saved is the cursor position BEFORE the jump, not the location jumped to. This corresponds to "go back to where I was before I came here".

The stack size is limited to 100, which means you can go back 99 times (plus the location you first went back from), and from the final back step, you can go forward 99 times. If you want to reduce that for testing purposes, e.g. to 3 or 5, the line to edit is maintext.py:582, where `self.history_size` is set to 100.

It is possible to get the same location occurring more than once in the stack, but it should not appear twice consecutively. For example, you could search for a word near the start of the file, then search for a word near the end, then search for the word near the start again, then the one at the end. The stack would then contain "initial location", "start word", "end word", "start word". 

If you go back in the stack some way, then do a new search, the "forward" part of the stack is removed (like the redo stack being lost when you make a manual edit). 
