### PR TITLE
Trap rare prefs file clash

### DIFF
--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -395,11 +395,17 @@ class Preferences:
 
         if is_older_than(week_backup, 7 * 86400):  # 7 days
             if os.path.exists(day_backup):
-                os.replace(day_backup, week_backup)
+                try:
+                    os.replace(day_backup, week_backup)
+                except FileNotFoundError:
+                    pass  # Nothing we can do
 
         if is_older_than(day_backup, 86400):  # 1 day
             if os.path.exists(self.prefsfile):
-                os.replace(self.prefsfile, day_backup)
+                try:
+                    os.replace(self.prefsfile, day_backup)
+                except FileNotFoundError:
+                    pass  # Nothing we can do
 
         try:
             with open(self.prefsfile, "w", encoding="utf-8") as fp:


### PR DESCRIPTION
Running 2 instances can cause a clash between prefs file reading/writing/renaming.

Nothing we can do except silently ignore.

Fixes #1461

Testing notes:
Run two instances and try and make them do things that will cause prefs file saving. I doubt you can get it to crash in `master`, but as long as it's no worse, that will be OK.