### PR TITLE
Extend sorting in Command Palette

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -666,6 +666,7 @@ class Guiguts:
         preferences.set_default(PrefKey.ASCII_TABLE_FILL_CHAR, "@")
         preferences.set_default(PrefKey.ASCII_TABLE_RIGHT_COL, 70)
         preferences.set_default(PrefKey.COMMAND_PALETTE_HISTORY, [])
+        preferences.set_default(PrefKey.COMMAND_PALETTE_SORT, 1)
         preferences.set_default(PrefKey.KEYBOARD_SHORTCUTS_DICT, {})
         preferences.set_default(PrefKey.AUTOTABLE_MULTILINE, False)
         preferences.set_default(PrefKey.AUTOTABLE_WIDE_FLAG, False)

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -148,6 +148,7 @@ class PrefKey(StrEnum):
     ASCII_TABLE_FILL_CHAR = auto()
     ASCII_TABLE_RIGHT_COL = auto()
     COMMAND_PALETTE_HISTORY = auto()
+    COMMAND_PALETTE_SORT = auto()
     KEYBOARD_SHORTCUTS_DICT = auto()
     AUTOTABLE_MULTILINE = auto()
     AUTOTABLE_WIDE_FLAG = auto()


### PR DESCRIPTION
1. Allow user to click column header to sort by that column
2. Click again to reverse
3. If there is a search string, sorting will be primarily based on how well the search string matches, rather than alphabetic.
4. Therefore, search arrows are not shown in header if there is a search string
5. Clicking header when there is a search string may slightly affect sorting, e.g. if two entries have the same match-score.

Testing notes:
Could have potentially broken Help->List of Compose Sequences, since sorting code has been extracted from there to  make it available to Command Palette