### PR TITLE
Handle missing scanno/regex library file better

### DIFF
--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -1757,6 +1757,8 @@ class ScannoRegexCheckerDialog(CheckerDialog):
         scanno_dict = load_dict_from_json(path)
         if scanno_dict is None:
             logger.error(f"Unable to load {self.type_adj} file {path}")
+            self.display_entries()
+            self.lift()
             return
         # Some scannos files require whole-word searching
         try:


### PR DESCRIPTION
If the current regex/scanno file (as stored in the prefs file) is deleted by the user, next time they try to open the dialog, an error pops up, the dialog ends up behind the main window and the cursor looks busy, so user thinks they can't use the dialog.

Instead, make sure dialog gets popped to front once error is dismissed and no longer looks busy.

Fixes #1483