### PR TITLE
Allow "Per LZ" re-indexing of footnotes

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -474,6 +474,7 @@ class Guiguts:
             PrefKey.LEVENSHTEIN_DISTANCE, LevenshteinEditDistance.ONE
         )
         preferences.set_default(PrefKey.FOOTNOTE_INDEX_STYLE, FootnoteIndexStyle.NUMBER)
+        preferences.set_default(PrefKey.FOOTNOTE_PER_LZ, False)
         preferences.set_default(PrefKey.SHOW_TOOLTIPS, True)
         preferences.set_default(PrefKey.WRAP_LEFT_MARGIN, 0)
         preferences.set_default(PrefKey.WRAP_RIGHT_MARGIN, 72)

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -54,6 +54,7 @@ class PrefKey(StrEnum):
     JEEBIES_PARANOIA_LEVEL = auto()
     LEVENSHTEIN_DISTANCE = auto()
     FOOTNOTE_INDEX_STYLE = auto()
+    FOOTNOTE_PER_LZ = auto()
     SHOW_TOOLTIPS = auto()
     WRAP_LEFT_MARGIN = auto()
     WRAP_RIGHT_MARGIN = auto()


### PR DESCRIPTION
User sets up Landing Zones, normally either at end of book, or end of chapter, but maybe end of section, or other scheme. Checkbox next to Reindex button causes renumbering to start from 1 for each LZ.
Note that the check for duplicate footnote numbers is now only done when "Per LZ" is turned off.

The HTML generation hasn't changed - it already used 2 numbers, the first is the label of the footnote, and the second is the number of the footnote counting from the start of the book. Therefore, FNs will get IDs something like: 1_1, 2_2, 3_3, 1_4, 2_5, 1_6, etc. They will thus be unique which is the only requirement.

Fixes #526
Fixes #909 (well, sort-of - it makes it less bizarre)