### PR TITLE
Improve CP features

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -785,7 +785,7 @@ class Guiguts:
         )
         cp_menu.add_button("Run ~Dehyphenator...", lambda: DehyphenatorChecker().run())
         cp_menu.add_button("~Filter File...", CPProcessingDialog.show_dialog)
-        cp_menu.add_button("Fix ~Common Scannos", cp_fix_common_scannos)
+        cp_menu.add_button("Fix ~Common English Scannos", cp_fix_common_scannos)
         cp_menu.add_button("Add [~Blank Page] to Empty Pages", cp_fix_empty_pages)
         cp_menu.add_button("Fix ~Olde Englifh", cp_fix_englifh)
         cp_menu.add_button("Compress ~PNG Files", cp_compress_pngs)

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -564,30 +564,32 @@ class CheckerDialog(ToplevelDialog):
         self.view_options_label = tk.StringVar(self, "")
         self.view_options_crit = tk.StringVar(self, "")
         if self.has_view_options:
-            view_options_frame = ttk.Frame(self.message_controls_frame)
-            view_options_frame.grid(row=1, column=0, sticky="NSW", columnspan=8)
+            self.view_options_frame = ttk.Frame(self.message_controls_frame)
+            self.view_options_frame.grid(row=1, column=0, sticky="NSW", columnspan=8)
             ttk.Button(
-                view_options_frame,
+                self.view_options_frame,
                 text="View Options",
                 command=show_view_options,
             ).grid(row=0, column=0, sticky="NS")
             ttk.Button(
-                view_options_frame,
+                self.view_options_frame,
                 text="Prev. Option",
                 command=lambda: self.prev_next_view_option(-1),
             ).grid(row=0, column=1, sticky="NS", padx=(10, 0))
             ttk.Button(
-                view_options_frame,
+                self.view_options_frame,
                 text="Next Option",
                 command=lambda: self.prev_next_view_option(1),
             ).grid(row=0, column=2, sticky="NS", padx=(0, 10))
-            ttk.Label(view_options_frame, textvariable=self.view_options_label).grid(
+            ttk.Label(
+                self.view_options_frame, textvariable=self.view_options_label
+            ).grid(
                 row=0,
                 column=3,
                 sticky="NS",
             )
             ttk.Label(
-                view_options_frame,
+                self.view_options_frame,
                 textvariable=self.view_options_crit,
                 foreground="red",
             ).grid(row=0, column=4, sticky="NS")
@@ -1158,8 +1160,11 @@ class CheckerDialog(ToplevelDialog):
         maxcollen = len(str(maxcol)) + 2  # Always colon & at least 1 space after col
 
         # If exactly one View Option enabled, hide error prefix,
-        # since it will be displayed in the View Options label
-        hide_ep = self.get_view_options_count_index()[0] == 1
+        # since it will be displayed in the View Options label, if View Options frame visible
+        hide_ep = (
+            self.get_view_options_count_index()[0] == 1
+            and self.view_options_frame.winfo_ismapped()
+        )
 
         for entry in self.entries:
             if self.skip_entry(entry):


### PR DESCRIPTION
1. Improve page number checking, e.g. `J923` is not a page number, it's a year. Also single letter Roman numeral is a page number
2. Report if blank lines before header, so user can easily hide all of those
3. Add checkboxes to show/hide odd/even header/ footers
4. Only use internal dehyphenation tests if "en" is one of the project languages, e.g. "un-xxxx" or
"xxxx-ing"
5. Add "English" to "Fix Common Scannos" menu entry in CP menu
6. Add "All⇒Remove" and "All⇒Keep" buttons
7. Fix "undo" - after "Fix All", you had to undo one at a time.
8. Limit length of long dashes made of hyphens to a maximum of 4 (via the "Convert non-standard
dashes to (max 4) hyphen(s)" Filter toggle.

Fixes #1438