### PR TITLE
Make initial dir persistent for file load/save

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -6,6 +6,7 @@ import argparse
 import logging
 import importlib.resources
 from importlib.metadata import version
+import os
 import sys
 import tkinter as tk
 from typing import Optional
@@ -702,6 +703,7 @@ class Guiguts:
             PrefKey.CP_PNG_CRUSH_COMMAND, "pngcrush -q -reduce $in $out"
         )
         preferences.set_default(PrefKey.CP_HIGHLIGHT_CHARSUITE_ORPHANS, False)
+        preferences.set_default(PrefKey.INITIAL_DIR, os.path.expanduser("~"))
 
         # Check all preferences have a default
         for pref_key in PrefKey:

--- a/src/guiguts/content_providing.py
+++ b/src/guiguts/content_providing.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import shutil
 import subprocess
 import tkinter as tk
-from tkinter import filedialog, ttk
+from tkinter import ttk
 from typing import Any, Final, Iterator
 
 from PIL import Image, UnidentifiedImageError
@@ -33,7 +33,7 @@ from guiguts.utilities import (
     sing_plur,
 )
 from guiguts.preferences import PersistentBoolean, PrefKey, preferences
-from guiguts.widgets import ToplevelDialog, Busy, ToolTip
+from guiguts.widgets import ToplevelDialog, Busy, ToolTip, FileDialog
 
 logger = logging.getLogger(__package__)
 
@@ -45,7 +45,7 @@ CP_ENGLIFH = str(importlib.resources.files(cp_files).joinpath("fcannos.json"))
 
 def export_prep_text_files() -> None:
     """Export the current file as separate prep text files."""
-    prep_dir = filedialog.askdirectory(
+    prep_dir = FileDialog.askdirectory(
         parent=root(),
         title=f"Select {folder_dir_str(True)} to export prep text files to",
     )
@@ -93,7 +93,7 @@ def import_prep_text_files() -> None:
     if not the_file().close_file():
         return
 
-    prep_dir = filedialog.askdirectory(
+    prep_dir = FileDialog.askdirectory(
         parent=root(),
         mustexist=True,
         title=f"Select {folder_dir_str(True)} to import prep text files from",
@@ -1396,7 +1396,7 @@ def import_tia_ocr_file() -> None:
     if not the_file().close_file():
         return
 
-    filename = filedialog.askopenfilename(
+    filename = FileDialog.askopenfilename(
         title="Open OCR file",
         filetypes=(
             ("Gzip files", "*.gz"),

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -6,7 +6,7 @@ import logging
 import os.path
 from pathlib import Path
 import tkinter as tk
-from tkinter import filedialog, messagebox, simpledialog
+from tkinter import messagebox, simpledialog
 from typing import Any, Callable, Final, TypedDict, Literal, Optional, cast
 
 import regex as re
@@ -41,7 +41,7 @@ from guiguts.utilities import (
     folder_dir_str,
     is_test,
 )
-from guiguts.widgets import grab_focus, ToplevelDialog, Busy
+from guiguts.widgets import grab_focus, ToplevelDialog, Busy, FileDialog
 
 logger = logging.getLogger(__package__)
 
@@ -225,7 +225,7 @@ class File:
         """
         if self.check_save():
             if not filename:
-                filename = filedialog.askopenfilename(
+                filename = FileDialog.askopenfilename(
                     filetypes=(
                         ("Text files", "*.txt *.html *.htm"),
                         ("All files", "*.*"),
@@ -421,10 +421,10 @@ class File:
         )
         if initialdir == "":
             initialdir = os.path.dirname(suggested_fn)
-        if fn := filedialog.asksaveasfilename(
+        if fn := FileDialog.asksaveasfilename(
             initialfile=initialfile,
             initialdir=initialdir,
-            filetypes=[(file_type, f"*{extension}"), ("All files", "*")],
+            filetypes=((file_type, f"*{extension}"), ("All files", "*")),
             title="Save As",
         ):
             self.store_recent_file(fn)
@@ -436,10 +436,10 @@ class File:
     def save_copy_as_file(self) -> None:
         """Save copy of current text as new file, without affecting
         current filename or "modified" flag."""
-        if fn := filedialog.asksaveasfilename(
+        if fn := FileDialog.asksaveasfilename(
             initialfile=os.path.basename(self.filename),
             initialdir=os.path.dirname(self.filename),
-            filetypes=[("All files", "*")],
+            filetypes=(("All files", "*"),),
             title="Save a Copy As",
         ):
             self.save_copy(fn)
@@ -459,7 +459,7 @@ class File:
 
     def include_file(self) -> None:
         """Open and insert a file into the current file."""
-        filename = filedialog.askopenfilename(
+        filename = FileDialog.askopenfilename(
             filetypes=(
                 ("Text files", "*.txt *.html *.htm"),
                 ("All files", "*.*"),
@@ -755,7 +755,7 @@ class File:
 
     def choose_image_dir(self) -> None:
         """Allow user to select directory containing png image files"""
-        self.image_dir = filedialog.askdirectory(
+        self.image_dir = FileDialog.askdirectory(
             mustexist=True, title=f"Select {folder_dir_str(True)} containing scans"
         )
 

--- a/src/guiguts/html_tools.py
+++ b/src/guiguts/html_tools.py
@@ -7,7 +7,7 @@ import logging
 import os
 import subprocess
 import tkinter as tk
-from tkinter import ttk, filedialog
+from tkinter import ttk
 from typing import Optional, Any
 import xml.sax
 import shutil
@@ -43,6 +43,7 @@ from guiguts.widgets import (
     TreeviewList,
     mouse_bind,
     grab_focus,
+    FileDialog,
 )
 
 logger = logging.getLogger(__package__)
@@ -331,7 +332,7 @@ class HTMLImageDialog(ToplevelDialog):
 
     def choose_file(self) -> None:
         """Allow user to choose image file."""
-        if file_name := filedialog.askopenfilename(
+        if file_name := FileDialog.askopenfilename(
             filetypes=(
                 ("Image files", "*.jpg *.png *.gif"),
                 ("All files", "*.*"),
@@ -1171,7 +1172,7 @@ class EbookmakerCheckerDialog(CheckerDialog):
 
             def locate_ebookmaker() -> None:
                 """Prompt user to give path to where ebookmaker was installed using pipenv."""
-                if dir_name := filedialog.askdirectory(
+                if dir_name := FileDialog.askdirectory(
                     title=f"Select the Ebookmaker 'pipenv install' {folder_dir_str(lowercase=True)}",
                     parent=self,
                 ):
@@ -2245,7 +2246,7 @@ class HTMLLinksDialog(ToplevelDialog):
 
     def browse_elink(self) -> None:
         """Browse for file to link to."""
-        linkname = filedialog.askopenfilename(title="Choose File")
+        linkname = FileDialog.askopenfilename(title="Choose File")
         grab_focus(self, self.e_entry)
         self.e_entry.icursor(tk.END)
         if not linkname:

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -9,7 +9,7 @@ import shlex
 import subprocess
 import time
 import tkinter as tk
-from tkinter import ttk, messagebox, EventType, filedialog
+from tkinter import ttk, messagebox, EventType
 from typing import Any, Callable, Optional
 from pathlib import Path
 
@@ -47,6 +47,7 @@ from guiguts.widgets import (
     TreeviewList,
     bind_shift_tab,
     init_global_font,
+    FileDialog,
 )
 
 logger = logging.getLogger(__package__)
@@ -1169,7 +1170,7 @@ class MainImage(tk.Frame):
             initial_dir = os.path.dirname(self.proj_filename)
         else:
             initial_dir = None
-        if filename := filedialog.askopenfilename(
+        if filename := FileDialog.askopenfilename(
             initialdir=initial_dir,
             title="Choose Image File",
             filetypes=(

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -5,7 +5,7 @@ import logging
 import platform
 import sys
 import tkinter as tk
-from tkinter import ttk, font, filedialog, messagebox, colorchooser
+from tkinter import ttk, font, messagebox, colorchooser
 from typing import Literal, Optional, Callable
 import unicodedata
 
@@ -45,6 +45,7 @@ from guiguts.widgets import (
     ScrollableFrame,
     themed_style,
     set_global_font,
+    FileDialog,
 )
 
 logger = logging.getLogger(__package__)
@@ -319,7 +320,7 @@ class PreferencesDialog(ToplevelDialog):
 
         def choose_external_viewer() -> None:
             """Choose program to view images."""
-            if filename := filedialog.askopenfilename(
+            if filename := FileDialog.askopenfilename(
                 parent=self, title="Choose Image Viewer"
             ):
                 preferences.set(PrefKey.IMAGE_VIEWER_EXTERNAL_PATH, filename)

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -5,7 +5,7 @@ import importlib.resources
 import logging
 import operator
 import tkinter as tk
-from tkinter import ttk, messagebox, filedialog
+from tkinter import ttk, messagebox
 from typing import Callable, Optional, Any, TypeVar
 import unicodedata
 
@@ -46,6 +46,7 @@ from guiguts.widgets import (
     PathnameCombobox,
     insert_in_focus_widget,
     ToolTip,
+    FileDialog,
 )
 
 logger = logging.getLogger(__package__)
@@ -1726,7 +1727,7 @@ class ScannoRegexCheckerDialog(CheckerDialog):
 
     def choose_file(self) -> None:
         """Choose & load a scannos file."""
-        filename = filedialog.askopenfilename(
+        filename = FileDialog.askopenfilename(
             filetypes=(
                 (f"{self.type_adj.capitalize()} files", "*.json"),
                 ("All files", "*.*"),

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -218,6 +218,7 @@ class PrefKey(StrEnum):
     CP_CURLY_QUOTES = auto()
     CP_PNG_CRUSH_COMMAND = auto()
     CP_HIGHLIGHT_CHARSUITE_ORPHANS = auto()
+    INITIAL_DIR = auto()
 
 
 class Preferences:


### PR DESCRIPTION
File loading, saving and directory choosing dialogs now remember the last-used directory and open at
that place initially.

Notes:
1. This preference is only set when those dialogs are used. It is not set if you do `-r1` or similar.
2. There are a couple exceptions where the code "knows best". If you are using Save As to save a
copy of your file, it opens in the directory of your current file, not the saved pref directory. Also if you try to open an image it will try to open in your pngs directory.
3. The default for a new user is your home directory.
4. If the saved directory doesn't exist, it tries the parent directory (maybe your projects dir, and you have deleted the project you just finished with).
5. If the parent directory doesn't exist, it tries the grandparent directory.
6. If no grandparent, it uses the default (see below)
7. The default in the above case, or for a first-time user of the feature (or `--nohome`) is the user's
home dir.