### PR TITLE
Fix exception from unpaired footnote anchors

### DIFF
--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -688,6 +688,9 @@ def reindex() -> None:
     index_style = preferences.get(PrefKey.FOOTNOTE_INDEX_STYLE)
     an_records = _THE_FOOTNOTE_CHECKER.get_an_records()
     fn_records = _THE_FOOTNOTE_CHECKER.get_fn_records()
+    if len(an_records) > len(fn_records):
+        logger.error("Unable to reindex with unpaired anchors")
+        return
     for index in range(1, len(an_records) + 1):
         if index_style == "roman":
             label = roman.toRoman(index)


### PR DESCRIPTION
If user tries to reindex when there are unpaired footnote anchors, it generated an exception. Instead output an error message, so user can fix the problem, either by pairing up the anchor, or editing it to `{{123}}` so it is not recognized as an anchor.

Test file: agricola-test-busy after changing one of the `{{nnn}}` back to `[nnn]`, then using Reindex.

