### PR TITLE
Show "working" when using Hide All button

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -1548,6 +1548,7 @@ class CheckerDialog(ToplevelDialog):
             all_matching: If True, repeat for all entries that have the same
                 message as the current entry (e.g. same spelling error).
         """
+        Busy.busy()
         maintext().undo_block_begin()
         entry_index = self.current_entry_index()
         if entry_index is None:
@@ -1603,6 +1604,7 @@ class CheckerDialog(ToplevelDialog):
             except IndexError:
                 return
             self.select_entry_by_index(entry_index)
+        Busy.unbusy()
 
     def report_fix_removes(self, process: bool, remove: bool, num: int) -> None:
         """Report how many removals and fixes were made."""


### PR DESCRIPTION
Should work in any checker dialog, e.g. Find All

Testing notes: Worth checking that various "Fix" or "Fix All" buttons in dialogs show "working" correctly, particularly, that the "working" label is turned off when it all finishes.
