### PR TITLE
Add Ctrl+Delete/Backspace to delete words

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1075,6 +1075,19 @@ class MainText(tk.Text):
             force_break=True,
             bind_peer=True,
         )
+        if is_mac():
+            self.bind_event(
+                "<Option-BackSpace>",
+                lambda evt: self.del_word(evt, -1),
+                force_break=True,
+                bind_peer=True,
+            )
+            self.bind_event(
+                "<Option-Delete>",
+                lambda evt: self.del_word(evt, 1),
+                force_break=True,
+                bind_peer=True,
+            )
 
         # Bind line numbers update routine to all events that might
         # change which line numbers should be displayed in maintext and peer


### PR DESCRIPTION
Equivalent to using Ctrl+Right/Left arrow, but deleting instead of moving the cursor.

(Note on macOS, Delete is used for deleting backwards, which is Backspace on other platforms, and fn+Delete is used for deleting forwards, which is Delete on other platforms)

Also fixed a few shortcuts that were not set up to work in the peer text widget: Undo/Redo side-effects (e.g. when the illo fixup dialog is visible, it should clear and wait for a re-run after undo/redo); smart cut/copy/paste, i.e. if column selection, cut/copy/paste the column selection; smart delete, i.e. if column selection, delete the column selection. All these worked in the main window, but not in the peer, since the bindings were not made to the peer window.

Fixes #1405