### PR TITLE
Default to using advanced regex behavior

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -3052,7 +3052,7 @@ class MainText(tk.Text):
         # Preferable to use flags rather than prepending "(?i)", for example,
         # because if we need to report bad regex to user, it's better if it's
         # the regex they typed.
-        flags = 0
+        flags = re.V1  # Use advanced version 1 behavior
         if backwards:
             flags |= re.REVERSE
         if nocase:


### PR DESCRIPTION
No real disadvantages, and it saves having to prefix the regex with `(?V1)` to use any VERSION1 features.

Testing notes:
The regex `[a-z--c-t]` will match all of a-z letters in `master` whereas with this commit, it will match `abuvwxyz`, i.e. `a-z` minus `c-t`.
If you want the advanced behavior in `master`, you have to use `(?V1)[a-z--c-t]`