### PR TITLE
Avoid crash in Command Palette

### DIFF
--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -1988,7 +1988,7 @@ class CommandPaletteDialog(ToplevelDialog):
         self.list.tag_configure(self.SEPARATOR_TAG, foreground="gray")
 
         # Bind events for list and entry
-        self.list.bind("<Return>", self.execute_command)
+        self.list.bind("<Return>", lambda _: self.execute_command())
         self.list.bind("<Double-Button-1>", self.execute_command)
         self.list.bind("<Down>", lambda _: self.move_in_list(1))
         self.list.bind("<Up>", lambda _: self.move_in_list(-1))
@@ -1997,7 +1997,7 @@ class CommandPaletteDialog(ToplevelDialog):
 
         self.entry.bind("<Down>", lambda _: self.move_in_list(1))
         self.entry.bind("<Up>", lambda _: self.move_in_list(-1))
-        self.entry.bind("<Return>", self.execute_command)
+        self.entry.bind("<Return>", lambda _: self.execute_command())
 
         self.update_list()
         self.entry.focus()

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -834,7 +834,7 @@ class TreeviewList(ttk.Treeview):
             col_id = "#1"
         else:
             row_id, col_id = self.identify_rowcol(event)
-        if self.sort_pref is not None and not row_id:
+        if self.sort_pref is not None and not row_id and col_id:
             col = int(col_id[1])
             cur = preferences.get(self.sort_pref)
             if abs(cur) == col:


### PR DESCRIPTION
Certain combinations of popping the dialog, then pressing Return/Enter could cause a traceback. The code wasn't handling the Return/Enter correctly, and treating it like a mouse click.

Fixes #1646

Testing notes:
Please check running commands from within the Command palette still works, either by double clicking in the list, or single-clicking in the list then pressing Enter/Return, or by single-clicking in the list, then clicking the Run button, or focusing in the entry field at the top, then pressing Enter/Return. Pressing Enter/Return should behave the same as clicking the Run button, i.e. run the currently selected command. Whatever happens, it shouldn't give a traceback. You may no be able to get `master` to traceback - it seems timing/sequence related, and I could get it to happen only occasionally. I've fixed the bit of code where the traceback happened anyway.

