### PR TITLE
Remove extra spaces after <cite> replacement

### DIFF
--- a/src/guiguts/data/regex_library/italic_semantic.json
+++ b/src/guiguts/data/regex_library/italic_semantic.json
@@ -5,7 +5,7 @@
 "replacement": [
 "<i>\\1</i>",
 "<em>\\1</em>",
-"<cite>\\1</cite>  ",
+"<cite>\\1</cite>",
 "<i lang=\"fr\">\\1</i>",
 "<i lang=\"la\">\\1</i>",
 "<i lang=\"de\">\\1</i>",


### PR DESCRIPTION
The `<cite>` replacement in italic_semantics.json had extra spaces after the replacement, which could result in incorrectly rendered space between a `<cite>` and punctuation, and possibly other issues.