### PR TITLE
Improve ", <UPPERCASE>" regex to aid sorting

### DIFF
--- a/src/guiguts/data/scannos/regex.json
+++ b/src/guiguts/data/scannos/regex.json
@@ -71,8 +71,8 @@
 "hint": "Find a comma at the end of a paragraph and replace it with a period"
 },
 {
-"match": ",(?= \\p{IsUpper}\\S)|,(?= [A-HJ-Z] )",
-"replacement": ".",
+"match": ",(\\s\\p{IsUpper}(?=\\S)|\\s[A-HJ-Z](?=\\s))",
+"replacement": ".\\1",
 "hint": "Find a comma followed by a space and an upper-case character (except I) and replace with a period."
 },
 {


### PR DESCRIPTION
This is regex number 15 in `regex.json`. Previously only the comma was captured and highlighted, so alpha sorting didn't appear to work, since every match was a comma. Changed to also capture the uppercase character after the comma, e.g. `, C` in `, Caesar`, so sorting is based on that character.
Note that, as previously, that uppercase `I` with a space after it is not matched by this regex, to avoid false positives from `Next, I followed...`

Fixes #1366