### PR TITLE
Allow escaping of FN anchors with backslash

### DIFF
--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -454,6 +454,7 @@ class FootnoteChecker:
 
             # Find previous occurrence of matching anchor, e.g. "[4]"
             # but not where used in context of block markup, e.g. "/#[4]"
+            # nor if PPer has used backslash to escape, e.g. "\[1928]"
             start_point = start
             while True:
                 anchor_match = maintext().find_match(
@@ -467,7 +468,7 @@ class FootnoteChecker:
                     f"{anchor_match.rowcol.index()}-2c", anchor_match.rowcol.index()
                 )
                 if not re.fullmatch(
-                    "/[#$*FILPXCR]", anchor_context, flags=re.IGNORECASE
+                    r"/[#$*FILPXCR]|.\\", anchor_context, flags=re.IGNORECASE
                 ):
                     break
                 start_point = anchor_match.rowcol
@@ -500,7 +501,7 @@ class FootnoteChecker:
         # Check for anchors that are not paired
         anchor_matches = maintext().find_all(
             maintext().start_to_end(),
-            r"(?<!/[#$*FfIiLlPpXxCcRr])\[([\d]+|[A-Z])]",
+            r"(?<!(/[#$*FfIiLlPpXxCcRr]|\\))\[([\d]+|[A-Z])]",
             regexp=True,
             wholeword=False,
             nocase=False,


### PR DESCRIPTION
An example would be a date in square brackets, e.g. `[1928]` which the FN code would interpret as an anchor. If PPer precedes the open bracket with backslash, FN fixup will now ignore it.

Fixes #1485