### PR TITLE
Fix copy-dragging

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -2474,8 +2474,9 @@ class MainText(tk.Text):
 
     def _is_drag_copy_mode(self, event: tk.Event) -> bool:
         """Return whether select drag should be copying."""
-        # Shift, Ctrl, Cmd
-        return bool(int(event.state) & (0x0001 | 0x0004 | 0x0008 | 0x0010))
+        # Shift, Ctrl, (Cmd)
+        mods = 0x0001 | 0x0004 | 0x0008 if is_mac() else 0x0001 | 0x0004
+        return bool(int(event.state) & mods)
 
     def _get_truncated_drag_preview(self, text: str) -> str:
         """Get a truncated version of the drag text."""


### PR DESCRIPTION
Previous Mac edit broke it when user had NumLock pressed. Make Mac edit Mac-specific.

Fixes [comment](https://github.com/DistributedProofreaders/guiguts-py/pull/1411#issuecomment-3288675372) in #1411