### PR TITLE
Fix word boundary regex bug

### DIFF
--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -1074,14 +1074,15 @@ def get_regex_replacement(
 
     # Since below we do a sub on the match text, rather than the whole text, we need
     # to handle start/end word boundaries and look-behind/ahead by removing them.
-    # At some point the sub will be done manually, handing groups, execution of
-    # python code, etc., like in GG1. At that point, these fixes can probably go.
-    search_regex = re.sub(r"^\(\?<=.*?\)", "", search_regex)
-    search_regex = re.sub(r"\(\?=.*?\)$", "", search_regex)
-    search_regex = search_regex.removeprefix(r"\b").removesuffix(r"\b")
+    search_regex = re.sub(r"^\(\?<[=!].*?\)", "^", search_regex)
+    search_regex = re.sub(r"\(\?[=!].*?\)$", "$", search_regex)
+    search_regex = re.sub(r"^\\b", "^", search_regex)
+    search_regex = re.sub(r"\\b$", "$", search_regex)
 
     for ch in ("E", "C", "L", "U", "T", "A", "R", "N"):
         replace_regex = replace_regex.replace(rf"\{ch}", f"{temp_bs}{ch}")
+    # It's possible this should have `count=1`, but I don't think it matters, since
+    # we know that `search_regex` should match the whole of `match_text`
     replace_str = re.sub(search_regex, replace_regex, match_text, flags=flags)
 
     def do_extended_regex(cmd: str, func: Callable[[str], str], string: str) -> str:


### PR DESCRIPTION
The combination of word boundary with a non-greedy match caused the replacement to be incorrect.

Example:
S: `\b.+?\b`
R: `X`

This should find words, i.e. groups of characters delimited by word boundaries, and replace it with a single `X`. In fact it replaced every character in the word with `X`.

This is because we can't use Tcl regex replacement since it is very limited, so we have to get the match into a python string, e.g. `word`. We now execute the replacement on that string. This means it does not have context, so word boundaries and look-ahead/behind at the start and end of the string don't work. We therefore removed them from the search string used on the Python string.

However, this means that the search term is now `.+?`, which matches just the `w` in `word`, which it replaces with `X`, then it matches the `o`, then the `r` then the `d`.

The fix is to replace a beginning of line `\b` with `^` and an end of line `\b` with `$`, and the same for lookahead/behind.

Fixes #1369