### PR TITLE
Fix "Preserve Illo's Page Number" bug in SN Fixup

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -646,7 +646,7 @@ class Guiguts:
         preferences.set_default(PrefKey.SURROUND_WITH_AFTER_HISTORY, [])
         preferences.set_default(PrefKey.REGEX_TIMEOUT, 5)
         preferences.set_default(PrefKey.LEVENSHTEIN_DIGITS, True)
-        preferences.set_default(PrefKey.ILLO_SN_MOVE_PAGE_MARKS, False)
+        preferences.set_default(PrefKey.ILLO_MOVE_PAGE_MARKS, False)
         preferences.set_default(PrefKey.CURLY_DOUBLE_QUOTE_EXCEPTION, False)
         preferences.set_default(PrefKey.CURLY_SINGLE_QUOTE_STRICT, True)
         preferences.set_default(PrefKey.CUSTOM_MARKUP_ATTRIBUTE_0, "")

--- a/src/guiguts/illo_sn_fixup.py
+++ b/src/guiguts/illo_sn_fixup.py
@@ -95,7 +95,7 @@ class IlloSNCheckerDialog(CheckerDialog):
             pg_btn = ttk.Checkbutton(
                 frame,
                 text="Preserve Illo's Page Number",
-                variable=PersistentBoolean(PrefKey.ILLO_SN_MOVE_PAGE_MARKS),
+                variable=PersistentBoolean(PrefKey.ILLO_MOVE_PAGE_MARKS),
             )
             pg_btn.grid(row=0, column=2, padx=(10, 0), sticky="NSW")
             ToolTip(
@@ -495,7 +495,9 @@ def move_selection_up(tag_type: str) -> None:
             # Gather information on page breaks if required
             page_marks: list[str] = []
             page_seps: list[str] = []
-            if preferences.get(PrefKey.ILLO_SN_MOVE_PAGE_MARKS):
+            if tag_type == "Illustration" and preferences.get(
+                PrefKey.ILLO_MOVE_PAGE_MARKS
+            ):
                 page_marks, page_seps = get_page_breaks(
                     line_num,
                     maintext().index(
@@ -612,7 +614,9 @@ def move_selection_down(tag_type: str) -> None:
         # If we are not in this situation, insert selected tag below the blank line we are at.
         # Otherwise look for next blank line below that one.
         if line_txt == "":
-            if preferences.get(PrefKey.ILLO_SN_MOVE_PAGE_MARKS):
+            if tag_type == "Illustration" and preferences.get(
+                PrefKey.ILLO_MOVE_PAGE_MARKS
+            ):
                 all_page_seps = True
                 for ln in range(
                     IndexRowCol(last_line_num).row + 1, IndexRowCol(line_num).row
@@ -632,7 +636,9 @@ def move_selection_down(tag_type: str) -> None:
                 # Gather information on page breaks if required
                 page_marks: list[str] = []
                 page_seps: list[str] = []
-                if preferences.get(PrefKey.ILLO_SN_MOVE_PAGE_MARKS):
+                if tag_type == "Illustration" and preferences.get(
+                    PrefKey.ILLO_MOVE_PAGE_MARKS
+                ):
                     page_marks, page_seps = get_page_breaks(
                         maintext().index(
                             f"{checker.updated_index(selected.last_line_num)} lineend"

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -162,7 +162,7 @@ class PrefKey(StrEnum):
     SURROUND_WITH_AFTER_HISTORY = auto()
     REGEX_TIMEOUT = auto()
     LEVENSHTEIN_DIGITS = auto()
-    ILLO_SN_MOVE_PAGE_MARKS = auto()
+    ILLO_MOVE_PAGE_MARKS = auto()
     CURLY_DOUBLE_QUOTE_EXCEPTION = auto()
     CURLY_SINGLE_QUOTE_STRICT = auto()
     CUSTOM_MARKUP_ATTRIBUTE_0 = auto()


### PR DESCRIPTION
The "Preserve Illo's Page Number" checkbox is only supposed to apply to Illo Fixup, not Sidenote Fixup, and only appears in Illo Fixup. However the code was applying it to sidenotes too.

Test file in linked issue.

Fixes #1457 (second part only)