### PR TITLE
Fix regex handling bug

### DIFF
--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -1099,7 +1099,7 @@ def strip_outer_lookarounds(pattern: str) -> str:
         if m:
             end = find_matching_paren(pattern, 0)
             if end is not None:
-                pattern = "^" + pattern[end + 1 :].lstrip()
+                pattern = "^" + pattern[end + 1 :]
 
     # Strip trailing lookaround
     if pattern.endswith(")"):


### PR DESCRIPTION
If a lookbehind in a regex was immediately followed by one or more spaces, e.g. `(?<=x)  yz` the spaces were removed, causing a replacement based on the regex to fail.

Fixes #1585