### PR TITLE
Add "Did You Know...?" tip of the day

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -240,7 +240,7 @@ class Guiguts:
                     title=f"What's New in Guiguts v{ver}", latest_only=True
                 )
                 preferences.set(PrefKey.RELEASE_NOTES_SHOWN, ver)
-            elif preferences.get(PrefKey.DID_YOU_KNOW_SHOW):
+            elif DidYouKnowDialog.show_on_startup():
                 dlg = DidYouKnowDialog.show_dialog()
             # Dialog needs bringing to front because otherwise mainwindow will cover it
             if dlg is not None:
@@ -734,7 +734,8 @@ class Guiguts:
         preferences.set_default(PrefKey.CP_HIGHLIGHT_CHARSUITE_ORPHANS, False)
         preferences.set_default(PrefKey.INITIAL_DIR, os.path.expanduser("~"))
         preferences.set_default(PrefKey.RELEASE_NOTES_SHOWN, "2.0.0")
-        preferences.set_default(PrefKey.DID_YOU_KNOW_SHOW, True)
+        preferences.set_default(PrefKey.DID_YOU_KNOW_INTERVAL, DidYouKnowDialog.DAILY)
+        preferences.set_default(PrefKey.DID_YOU_KNOW_LAST_SHOWN, "2025-09-01")
         preferences.set_default(PrefKey.DID_YOU_KNOW_INDEX, -1)
 
         # Check all preferences have a default

--- a/src/guiguts/data/tips/tips.json
+++ b/src/guiguts/data/tips/tips.json
@@ -12,7 +12,7 @@
   },
   {
     "text": [
-      "You can set up a [keyboard shortcut](https://www.pgdp.net/wiki/PPTools/Guiguts/Guiguts_2_Manual/Help_Menu#User-defined_Keyboard_Shortcuts key for any menu entry and many dialog features. Use the [Command Palette](https://www.pgdp.net/wiki/PPTools/Guiguts/Guiguts_2_Manual/Help_Menu#Command_Palette) \"Edit Shortcut\" button.",
+      "You can set up a [keyboard shortcut](https://www.pgdp.net/wiki/PPTools/Guiguts/Guiguts_2_Manual/Help_Menu#User-defined_Keyboard_Shortcuts) key for any menu entry and many dialog features. Use the [Command Palette](https://www.pgdp.net/wiki/PPTools/Guiguts/Guiguts_2_Manual/Help_Menu#Command_Palette) \"Edit Shortcut\" button.",
       "The shortcut key will be shown on the menu button."
     ]
   },
@@ -43,13 +43,13 @@
   {
     "text": [
       "[Column Selection](https://www.pgdp.net/wiki/PPTools/Guiguts/Guiguts_2_Manual/Edit_Menu#Selecting_Columns) allows you to select a rectangle of text.",
-      "You can do this by dragging the mouse while holding down the Alt key  Option key on Macs). Alternatively, do a regular selection and convert it to a column selection using Edit-->Toggle Column/Regular Selection."
+      "You can do this by dragging the mouse while holding down the Alt key (Option key on Macs). Alternatively, do a regular selection and convert it to a column selection using Edit-->Toggle Column/Regular Selection."
     ]
   },
   {
     "text": [
       "Guiguts supports [light and dark themes](https://www.pgdp.net/wiki/PPTools/Guiguts/Guiguts_2_Manual/Edit_Menu#Appearance).",
-      "With the \"Automatic\" setting, it will switch to match your computer's current setting."
+      "With the \"Default\" setting, it will switch to match your computer's current setting."
     ]
   },
   {
@@ -67,7 +67,7 @@
   {
     "text": [
       "[Highlight All](https://www.pgdp.net/wiki/PPTools/Guiguts/Guiguts_2_Manual/Search_Menu#Highlight_All) in the Search/Replace dialog will highlight all occurrences of a string or regular expression using the current dialog settings.",
-      "If you prefer a list of the matches, use \"Find All\" instead."
+      "If you prefer a list of the matches, use [Find All](https://www.pgdp.net/wiki/PPTools/Guiguts/Guiguts_2_Manual/Search_Menu#Find_All) instead."
     ]
   },
   {
@@ -111,7 +111,7 @@
   {
     "text": [
       "Messages that appear in [the message bar](https://www.pgdp.net/wiki/PPTools/Guiguts/Guiguts_2_Manual/Introduction#Tool_Bar_and_Message_Bar) are also added to the [Message Log](https://www.pgdp.net/wiki/PPTools/Guiguts/Guiguts_2_Manual/View_Menu#Message_Log).",
-      "Use View-->Message Log to view past messages at any time."
+      "Use View-->Message Log to view past messages in the current session at any time."
     ]
   },
   {

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -221,7 +221,8 @@ class PrefKey(StrEnum):
     CP_HIGHLIGHT_CHARSUITE_ORPHANS = auto()
     INITIAL_DIR = auto()
     RELEASE_NOTES_SHOWN = auto()
-    DID_YOU_KNOW_SHOW = auto()
+    DID_YOU_KNOW_LAST_SHOWN = auto()
+    DID_YOU_KNOW_INTERVAL = auto()
     DID_YOU_KNOW_INDEX = auto()
 
 

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -1480,3 +1480,9 @@ def set_global_font() -> None:
             size=preferences.get(PrefKey.GLOBAL_FONT_SIZE),
             weight=default_font.cget("weight"),
         )
+
+
+def get_global_font() -> tk_font.Font:
+    """Return global font."""
+    assert global_font is not None
+    return global_font


### PR DESCRIPTION
1. Show it at startup unless the Release Notes dialog is being shown at startup
2. Allow user to turn tips on/off in the dialog and in the Settings dialog
3. Allow user to open tips dialog from the Help menu
4. Provide Next/Previous tip buttons in the dialog
5. Tips are in `data/tips/tips.json`, consisting of a list of strings. Each string is a "paragraph", i.e. has a newline and a small gap from the previous "paragraph".
6. Tips may have Markdown-style hyperlinks, e.g. to the relevant manual page
7. Hyperlinks are shown in blue, underlined, and the cursor should change when hovering over them.
8. Current tip.json is proof of concept, and needs further input before the PR is merged.