### PR TITLE
Add `/c` and `/r` to HTML chapter heading checks

### DIFF
--- a/src/guiguts/html_convert.py
+++ b/src/guiguts/html_convert.py
@@ -843,7 +843,9 @@ def html_convert_body() -> None:
                     maintext().insert(line_start, "  </h2>\n")
                 # If stopping due to blockquote/poetry/footnote/etc, don't advance through file
                 # Need to loop round again so the found markup is processed
-                if not selection_lower.startswith(("/#", "/p", "/*", "/c", "/r", "[footnote")):
+                if not selection_lower.startswith(
+                    ("/#", "/p", "/*", "/c", "/r", "[footnote")
+                ):
                     next_step += 1
                 # Don't want footnote anchors in auto ToC
                 chap_heading = re.sub(r"\[.{1,5}\]", "", chap_heading)


### PR DESCRIPTION
If they are used, stop treating the lines as part of the h2
heading, and leave PPer to manual format as necessary.

Fixes [#1509](https://github.com/DistributedProofreaders/guiguts-py/issues/1509)