### PR TITLE
Improve Entry theming

### DIFF
--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -1677,6 +1677,22 @@ class MainWindow:
             "*Entry.disabledForeground",
             themed_style().lookup("TCombobox", "foreground", state=("disabled",)),
         )
+        root().option_add(
+            "*Entry.borderWidth",
+            0,
+        )
+        root().option_add(
+            "*Entry.highlightThickness",
+            1,
+        )
+        root().option_add(
+            "*Entry.highlightBackground",
+            themed_style().lookup("TCombobox", "bordercolor"),
+        )
+        root().option_add(
+            "*Entry.highlightColor",
+            themed_style().lookup("TCombobox", "focuscolor"),
+        )
 
     def hide_image(self) -> None:
         """Stop showing the current image."""


### PR DESCRIPTION
Border wasn't themed properly in the work done
for #1428.

The actual border is not configurable for an entry, but this gets similar properties from a combo box, and applies them to a slightly different property
in entries, that gives a reasonable facsimile.