### PR TITLE
Fix Autotable bug

### DIFF
--- a/src/guiguts/html_tools.py
+++ b/src/guiguts/html_tools.py
@@ -1799,7 +1799,9 @@ class HTMLAutoTableDialog(ToplevelDialog):
                 and rev_row_num < len(text_rows) - 1
                 and re.fullmatch(
                     r"[| \u00a0]*",
-                    maintext().get(f"{start_linenum}.0 -1l", f"{end_linenum - 2}.end"),
+                    maintext().get(
+                        f"{start_linenum}.0 -1l", f"{start_linenum}.0 -1l lineend"
+                    ),
                 )
             ):
                 start_linenum -= 1


### PR DESCRIPTION
With Multiline on, if a row was spread across more than one line, it left an copy of an original line at the top of the table

Fixes #1380