### PR TITLE
Fix reindex bug if 2 anchors per footnote

### DIFF
--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -765,15 +765,15 @@ def reindex() -> None:
                 label = str(new_index)
 
             maintext().replace(an_start, an_end, f"[{label}]")
-            #
-            fn_record = fn_records[index]
-            label_start = fn_record.hilite_start + 9
-            label_end = fn_record.hilite_end
-            fn_start = f"{fn_record.start.index()}"
-            # Replace label in footnote with new label value.
-            maintext().replace(
-                f"{fn_start}+{label_start}c", f"{fn_start}+{label_end}c", label
-            )
+        #
+        fn_record = fn_records[index]
+        label_start = fn_record.hilite_start + 9
+        label_end = fn_record.hilite_end
+        fn_start = f"{fn_record.start.index()}"
+        # Replace label in footnote with new label value.
+        maintext().replace(
+            f"{fn_start}+{label_start}c", f"{fn_start}+{label_end}c", label
+        )
     # AN/FN file entries have changed. Update AN/FN records.
     _the_footnote_checker.run_check()
     # Maintain the order of function calls below.


### PR DESCRIPTION
Bug occurred because it changed the number in the footnote for every anchor. So if there were two anchors, it changed the number in the footnote twice. However, the change was based on character positions, so if the number was "26", it replaced those two characters with "XXVI.", for example, then when it did the second replacement, it replaced two of those characters with "XXVI." leading to something like "XXVI.VI."

Fixes #1595