### PR TITLE
Make PPhtml find defined-not-used class correctly

### DIFF
--- a/src/guiguts/tools/pphtml.py
+++ b/src/guiguts/tools/pphtml.py
@@ -1113,7 +1113,7 @@ class PPhtmlChecker:
     def find_defined_class(self, css_class: str) -> Optional[IndexRange]:
         """Return index range of first occurrence of css_class in file."""
         if idx := maintext().search(
-            rf"\.{css_class}\y", "1.0", self.end_css, regexp=True
+            rf"\.{css_class}(?![-_a-zA-Z0-9])", "1.0", self.end_css, regexp=True
         ):
             beg_idx = maintext().rowcol(f"{idx}+1c")
             end_idx = maintext().rowcol(f"{idx}+{len(css_class) + 1}c")


### PR DESCRIPTION
Example file in linked issue shows that PPhtml got confused if a class name began with the same string as the reported class, e.g. `double` found `double-line-top` definition.

Corrected by improving the regex that searches for the class definition.

Fixes #1363