### PR TITLE
Permit NumLock & ScrollLock when typing in WF

### DIFF
--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -639,8 +639,8 @@ class WordFrequencyDialog(ToplevelDialog):
         """
         if not event.char or not event.char.isprintable():
             return ""
-        # If modifiers other than Shift & Caps Lock, don't goto word - allow default processing
-        if int(event.state) & ~(0x0001 | 0x0002) != 0:
+        # If modifiers other than Shift, Caps Lock, Num Lock, ScrollLock don't goto word - allow default processing
+        if int(event.state) & ~(0x0001 | 0x0002 | 0x0010 | 0x0080 | 0x0100) != 0:
             return ""
 
         def reset_buffer() -> None:


### PR DESCRIPTION
Also in checker dialogs.

Fixes #1371