### PR TITLE
Make Ctrl-A select all in Entry fields

### DIFF
--- a/src/guiguts/root.py
+++ b/src/guiguts/root.py
@@ -50,6 +50,19 @@ class Root(tk.Tk):
         self.save_config = False
         self.bind("<Configure>", self._handle_config)
 
+        # Make Ctrl-A select all in Entries/Comboboxes on Linux only
+        # Works by default on Windows/macOS (Cmd-A)
+        if is_x11():
+
+            def select_all(event: tk.Event) -> str:
+                event.widget.selection_range(0, tk.END)
+                return "break"
+
+            self.bind_class("Entry", "<Control-a>", select_all)
+            self.bind_class("Entry", "<Control-A>", select_all)
+            self.bind_class("TCombobox", "<Control-a>", select_all)
+            self.bind_class("TCombobox", "<Control-A>", select_all)
+
     def report_callback_exception(
         self, exc: type[BaseException], val: BaseException, tb: TracebackType | None
     ) -> None:


### PR DESCRIPTION
Example of Entry field is in ASCII Table Effects dialog. Also applies to comboboxes, like S/R Search/Replace fields.

Only affects Linux, since Windows/macOS support
Select All natively via Cmd/Ctrl-A

Fixes #1420

@srjfoo - I've tested that the change happens and works on WSL, and that Windows behavior is unchanged. Please can you just check that Cmd-A still selects all text in Entry and Combobox fields on macOS. Thanks.