### PR TITLE
Don't report XHTML header external links

### DIFF
--- a/src/guiguts/tools/pphtml.py
+++ b/src/guiguts/tools/pphtml.py
@@ -319,6 +319,9 @@ class PPhtmlChecker:
         count_links = 0
         for line_num, line in enumerate(self.file_lines):
             if match := re.search(r"https?://[^'\"\) ]*", line):
+                # Don't report links to w3.org in the first few lines
+                if line_num < 5 and re.match(r"https?://www.w3.org/", match[0]):
+                    continue
                 test_passed = False
                 if count_links <= 10:
                     start = IndexRowCol(line_num + 1, match.span()[0])


### PR DESCRIPTION
XHTML files (example in linked issue) have links to `www.w3.org` - don't report these if in the first 5 lines of the HTML file.

Fixes #1069