### PR TITLE
Add `--resetgeometry` command line option

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -181,6 +181,11 @@ class Guiguts:
         logger.info("Guiguts started")
 
         self.initialize_preferences()
+        if self.args.resetgeometry:
+            preferences.reset(PrefKey.ROOT_GEOMETRY)
+            preferences.reset(PrefKey.ROOT_GEOMETRY_FULL_SCREEN)
+            preferences.reset(PrefKey.ROOT_GEOMETRY_STATE)
+            preferences.reset(PrefKey.DIALOG_GEOMETRY)
 
         self.file = File(self.filename_changed, self.languages_changed)
         the_file(self.file)
@@ -287,6 +292,11 @@ class Guiguts:
             "--version",
             action="store_true",
             help="Display the version of Guiguts",
+        )
+        parser.add_argument(
+            "--resetgeometry",
+            action="store_true",
+            help="Reset layout of dialogs and main window to defaults",
         )
         self.args = parser.parse_args(args)
 

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -296,6 +296,14 @@ class Preferences:
             for var in self.persistent_vars[key]:
                 var.set(value)
 
+    def reset(self, key: PrefKey) -> None:
+        """Reset a preference to its default.
+
+        Args:
+            key: Name of preference.
+        """
+        self.set(key, self.get_default(key))
+
     def toggle(self, key: PrefKey) -> None:
         """Toggle the value of a boolean preference.
 


### PR DESCRIPTION
No PPers have reported a problem with multiple monitors, but if the main window or dialogs are dragged onto a second monitor, then the monitor is removed before the next run of GG, the windows may be placed off-screen.

Use `guiguts --resetgeometry` to reset the size and position of the main window and all dialogs to the default values, which will bring them back onto the main screen.

I think this is sufficient for now for a situation that hasn't arisen during PPing.

Fixes #206

Testing notes: 

- Add second/third monitors, and drag various windows (including main window?) onto them. 
- Quit GG
- Turn one or more additional monitors off
- Start GG
- Notice dialogs are invisible
- Quit GG
- Start GG with the `--resetgeometry` argument
- Notice dialogs are now visible