### PR TITLE
Fix WF search for `_italic_` words

### DIFF
--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -763,13 +763,13 @@ class WordFrequencyDialog(ToplevelDialog):
             # boundary is a word/space character
             emdash_bound = "—" if newline_word[0] == "—" else r"[^\w\s]"
             left_boundary = (
-                r"(?<!(\w|\w['’]))"
+                r"(?<!([^\W_]|\w['’]))"
                 if newline_word[0].isalnum()
                 else rf"(?<!{emdash_bound})"
             )
             emdash_bound = "—" if newline_word[-1] == "—" else r"[^\w\s]"
             right_boundary = (
-                r"(?!(\w|['’]\w))"
+                r"(?!([^\W_]|['’]\w))"
                 if newline_word[-1].isalnum()
                 else rf"(?!{emdash_bound})"
             )


### PR DESCRIPTION
If words were marked up with underscores for italics, WF didn't find them.

Linked issue has example file. Although diacritics are mentioned in the linked issue, it applies to most WF checks, even All Words, e.g. `Locksley` in example file.

Fixes #1430