### PR TITLE
Clear "Working" label if Autosave doesn't save

### DIFF
--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -344,6 +344,7 @@ class File:
                 # Don't autosave if nothing changed - just reschedule
                 if not maintext().is_modified():
                     self.reset_autosave()
+                    Busy.unbusy()
                     return ""
                 backup2_file, backup2_bin = get_backup_names(".bk2")
                 backup1_file, backup1_bin = get_backup_names(".bk1")


### PR DESCRIPTION
If Autosave is triggered, but the file hasn't been modified, no save is necessary. Under these circumstances, the "Working" label was not being cleared.

Fixes #1507