### PR TITLE
Fix bookmark/search cursor position clash

### DIFF
--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -1159,6 +1159,7 @@ class File:
         except tk.TclError:
             sound_bell()  # Bookmark hasn't been set
             return
+        maintext().clear_selection()
         try:
             start = maintext().rowcol(f"{BOOKMARK_START}{bm_num}")
             end = maintext().rowcol(f"{BOOKMARK_END}{bm_num}")


### PR DESCRIPTION
If there was a selection, e.g. from a search, then going to a bookmark did not clear that selection.

So, you didn't see the insert cursor at the bookmark position, and if you then used an arrow key it would jump to the location of the selection rather than moving relative to the bookmark position.

Fixes #1374