### PR TITLE
Add pinning to dialogs

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -647,6 +647,7 @@ class Guiguts:
         preferences.set_default(PrefKey.PPTXT_HTML_CHECK, True)
         preferences.set_default(PrefKey.PPTXT_UNICODE_NUMERIC_CHARACTER_CHECK, True)
         preferences.set_default(PrefKey.PPTXT_SPECIALS_CHECK, True)
+        preferences.set_default(PrefKey.DIALOG_PIN_DICT, {})
 
         # Check all preferences have a default
         for pref_key in PrefKey:
@@ -1114,6 +1115,11 @@ class Guiguts:
             lambda: maintext().hide_peer(),
             "Cmd/Ctrl+Shift+T",
         )
+        if not is_x11():
+            view_menu.add_button(
+                "~Pin/Unpin Dialog",
+                ToplevelDialog.toggle_pin_last_dialog,
+            )
         view_menu.add_separator()
         view_menu.add_checkbutton(
             "Image ~Viewer",

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -186,6 +186,7 @@ class PrefKey(StrEnum):
     PPTXT_UNICODE_NUMERIC_CHARACTER_CHECK = auto()
     PPTXT_SPECIALS_CHECK = auto()
     CHECKERDIALOG_FULL_SEARCH = auto()
+    DIALOG_PIN_DICT = auto()
 
 
 class Preferences:

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -80,7 +80,7 @@ class ToplevelDialog(tk.Toplevel):
             self._pin_menu = tk.Menu(self, tearoff=False)
             self._pin_menu.add_command(label="Pin 📌", command=self.toggle_pin)
             mouse_bind(self, "3", self._show_context_menu)
-            self.pin_unpin()
+            self.pin_unpin(first=True)
 
         self.columnconfigure(0, weight=1)
         self.rowconfigure(0, weight=1)
@@ -183,14 +183,23 @@ class ToplevelDialog(tk.Toplevel):
         self.save_dialog_pref(PrefKey.DIALOG_PIN_DICT, new_pin)
         self.pin_unpin()
 
-    def pin_unpin(self) -> None:
-        """Pin/unpin dialog based on it's pref setting."""
+    def pin_unpin(self, first: bool = False) -> None:
+        """Pin/unpin dialog based on it's pref setting.
+
+        Args:
+            first: Set True on first call for this dialog.
+        """
         if self.is_pinned():
             self.transient(root())
             self.title(f"{self.base_title} 📌")
         else:
             self.transient(None)
-            self.title(self.base_title)
+            # Window manager won't release dialog even with the above call, so if
+            # unpinning from pinned, tell user they need to close the dialog to fully unpin.
+            if first:
+                self.title(self.base_title)
+            else:
+                self.title(f"{self.base_title} 📌 (will unpin when closed)")
 
     def _show_context_menu(self, event: tk.Event) -> None:
         """Display pin/unpin context menu."""

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -41,6 +41,9 @@ class ToplevelDialog(tk.Toplevel):
     # Used to ensure only one instance of any dialog is created.
     toplevel_dialogs: dict[str, "ToplevelDialog"] = {}
 
+    # Most recently focused dialog - must check it still exists before using it
+    recent_dialog: Optional[tk.Toplevel] = None
+
     # Location of manual page for most recently focused dialog
     context_help = ""
     manual_page: Optional[str] = None
@@ -68,8 +71,16 @@ class ToplevelDialog(tk.Toplevel):
 
         super().__init__(**kwargs)
         self.bind("<Escape>", lambda event: self.destroy())
-        self.title(title)
+
+        self.base_title = title
         self.resizable(resize_x, resize_y)
+
+        if not is_x11():
+            # Bind right-click context menu for pin/unpin anywhere in the dialog
+            self._pin_menu = tk.Menu(self, tearoff=False)
+            self._pin_menu.add_command(label="Pin 📌", command=self.toggle_pin)
+            self.bind("<Button-3>", self._show_context_menu)
+            self.pin_unpin()
 
         self.columnconfigure(0, weight=1)
         self.rowconfigure(0, weight=1)
@@ -162,6 +173,31 @@ class ToplevelDialog(tk.Toplevel):
         """
         return cls.__name__.removesuffix("Dialog")
 
+    def is_pinned(self) -> bool:
+        """Return whether dialog is pinned on not."""
+        return bool(self.get_dialog_pref(PrefKey.DIALOG_PIN_DICT))
+
+    def toggle_pin(self) -> None:
+        """Toggle whether dialog is pinned or not."""
+        new_pin = not self.is_pinned()
+        self.save_dialog_pref(PrefKey.DIALOG_PIN_DICT, new_pin)
+        self.pin_unpin()
+
+    def pin_unpin(self) -> None:
+        """Pin/unpin dialog based on it's pref setting."""
+        if self.is_pinned():
+            self.transient(root())
+            self.title(f"{self.base_title} 📌")
+        else:
+            self.transient(None)
+            self.title(self.base_title)
+
+    def _show_context_menu(self, event: tk.Event) -> None:
+        """Display pin/unpin context menu."""
+        label = "Unpin 📍" if self.is_pinned() else "Pin 📌"
+        self._pin_menu.entryconfigure(0, label=label)
+        self._pin_menu.tk_popup(event.x_root, event.y_root)
+
     def grab_focus(self) -> None:
         """Grab focus and raise to top (if permitted by window manager)."""
         if is_x11():
@@ -171,6 +207,7 @@ class ToplevelDialog(tk.Toplevel):
         """Called when dialog gets focus."""
         assert self.manual_page is not None
         ToplevelDialog.context_help = self.manual_page
+        ToplevelDialog.recent_dialog = self
 
     def register_tooltip(self, tooltip: "ToolTip") -> None:
         """Register a tooltip as being attached to a widget in this
@@ -378,6 +415,12 @@ class ToplevelDialog(tk.Toplevel):
 
         assert hasattr(cls, method_name)
         return wrapper
+
+    @classmethod
+    def toggle_pin_last_dialog(cls) -> None:
+        """Toggle pinning for the most recently focused dialog."""
+        if ToplevelDialog.recent_dialog and ToplevelDialog.recent_dialog.winfo_exists():
+            ToplevelDialog.recent_dialog.toggle_pin()  # type:ignore[attr-defined]
 
 
 class OkApplyCancelDialog(ToplevelDialog):

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -79,7 +79,7 @@ class ToplevelDialog(tk.Toplevel):
             # Bind right-click context menu for pin/unpin anywhere in the dialog
             self._pin_menu = tk.Menu(self, tearoff=False)
             self._pin_menu.add_command(label="Pin 📌", command=self.toggle_pin)
-            self.bind("<Button-3>", self._show_context_menu)
+            mouse_bind(self, "3", self._show_context_menu)
             self.pin_unpin()
 
         self.columnconfigure(0, weight=1)
@@ -960,7 +960,7 @@ def grab_focus(
 
 
 def mouse_bind(
-    widget: tk.Widget, event: str, callback: Callable[[tk.Event], object]
+    widget: tk.Widget | tk.Toplevel, event: str, callback: Callable[[tk.Event], object]
 ) -> None:
     """Bind mouse button callback to event on widget.
 


### PR DESCRIPTION
1. Add right-click context menu to dialogs which should work anywhere in the dialog that doesn't already capture a right-click.
2. Context menu shows "Pin" or "Unpin", depending on current setting.
3. "Pinned" setting is stored per dialog in prefs file.
4. An entry in the View menu toggles the "pinned" setting for the dialog that has focus.
5. This entry can be assigned a shortcut in the usual way.
6. When pinned, a pin shows in the title bar of the dialog.
7. When pinned, dialog is subordinate to the main window in a way that means it remains in front, and moves up/down the window manager stack with the main window. If the main window is iconified/minimized, the pinned dialogs will be too.
8. When unpinned, a dialog continues to behave like a pinned dialog until it is closed and re-opened.
9. A second pinned dialog can be positioned either above or below a first pinned dialog by clicking to raise it as normal
10. An unpinned dialog can either be above the main window and all pinned dialogs, or below the main window and all pinned dialogs - it can't go "between" them
11. Pinning is not available on Linux (Window Manager doesn't permit it)
12. The above limitations cannot be fixed - note that GG1 has the same feature via Prefs, Appearance, either for all dialogs, or individually for the WF dialog or the S/R dialog. GG1 has the same limitations.

Fixes #974