### PR TITLE
Fix Ctrl-clicking in Curly Quote dialog

### DIFF
--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -2589,8 +2589,8 @@ def do_fix_quote(checker_entry: CheckerEntry) -> None:
     if (
         checker_entry.error_prefix
         in (
-            "DOUBLE QUOTE NOT CONVERTED: ",
-            "SINGLE QUOTE NOT CONVERTED: ",
+            "DQ not converted: ",
+            "SQ not converted: ",
         )
         and maintext().get(
             _the_curly_quotes_dialog.mark_from_rowcol(checker_entry.text_range.start),


### PR DESCRIPTION
Broken by #1152

Testing notes:

1. Add some straight single/double quotes
2. Run Curly Quote CHECK (not convert)
3. Ctrl-click on messages about unconverted quotes
4. Unlike in `master`, straights should be converted to curly. 