### PR TITLE
application.py - fix the creation of the preferences

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -603,7 +603,7 @@ class Guiguts:
         preferences.set_default(
             PrefKey.CUSTOM_MENU_ENTRIES,
             [
-                ["View HTML in browser", 'start "$f"' if is_windows() else 'open "$f"'],
+                ["View HTML in browser", 'start "$f"' if is_windows() else 'open "$f"' if is_mac() else 'xdg-open "$f"'],
                 ["Onelook.com (several dictionaries)", "https://www.onelook.com/?w=$t"],
                 [
                     "Google Books Ngram Viewer",


### PR DESCRIPTION
fix the creation of the preferences to use xdg-open if not on windows or mac

On Linux distributions that don't alias open to xdg-open, the open "$f" command won't work.  For the Custom menu, the default was still open "$f".  This change adds a check for mac and then defaults to xdg-open "$f" if not on windows or mac os.