### PR TITLE
Add support for HTML curly quote conversion

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -92,6 +92,8 @@ from guiguts.misc_tools import (
     DEFAULT_MISSPELLED_SCANNOS,
     convert_to_curly_quotes,
     check_curly_quotes,
+    protect_html_straight_quotes,
+    restore_html_straight_quotes,
     indent_selection,
     align_selection,
     right_align_numbers,
@@ -983,8 +985,16 @@ class Guiguts:
         tools_menu.add_button("R~ewrap Selection", self.file.rewrap_selection)
         tools_menu.add_button("C~lean Up Rewrap Markers", self.file.rewrap_cleanup)
         tools_menu.add_separator()
-        tools_menu.add_button("Convert to Curly ~Quotes", convert_to_curly_quotes)
-        tools_menu.add_button("Check Curly Quo~tes", check_curly_quotes)
+        curly_menu = tools_menu.add_submenu("Curly ~Quotes")
+        curly_menu.add_button("Convert to Curly ~Quotes", convert_to_curly_quotes)
+        curly_menu.add_button("~Check Curly Quotes", check_curly_quotes)
+        curly_menu.add_separator()
+        curly_menu.add_button(
+            "~Protect HTML Straight Quotes", protect_html_straight_quotes
+        )
+        curly_menu.add_button(
+            "~Restore HTML Straight Quotes", restore_html_straight_quotes
+        )
 
         unmatched_menu = tools_menu.add_submenu("Un~matched")
         unmatched_menu.add_button("Bloc~k Markup", unmatched_block_markup)


### PR DESCRIPTION
Add two new curly quote buttons, in a submenu. The first converts straight quotes that are inside HTML tags to obscure characters, just like ppsmq, but GG copes with tags that are split across line breaks, such as
```
<  div class
= "test"
>
```

Second button does the reverse, converting ALL
occurrences of contour/surface integral characters back to straight quotes.

This therefore provides at least the functionality of ppsmq, and can probably cope better with real-life occurrences of `<` or `>` in the text.

The reason for doing it this way rather than trying to make both Convert to Curly Quotes and Check Curly Quotes cope with HTML tags is that it would introduce too much complexity into the curly quotes code, potentially breaking it for the 99% of cases which are not HTML files.

Fixes #1216