### PR TITLE
Improve support for Google Ngram Viewer

### DIFF
--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -546,11 +546,31 @@ class PreferencesDialog(ToplevelDialog):
             "Clear the field completely to use built-in compression (quicker but less effective).",
         )
 
+        ttk.Label(advance_frame, text="Google Ngram parameters:").grid(
+            row=10, column=0, sticky="NSE", pady=5
+        )
+        ngram_entry = ttk.Entry(
+            advance_frame,
+            textvariable=PersistentString(PrefKey.NGRAM_PARAMETERS),
+            width=30,
+        )
+        ngram_entry.grid(
+            row=10, column=1, sticky="NSEW", padx=(5, 0), pady=5, columnspan=2
+        )
+        ToolTip(
+            ngram_entry,
+            "Parameters to be added to the Google Books Ngram URL.\n"
+            'Each parameter must be preceded by "&", for example,\n'
+            '"&corpus=en-2019&year_start=1700&year_end=2000".\n'
+            'Corpus can be a supported language code, e.g. "de", "fr", "es", etc.\n'
+            'It can also include a year to select a specific dataset, e.g. "es-2019".',
+        )
+
         ttk.Button(
             advance_frame,
             text="Reset shortcuts to default (requires restart)",
             command=lambda: KeyboardShortcutsDict().reset(),
-        ).grid(row=10, column=0, sticky="NSW", pady=5, columnspan=3)
+        ).grid(row=11, column=0, sticky="NSW", pady=5, columnspan=3)
 
         notebook.bind(
             "<<NotebookTabChanged>>",

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -8,6 +8,7 @@ import tkinter as tk
 from tkinter import ttk, messagebox
 from typing import Callable, Optional, Any, TypeVar
 import unicodedata
+import webbrowser
 
 import regex as re
 
@@ -2773,3 +2774,22 @@ def convert_sequential() -> None:
         maintext().delete(start, f"{start}+4c")
         maintext().insert(start, str(counter))
         counter += 1
+
+
+def open_ngram() -> None:
+    """Open Google Books Ngram viewer, using selected text if any.
+    If a single hyphenated word, compare with unhyphenated."""
+    content = re.sub(r"\s+", " ", maintext().selected_text().strip())
+    # If single hyphenated word, add non-hyphenated version
+    if "-" in content and "," not in content and " " not in content:
+        content = f"{content},{content.replace('-','')}"
+    if not content:  # Default content to same as Ngram website
+        content = r"Albert%20Einstein,Sherlock%20Holmes,Frankenstein"
+    do_open_ngram(content)
+
+
+def do_open_ngram(content: str) -> None:
+    """Open Google Books Ngram viewer with given content."""
+    base_url = "https://books.google.com/ngrams/graph?content="
+    params = preferences.get(PrefKey.NGRAM_PARAMETERS)
+    webbrowser.open(f"{base_url}{content}{params}")

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -227,6 +227,7 @@ class PrefKey(StrEnum):
     DID_YOU_KNOW_LAST_SHOWN = auto()
     DID_YOU_KNOW_INTERVAL = auto()
     DID_YOU_KNOW_INDEX = auto()
+    NGRAM_PARAMETERS = auto()
 
 
 class Preferences:


### PR DESCRIPTION
1. Add `Google Ngram parameters` field to Settings, Advanced tab, where user can specify corpus, start year, end year, etc. Default to use English 2019 dataset.
2. Remove Ngram Viewer from Custom Menu if the label string and command are still set to the default values. If user has customized the entry, do not remove it. User can remove it if they wish to - it will not use the parameters from Settings.
3. Add `Google Books Ngram Viewer` to Tools Menu.
4. If user has text selected, pass that to the Ngram Viewer.
5. If user has selected a single, hyphenated word, pass that word and its unhyphenated form to the Ngram Viewer
6. In Word Frequency, make Shift-Cmd/Ctrl-Left-Click show word in Ngram Viewer.
7. If WF is in "Hyphens" mode, and selected word is marked as a suspect, pass the word and all the other suspects in the viewer. This could be "flash-light" & "flashlight", or "flash-light" & "flash light", or all 3 variants, depending on what is in the text.
8. If in WF Hyphens mode, but word is not marked as a suspect, it must contain a hyphen, so pass the word and its unhyphenated form to the Ngram viewer.

Fixes #1559