### PR TITLE
Suggest "Keep"-ing hyphenated number ranges

### DIFF
--- a/src/guiguts/content_providing.py
+++ b/src/guiguts/content_providing.py
@@ -295,7 +295,8 @@ class DehyphenatorChecker:
                         "de",
                         "im",
                     )
-            if not remove and use_dict:
+
+            if not remove and use_dict and not (frag1.isdigit() and frag2.isdigit()):
                 remove = (
                     spell_checker.spell_check_word(f"{frag1}{frag2}", dummy_proj_dict)
                     == SPELL_CHECK_OK_YES


### PR DESCRIPTION
In CP Dehyphenator, if split "word" is actually a number range, i.e. "digits", hyphen, newline, "digits", then when "Use Dictionary" flag is set, it checks the dictionary for "several digits", which always returns True.

So, in case of digits, don't check dictionary, retain the "Keep" flag.

Fixes #1487