### PR TITLE
Detect duplicate Roman FN anchors correctly

### DIFF
--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -507,7 +507,7 @@ class FootnoteChecker:
         # Check for anchors that are not paired
         anchor_matches = maintext().find_all(
             maintext().start_to_end(),
-            r"(?<!(/[#$*FfIiLlPpXxCcRr]|\\))\[([\d]+|[A-Z]|[ivx]+)]",
+            r"(?<!(/[#$*FfIiLlPpXxCcRr]|\\))\[([\d]+|[IiVvXxLlCc]+\.?|[A-Z])]",
             regexp=True,
             wholeword=False,
             nocase=False,


### PR DESCRIPTION
Case was wrong in regex, and no optional trailing period.