### PR TITLE
Make toolbar icon size a preference

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -764,6 +764,7 @@ class Guiguts:
         preferences.set_default(
             PrefKey.NGRAM_PARAMETERS, "&corpus=en-2019&year_start=1700&year_end=2000"
         )
+        preferences.set_default(PrefKey.TOOLBAR_ICON_SIZE, 20)
 
         # Check all preferences have a default
         for pref_key in PrefKey:

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -1467,14 +1467,14 @@ class MainWindow:
         status_row2_frame.grid(row=1, column=0, sticky="NSEW", pady=(2, 0))
         status_row2_frame.columnconfigure(1, weight=1)
         toolbar_frame = ttk.Frame(status_row2_frame)
-        toolbar_frame.grid(row=0, column=0, sticky="NSEW")
+        toolbar_frame.grid(row=0, column=0, sticky="EW")
 
         self.tool_btns: dict[str, ttk.Button] = {}
         self.light_photos: dict[str, ImageTk.PhotoImage] = {}
         self.dark_photos: dict[str, ImageTk.PhotoImage] = {}
 
         def create_toolbar_btn(
-            col: int, name: str, tooltip: str, size: tuple[int, int] = (20, 20)
+            col: int, name: str, tooltip: str, size: Optional[tuple[int, int]] = None
         ) -> None:
             """Create a toolbar button.
 
@@ -1484,6 +1484,9 @@ class MainWindow:
                 tooltip: Tooltip for button.
                 size: Size of image to create.
             """
+            if size is None:
+                default_size = max(preferences.get(PrefKey.TOOLBAR_ICON_SIZE), 1)
+                size = (default_size, default_size)
             icon_path = str(
                 importlib.resources.files(icons).joinpath(
                     f"{name.removesuffix('_small')}.png"
@@ -1553,9 +1556,9 @@ class MainWindow:
         status_label_frame.columnconfigure(0, weight=1)
         status_label_frame.columnconfigure(1, weight=0)
         self.status_label_widget = ttk.Label(
-            status_label_frame, borderwidth=1, relief=tk.SUNKEN, padding=1
+            status_label_frame, borderwidth=1, relief=tk.SUNKEN
         )
-        self.status_label_widget.grid(row=0, column=0, sticky="NSEW", padx=5, pady=2)
+        self.status_label_widget.grid(row=0, column=0, sticky="EW", padx=5)
         self.status_label_widget.bind(
             "<ButtonRelease-1>", lambda _: self.messagelog.show()
         )
@@ -1566,9 +1569,8 @@ class MainWindow:
             width=8,
             borderwidth=1,
             relief=tk.SUNKEN,
-            padding=1,
         )
-        self.busy_widget.grid(column=1, row=0, sticky="NSE", padx=(3, 0), pady=2)
+        self.busy_widget.grid(column=1, row=0, sticky="E", padx=(3, 0))
         Busy.busy_widget_setup(self.busy_widget)
 
         ttk.Separator(root()).grid(

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -114,9 +114,9 @@ class PreferencesDialog(ToplevelDialog):
             variable=PersistentBoolean(PrefKey.HIGH_CONTRAST),
         ).grid(column=0, row=1, sticky="NW", pady=5)
 
-        ttk.Label(
-            appearance_frame, text="Tear-Off Menus (change requires restart)"
-        ).grid(row=2, column=0)
+        ttk.Label(appearance_frame, text="Tear-Off Menus (requires restart)").grid(
+            row=2, column=0
+        )
         tearoff_frame = ttk.Frame(appearance_frame)
         tearoff_frame.grid(column=1, row=2, sticky="NSEW")
         tearoff_textvariable = PersistentString(PrefKey.TEAROFF_MENU_TYPE)
@@ -165,23 +165,30 @@ class PreferencesDialog(ToplevelDialog):
             PrefKey.TEXT_CURSOR_WIDTH,
             "Width of insert cursor in main text window",
         )
+        add_label_spinbox(
+            appearance_frame,
+            7,
+            "Toolbar Icon Size (requires restart):",
+            PrefKey.TOOLBAR_ICON_SIZE,
+            "Size of icons in toolbar",
+        )
         ttk.Checkbutton(
             appearance_frame,
             text="Highlight Cursor Line",
             variable=PersistentBoolean(PrefKey.HIGHLIGHT_CURSOR_LINE),
-        ).grid(column=0, row=7, sticky="NW", pady=5)
+        ).grid(column=0, row=8, sticky="NW", pady=5)
 
         ttk.Checkbutton(
             appearance_frame,
             text="Show Character Names in Status Bar",
             variable=PersistentBoolean(PrefKey.ORDINAL_NAMES),
-        ).grid(column=0, row=8, sticky="NW", pady=5)
+        ).grid(column=0, row=9, sticky="NW", pady=5)
 
         ttk.Label(appearance_frame, text="Warning bell: ").grid(
-            column=0, row=9, pady=(5, 0), sticky="E"
+            column=0, row=10, pady=(5, 0), sticky="E"
         )
         bell_frame = ttk.Frame(appearance_frame)
-        bell_frame.grid(column=1, row=9, sticky="EW", pady=(5, 0), columnspan=2)
+        bell_frame.grid(column=1, row=10, sticky="EW", pady=(5, 0), columnspan=2)
         ttk.Checkbutton(
             bell_frame,
             text="Audible",

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -232,6 +232,7 @@ class PrefKey(StrEnum):
     DID_YOU_KNOW_INTERVAL = auto()
     DID_YOU_KNOW_INDEX = auto()
     NGRAM_PARAMETERS = auto()
+    TOOLBAR_ICON_SIZE = auto()
 
 
 class Preferences:


### PR DESCRIPTION
In the Settings dialog, Appearance tab.

Please check that small or (moderately) large values still look "sensible", and don't cause traceback (zero caused traceback initally).

Fixes #1645