### PR TITLE
Make "Home" key scroll left if needed

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -3676,6 +3676,7 @@ class MainText(tk.Text):
         # If no Shift, just moving, so clear selection
         else:
             self.clear_selection()
+        self.see(tk.INSERT)
         return "break"
 
     def store_page_mark(self, mark: str) -> None:


### PR DESCRIPTION
On Macs it's the Command-Left key

Fixes #1385
