### PR TITLE
Fix click-drag bug with NumLock

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -2401,8 +2401,7 @@ class MainText(tk.Text):
     def _is_drag_copy_mode(self, event: tk.Event) -> bool:
         """Return whether select drag should be copying."""
         # Shift, Ctrl, Cmd
-        print(f"{int(event.state):x}", flush=True)
-        return bool(int(event.state) & (0x0001 | 0x0004 | 0x0010))
+        return bool(int(event.state) & (0x0001 | 0x0004 | 0x0008 | 0x0010))
 
     def _get_truncated_drag_preview(self, text: str) -> str:
         """Get a truncated version of the drag text."""


### PR DESCRIPTION
NumLock was being interpreted as "a modifier key", and thus causing "copy" behavior.

Fixes #1410