### PR TITLE
Fix whole word bug with regex

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -3042,10 +3042,11 @@ class MainText(tk.Text):
         else:
             search_string = re.escape(search_string)
         # Don't use \b for word boundary because it includes underscore
+        # Use non-capture group round user's regex to avoid `a|b` being split
         if wholeword:
             search_string = (
                 r"(?=[[:alnum:]])(?<![[:alnum:]])"
-                + search_string
+                + f"(?:{search_string})"
                 + r"(?<=[[:alnum:]])(?![[:alnum:]])"
             )
         # Preferable to use flags rather than prepending "(?i)", for example,


### PR DESCRIPTION
Wrap user's regex in non-capturing parentheses so low priority elements like `|` don't end up splitting the regex into two parts with the word-begin on the first part and the word-end on the second part.