### PR TITLE
Add Image Prev/Next to Command Palette

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -330,6 +330,7 @@ class Guiguts:
         """Show the image corresponding to current location."""
         self.file.image_dir_check()
         self.mainwindow.load_image(self.file.get_current_image_path())
+        mainimage().auto_image_state(AutoImageState.NORMAL)
 
     def show_image_viewer(self) -> None:
         """Show the image viewer."""

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -721,6 +721,14 @@ class MainImage(tk.Frame):
             "Image Browse",
             self.browse,
         )
+        menubar_metadata().add_button_orphan(
+            "Image Prev",
+            lambda: self.next_image(reverse=True),
+        )
+        menubar_metadata().add_button_orphan(
+            "Image Next",
+            self.next_image,
+        )
 
     def scroll_y(self, *args: Any, **kwargs: Any) -> None:
         """Scroll canvas vertically and redraw the image"""
@@ -1067,9 +1075,11 @@ class MainImage(tk.Frame):
 
     def handle_enter(self, _event: tk.Event) -> None:
         """Handle enter event."""
+        if self.auto_image_state() != AutoImageState.NORMAL:
+            mainimage().alert_user()
         self.auto_image_state(AutoImageState.NORMAL)
 
-    def handle_leave(self, _event: tk.Event) -> None:
+    def handle_leave(self, _event: Optional[tk.Event] = None) -> None:
         """Handle leave event."""
         # Restart auto img
         if self.auto_image_state() == AutoImageState.PAUSED:


### PR DESCRIPTION
These are equivalents of the Prev/Next arrow buttons in the Image Viewer.

The current code relies on the mouse leaving the image viewer window to know when to revert the image view to the current page in the case of AutoImg being on. Now that Prev/Next Image can be run from the Command
Palette or by keyboard shortcut, a method is needed to revert the image viewer to showing the "auto image", i.e. "unpause" AutoImg. Simply clicking AutoImg (or using View-->See Image) will do this. You can of course
Shift-click AutoImg twice to turn it off and on again. Alternatively moving the mouse into the image viewer (or out of the viewer) will do the same.
If the orange border highlight is turned on in the settings dialog, this will be shown when the mouse is moved in or out to unpause AutoImg, but won't be shown if the user explicitly clicks the AutoImg button or uses the View Menu to unpause AutoImg.

Fixes #1649