### PR TITLE
Cope with `<div>` round Auto-illos

### DIFF
--- a/src/guiguts/html_tools.py
+++ b/src/guiguts/html_tools.py
@@ -381,7 +381,10 @@ class HTMLImageDialog(ToplevelDialog):
         # Find and go to start of next unconverted illo markup
         illo_match_start = maintext().find_match(
             r"\[Illustration",
-            IndexRange(maintext().get_insert_index().index(), maintext().end()),
+            IndexRange(
+                maintext().rowcol(f"{maintext().get_insert_index().index()}+1c"),
+                maintext().end(),
+            ),
             regexp=True,
         )
         if illo_match_start is None:


### PR DESCRIPTION
When GG converts `[Illustration]` to HTML, it adds `<p>` markup around it. Auto-illus removes this when it converts the illustration to an HTML `<figure>`.

New behavior: If the user customizes that `<p>` markup with a class, or uses a `<div>` instead, leave their markup alone and just put the `<figure>` inside it.

Fixes #1512