### PR TITLE
Add multiple replacements to regex library

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -107,6 +107,7 @@ from guiguts.misc_tools import (
     DEFAULT_MISSPELLED_SCANNOS,
     DEFAULT_REGEX_LIBRARY_DIR,
     DEFAULT_DASHES_REGEX_LIBRARY,
+    DEFAULT_ITALIC_SEMANTIC_REGEX_LIBRARY,
     convert_to_curly_quotes,
     check_curly_quotes,
     protect_html_straight_quotes,
@@ -564,6 +565,11 @@ class Guiguts:
             PrefKey.REGEX_LIBRARY_HISTORY,
             [
                 str(DEFAULT_REGEX_LIBRARY_DIR.joinpath(DEFAULT_DASHES_REGEX_LIBRARY)),
+                str(
+                    DEFAULT_REGEX_LIBRARY_DIR.joinpath(
+                        DEFAULT_ITALIC_SEMANTIC_REGEX_LIBRARY
+                    )
+                ),
             ],
         )
         preferences.set_default(PrefKey.REGEX_LIBRARY_AUTO_ADVANCE, True)

--- a/src/guiguts/data/regex_library/italic_semantic.json
+++ b/src/guiguts/data/regex_library/italic_semantic.json
@@ -1,0 +1,17 @@
+{
+"regexes": [
+{
+"match": "<i>((.|\\n)*?)</i>",
+"replacement": [
+"<i>\\1</i>",
+"<em>\\1</em>",
+"<cite>\\1</cite>  ",
+"<i lang=\"fr\">\\1</i>",
+"<i lang=\"la\">\\1</i>",
+"<i lang=\"de\">\\1</i>",
+"<q>\\1</q>"
+],
+"hint": "Mark italic phrases with semantic tags using S/R dialog (Shift-click Replace)"
+}
+]
+}

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -663,6 +663,11 @@ class PathnameCombobox(Combobox):
         for path in preferences.get(self.prefs_key):
             if os.path.exists(path):
                 path_list.append(path)
+        # Ensure default files are included in list (in case new default is added
+        # in a later release after the user has customized the list)
+        for path in preferences.get_default(self.prefs_key):
+            if path not in path_list and os.path.exists(path):
+                path_list.append(path)
         preferences.set(self.prefs_key, path_list)
 
 


### PR DESCRIPTION
1. In regex library json file, allow the `replacement` value to either be a single string (as before) or a list of strings.
2. Only the first replacement appears in the regex library dialog (as before) - in order to use the multiple replacements user Shift-clicks Replace to bring up the S/R dialog.
3. Although any number of strings will be accepted, the S/R dialog can only display the first 10
4. If necessary Multi-replace will be turned on, and S/R dialog will be expanded (but never contracted) to have enough replacement fields.
5. If S/R dialog was already visible, and had values in later replacement fields that are not needed for this regex, the later fields are cleared to avoid confusion
6. Note edge case: user can edit the first replacement field in the regex library dialog (as before). First field in popped S/R dialog will then be taken from the regex library dialog, (as before) rather than the value in the json file. Will "never" happen except during over-zealous testing :)
7. Example json file included: `...data/regex_library/italic_semantic.json`
Shows syntax needed for multiple replacements. Hint also alerts user that they need to pop the S/R dialog to use it.
8. Example json file would not appear in dropdown in regex library dialog if user had previously loaded their own file from elsewhere. This is because the prefs file contains a list of the regex library files, which overrides the default list. Specifically, in previous release, only regex library file was dashes.json so default list of regex library files just consisted of `dashes.json`; user adds `myregs.json`, so now the list `dashes.json, myregs.json` is stored in prefs file; then the new release is issued, which has default list of `dashes.json, semantic_italic.json`, but that default gets overwritten with the user's previously stored `dashes.json, myregs.json`, and they don't see `semantic_italic`. Fixed by ensuring all files in the default list are added to the current list if they are not already there.
9. Text-->Convert <sc>Manually (which also pops the S/R dialog) has had a couple of bug fixes added that were developed during the regex library work: if the S/R dialog were already visible, with too few multi-replace fields, it wasn't updated properly to show the additional fields when Convert <sc> Manually was run; similarly if there were too many replace fields, some of which had text in them, that text wasn't cleared.