### PR TITLE
Sequential Counter

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -112,6 +112,7 @@ from guiguts.misc_tools import (
     right_align_numbers,
     ScannoCheckerDialog,
     RegexCheckerDialog,
+    convert_sequential,
 )
 from guiguts.page_details import PageDetailsDialog
 from guiguts.preferences import preferences, PrefKey, PersistentBoolean
@@ -921,6 +922,11 @@ class Guiguts:
         search_menu.add_button(
             "Replace ~Match",
             replace_matched_string,
+        )
+        search_menu.add_separator()
+        search_menu.add_button(
+            "Replace [::] With ~Incremental Counter",
+            convert_sequential,
         )
         search_menu.add_separator()
         search_menu.add_button(

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -2726,3 +2726,15 @@ def align_indent(do_func: Callable[[int], None]) -> None:
             maintext().do_select(ranges[0])
     else:
         do_func(maintext().get_insert_index().row)
+
+
+def convert_sequential() -> None:
+    """Replace `[::]` with sequential numbers"""
+
+    maintext().undo_block_begin()
+    counter = 1
+    start = maintext().start().index()
+    while start := maintext().search("[::]", start, tk.END):
+        maintext().delete(start, f"{start}+4c")
+        maintext().insert(start, str(counter))
+        counter += 1

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -1118,11 +1118,20 @@ def get_regex_replacement(
 
     def cget(key: str) -> str | int:
         """Get value from lglobal[key]."""
+        if key not in lglobal:
+            lglobal[key] = ""
+        return lglobal[key]
+
+    def cinc(key: str) -> str | int:
+        """Increment and return value from lglobal[key]."""
+        if key not in lglobal:
+            lglobal[key] = 0
+        lglobal[key] = int(lglobal[key]) + 1
         return lglobal[key]
 
     def eval_python(python_in: str) -> str:
         """Evaluate string as python and return results as string."""
-        global_vars = {"lglobal": lglobal, "cset": cset, "cget": cget}
+        global_vars = {"lglobal": lglobal, "cset": cset, "cget": cget, "cinc": cinc}
         try:
             return str(eval(python_in, global_vars))  # pylint:disable=eval-used
         except Exception as exc:


### PR DESCRIPTION
### Add `Replace [::] With Incremental Counter` (Search menu)

It's a clone of the GG1 feature. Starting from the top of the
file, it replaces the first `[::]` with `1`, then next with `2`, etc.

Fixes [#1370](https://github.com/DistributedProofreaders/guiguts-py/issues/1370)

### Add `cinc` to `\C...\E` functions

Increments & returns the value referenced by the key.

E.g.
`\Ccinc("X")\E` will increment the value stored in X, and
will be replaced by that value. If "X" doesn't exist, it is
assumed to be zero, so the first call will return "1".

Using this as a replacement expression is equivalent to
the `[::]` incremental feature, but more flexible, since it
can easily be made to start at any value, using
`\Ccset("X", 27)\E` as a replacement before all the other
replacements.