### PR TITLE
Fix minor CSS niggles

### DIFF
--- a/src/guiguts/data/html/html_header.txt
+++ b/src/guiguts/data/html/html_header.txt
@@ -20,9 +20,9 @@ h1,h2,h3,h4,h5,h6 {
 }
 
 p {
-    margin-top: .51em;
+    margin-top: .5em;
     text-align: justify;
-    margin-bottom: .49em;
+    margin-bottom: .5em;
 }
 
 .p2       {margin-top: 2em;}
@@ -143,7 +143,7 @@ blockquote {
 
 .bbox     {border: 2px solid;}
 
-.center   {text-align: center;}
+.center   {text-align: center; text-indent: 0;}
 
 .right    {text-align: right;}
 

--- a/tests/expected/htmlconvert1.txt
+++ b/tests/expected/htmlconvert1.txt
@@ -20,9 +20,9 @@ h1,h2,h3,h4,h5,h6 {
 }
 
 p {
-    margin-top: .51em;
+    margin-top: .5em;
     text-align: justify;
-    margin-bottom: .49em;
+    margin-bottom: .5em;
 }
 
 .p2       {margin-top: 2em;}
@@ -143,7 +143,7 @@ blockquote {
 
 .bbox     {border: 2px solid;}
 
-.center   {text-align: center;}
+.center   {text-align: center; text-indent: 0;}
 
 .right    {text-align: right;}
 

--- a/tests/expected/htmlconvert2.txt
+++ b/tests/expected/htmlconvert2.txt
@@ -20,9 +20,9 @@ h1,h2,h3,h4,h5,h6 {
 }
 
 p {
-    margin-top: .51em;
+    margin-top: .5em;
     text-align: justify;
-    margin-bottom: .49em;
+    margin-bottom: .5em;
 }
 
 .p2       {margin-top: 2em;}
@@ -143,7 +143,7 @@ blockquote {
 
 .bbox     {border: 2px solid;}
 
-.center   {text-align: center;}
+.center   {text-align: center; text-indent: 0;}
 
 .right    {text-align: right;}
 


### PR DESCRIPTION
1. Change p margins to exactly 0.5 (used to be different for historical reasons).
2. Add `text-indent:0` to center class to avoid problems if user sets text-indent on paragraphs

For point 2:

[This test HTML file](https://github.com/user-attachments/files/24387236/test.zip) is a minimal example, showing the problem with the old CSS. Changing the definition of "center" in the CSS to include `text-indent:0;` with fix it. Alternatively, you could test by taking a text file with some multi-line center markup, e.g.

```
/C
A B R A C A D A B R A
A B R A C A D A B R
A B R A C A D A B 
C/
```

Convert it to HTML, and edit the CSS for `p` to include the text-indent (like the test HTML file above has), and view it. This process will give incorrect results in `master`, and correct in the branch.

Not much to test for point 1 - shouldn't affect the look of books at all.