### PR TITLE
Add Block Rewrap Selection

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -1069,6 +1069,9 @@ class Guiguts:
         tools_menu.add_separator()
         tools_menu.add_button("~Rewrap All", self.file.rewrap_all)
         tools_menu.add_button("R~ewrap Selection", self.file.rewrap_selection)
+        tools_menu.add_button(
+            "Block Rewrap Selec~tion", lambda: self.file.rewrap_selection(bq_depth=1)
+        )
         tools_menu.add_button("C~lean Up Rewrap Markers", self.file.rewrap_cleanup)
         tools_menu.add_separator()
         curly_menu = tools_menu.add_submenu("Curly ~Quotes")

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -1023,8 +1023,13 @@ class File:
         with path.open("a", encoding="utf-8") as fp:
             fp.write(f"{word}\n")
 
-    def rewrap_selection(self) -> None:
-        """Wrap selected text."""
+    def rewrap_selection(self, bq_depth: int = 0) -> None:
+        """Wrap selected text.
+
+        Args:
+            section_range: Range of text to be wrapped.
+            bq_depth: Starting blockquote depth (only 0 or 1 supported)
+        """
         ranges = maintext().selected_ranges()
         if not ranges:
             sound_bell()
@@ -1035,18 +1040,19 @@ class File:
             ranges[0].end.col = 0
             ranges[0].end.row += 1
         maintext().undo_block_begin()
-        self.rewrap_section(ranges[0])
+        self.rewrap_section(ranges[0], bq_depth)
 
     def rewrap_all(self) -> None:
         """Wrap whole text."""
         maintext().undo_block_begin()
         self.rewrap_section(IndexRange("1.0", maintext().index(tk.END)))
 
-    def rewrap_section(self, section_range: IndexRange) -> None:
+    def rewrap_section(self, section_range: IndexRange, bq_depth: int = 0) -> None:
         """Wrap a section of the text, preserving page mark locations.
 
         Args:
             section_range: Range of text to be wrapped.
+            bq_depth: Starting blockquote depth (only 0 or 1 supported)
         """
         maintext().selection_ranges_store_with_marks()
 
@@ -1059,7 +1065,7 @@ class File:
         maintext().strip_end_of_line_spaces()
         mark_list = self.pin_page_marks()
         maintext().rewrap_section(
-            section_range, lambda: self.unpin_page_marks(mark_list)
+            section_range, lambda: self.unpin_page_marks(mark_list), bq_depth
         )
         maintext().selection_ranges_restore_from_marks()
 

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -3248,13 +3248,17 @@ class MainText(tk.Text):
         return self.languages.split("+")
 
     def rewrap_section(
-        self, section_range: IndexRange, tidy_function: Callable[[], None]
+        self,
+        section_range: IndexRange,
+        tidy_function: Callable[[], None],
+        bq_depth: int,
     ) -> None:
         """Wrap a section of the text.
 
         Args:
             section_range: Range of text to be wrapped.
             tidy_function: Function to call to tidy up before returning.
+            bq_depth: Block quote depth to start at - only 0 and 1 supported.
         """
         default_left = preferences.get(PrefKey.WRAP_LEFT_MARGIN)
         default_right = preferences.get(PrefKey.WRAP_RIGHT_MARGIN)
@@ -3263,7 +3267,6 @@ class MainText(tk.Text):
         bq_indent = preferences.get(PrefKey.WRAP_BLOCKQUOTE_INDENT)
         bq_right = preferences.get(PrefKey.WRAP_BLOCKQUOTE_RIGHT_MARGIN)
 
-        bq_depth = 0
         paragraph = ""
         paragraph_complete = False
         section_start = section_range.start.index()
@@ -3282,6 +3285,16 @@ class MainText(tk.Text):
         block_params_list: list[WrapParams] = [
             WrapParams(default_left, default_left, default_right)
         ]
+        # If operation is "block rewrap", also add the depth=1 parameters
+        assert bq_depth in (0, 1)  # Only non-zero initial depth supported is 1
+        if bq_depth > 0:
+            block_params_list.append(
+                WrapParams(
+                    block_params_list[-1].left + bq_indent,
+                    block_params_list[-1].left + bq_indent,
+                    block_params_list[-1].right,
+                )
+            )
         paragraph_complete = False
 
         # Loop until we reach the end of the whole section we want to rewrap


### PR DESCRIPTION
Rewraps selected text with an initial indent equal to block quote left margin. If section contains `/#`
markup, these will be further indented, thus
supporting nested blockquotes like standard rewrap.

Fixes #1361