### PR TITLE
Make CP Dehyphenator flag beg-of-page hyphens

### DIFF
--- a/src/guiguts/content_providing.py
+++ b/src/guiguts/content_providing.py
@@ -313,6 +313,15 @@ class DehyphenatorChecker:
                 ep_index=0 if remove else 1,
                 severity=CheckerEntrySeverity.INFO,
             )
+        # Flag start-of-page hyphens
+        start = maintext().start().index()
+        while start := maintext().search(r"^-----File:", start, tk.END, regexp=True):
+            start = maintext().index(f"{start} lineend")
+            next_line = maintext().get(f"{start} +1l linestart", f"{start} +1l lineend")
+            if next_line.startswith("-----File:"):
+                continue
+            if next_line.startswith("-"):
+                maintext().insert(f"{start} +1l linestart", "*")
         self.dialog.display_entries()
 
     def dehyphenate(self, checker_entry: CheckerEntry) -> None:


### PR DESCRIPTION
Both single and double hyphens at start of page will be flagged with asterisk by CP dehyphenator, just like end of page hyphens.

Fixes #1547

Testing notes:
1. File-->CP-->Import these files: [beop-hyphens.zip](https://github.com/user-attachments/files/24170518/beop-hyphens.zip)
2. Look at start/end of 005, end of 006 and start of 007 for examples of single/double hyphens
3. Run File-->CP-->Dehyphenator
4. Look again at those locations to see asterisks
