### PR TITLE
Report unconverted italics in PPhtml

### DIFF
--- a/src/guiguts/tools/pphtml.py
+++ b/src/guiguts/tools/pphtml.py
@@ -1241,6 +1241,8 @@ class PPhtmlChecker:
                 errors.append(("Blank Page", self.idx_range(line_num, match)))
             for match in re.finditer(r"\[[o|a]e\]", line):
                 errors.append(("Unconverted ligature", self.idx_range(line_num, match)))
+            for match in re.finditer(r"\b_[^_]+_|\b_[^_]+|[^_]+_\b", line):
+                errors.append(("Unconverted italics", self.idx_range(line_num, match)))
             if match := re.search(r"<hr style", line):
                 errors.append(("HR using 'style'", self.idx_range(line_num, match)))
             for match in re.finditer(r"&amp;amp", line):


### PR DESCRIPTION
Add to the miscellaneous special checks near the end. Should catch `_this_`, `_multi word on one line phrase_`, `_broken`, `missing_`, `P_art_`, but not `mid_word`. It's detecting when there's an underscore at the start and/or end of the word, but permits mid-word underscores.

Fixes #1375