### PR TITLE
Speed up Unmatched HTML Tags check

### DIFF
--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -836,8 +836,8 @@ def unmatched_dp_markup() -> None:
 
 def unmatched_html_markup() -> None:
     """Check for unmatched HTML markup."""
-
     open_regex = "<([[:alnum:]]+)( [^>\n]+)?>"
+    open_regex_c = re.compile(open_regex)
     close_regex = "</([[:alnum:]]+)>"
 
     def get_tag_type_regex(markup_in: str) -> str:
@@ -845,7 +845,7 @@ def unmatched_html_markup() -> None:
 
         Escaped so suitable for use in a regex.
         """
-        return re.escape(re.sub(open_regex, r"\1", markup_in.replace("/", "")))
+        return re.escape(open_regex_c.sub(r"\1", markup_in.replace("/", "")))
 
     def matched_pair_html_markup(markup_in: str) -> tuple[str, bool]:
         """Get regex that matches open and close HTML markup.
@@ -881,8 +881,8 @@ def unmatched_html_markup() -> None:
         and both opening or both closing. This is to make `<p class="center">`
         match `<p>`, for example, which simple equality would not.
         """
-        s1 = re.sub(open_regex, r"<\1>", s1)
-        s2 = re.sub(open_regex, r"<\1>", s2)
+        s1 = open_regex_c.sub(r"<\1>", s1)
+        s2 = open_regex_c.sub(r"<\1>", s2)
         return s1 == s2
 
     unmatched_markup_check(


### PR DESCRIPTION
Reduces from 94 to 67 seconds on my computer by compiling one of the much-used regexes.

Fixes #1470 