### PR TITLE
Align column ruler better

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -110,7 +110,7 @@ class TextColumnNumbers(tk.Text):
             parent,
             font=self.font,
             height=1,
-            padx=3,
+            padx=text_widget["padx"] + 3,
             borderwidth=0,
             highlightthickness=0,
             takefocus=False,


### PR DESCRIPTION
It wasn't taking into account the additional padding added to the text window during #1125