### PR TITLE
Confirm with user before processing >1000 messages

### DIFF
--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -1600,6 +1600,7 @@ class CheckerDialog(ToplevelDialog):
         ):
             for ii in match_indices:
                 if process_bool:
+                    assert self.process_command is not None
                     self.process_command(self.entries[ii])
                 if remove:
                     if self.entries[ii].severity >= CheckerEntrySeverity.INFO:


### PR DESCRIPTION
When using Fix/Hide All, if number of messages is very large, user may become alarmed by the time taken to complete the operation, particularly if the operation was begun in error. Warn the user before proceeding if the operation would affect >1000 messages.