### PR TITLE
Fix SR bugs

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -919,7 +919,7 @@ class Guiguts:
         )
         search_menu.add_button(
             "Find Pre~vious",
-            lambda: find_next(backwards=True),
+            lambda: find_next(previous=True),
             "Cmd+Shift+G" if is_mac() else "Shift+F3",
         )
         search_menu.add_button(

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -1336,6 +1336,8 @@ class ErrorHandler(logging.Handler):
             record: Record containing error message.
         """
         messagebox.showerror(title=record.levelname, message=record.getMessage())
+        # Since this will have interrupted processing, restore the cursor to be non-busy
+        Busy.unbusy()
 
 
 class MessageLog(logging.Handler):


### PR DESCRIPTION
1. Make Search menu, Find Next/Previous respect the "Reverse" flag in the S/R dialog. So, Find Next will find the next in the reverse direction if "Reverse" is set, for example.
2. Fix exception when Find All is Re-Run after closing the S/R dialog.
3. Also, set cursor back to non-busy when an exception happens, because it confuses users into
thinking they need to quit the program, when in
fact they could just carry on.

Fixes #1444 
Fixes #1445 