### PR TITLE
Preserve newlines in source of  HTML Autotable

### DIFF
--- a/src/guiguts/html_tools.py
+++ b/src/guiguts/html_tools.py
@@ -1874,7 +1874,7 @@ class HTMLAutoTableDialog(ToplevelDialog):
         html = ["<tr>"]
         for col_num, cell in enumerate(row_cells):
             col_align = self.get_align_class(col_num)
-            html.append(f'<td class="{col_align}">{cell}</td>')
+            html.append(f'<td class="{col_align}">\n{cell}\n</td>')
         html.append("</tr>")
         return "\n".join(html)
 


### PR DESCRIPTION
For a Multiline table, chunks of text were concatenated with a space between to construct the `<td>` element, thus losing the newlines from the original. Instead concatenate them with newlines between to preserve text structure. This has no effect on the book as viewed in the browser, only the HTML source.

Testing notes:
Convert this table using HTML Autotable, with Multiline turned on.
```
abc  def  ghu
xyz  29

ab2  d2f  g2u
x2z  22
```