### PR TITLE
Improve HTML Markup handling of class names

### DIFF
--- a/src/guiguts/html_tools.py
+++ b/src/guiguts/html_tools.py
@@ -2037,9 +2037,9 @@ class HTMLMarkupDialog(ToplevelDialog):
         attr: str = preferences.get(attr_key)
         if cbx is not None:
             cbx.add_to_history(attr)
-        # If simple word given, it's a class name
-        if re.fullmatch(r"[-_\w]+", attr):
-            attr = f"class={attr}"
+        # If no equals sign, it's class name(s)
+        if attr and "=" not in attr:
+            attr = f'class="{attr}"'
         if attr:
             attr = f" {attr}"
         cls.add_markup(f"<{markup}{attr}>", f"</{markup}>")


### PR DESCRIPTION
1. Bug where classname didn't get quotes round it
2. Allow user to add 2 or more classnames, not just 1.

Previous algorithm checked if user's string was a single word, and if so added `class=` (but forgot the quotes!)
New algorithm checks if string contains `=` sign, and if not adds `class=` (with quotes!)

Fixes #1522