### PR TITLE
Display English Scannos before fixing

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -1526,8 +1526,12 @@ class CheckerDialog(ToplevelDialog):
         entry_index = self.current_entry_index()
         if entry_index is None:
             return
-        linenum = self.text.get_select_line_num()
-        if linenum is None:
+        linenum = (
+            self.linenum_from_entry_index(0)
+            if self.match_on_highlight == CheckerMatchType.ALL_MESSAGES
+            else self.text.get_select_line_num()
+        )
+        if not linenum:
             return
         # Mark before starting so location can be selected later
         self.text.mark_set(MARK_ENTRY_TO_SELECT, f"{linenum}.0")


### PR DESCRIPTION
For Common English Scannos, and Olde Englifh checks, list the changes that need to be made. User can then hide any they do not want to make, then use Fix All to fix all the rest.

Fixes #1541 (2nd alternative)