### PR TITLE
Attempt to speed up "Busy" on Macs

### DIFF
--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -1293,7 +1293,6 @@ class Busy:
         for widget in list(Busy._busy_widget_cursors.keys()):
             if widget.winfo_exists():
                 widget["cursor"] = cursor or Busy._busy_widget_cursors[widget]
-                widget.update()
             else:
                 # Remove old widgets from register
                 try:


### PR DESCRIPTION
Remove calls to `update()` from the recursive calls to set the cursor shape. So instead of 100-200 calls to update, there should now be 2.

This still works acceptably on Windows & Linux (WSL), but needs testing on Macs

Previous suggestion, to not change the cursor recursively on the widgets, stop the cursor being changed on Windows, at least.