### PR TITLE
Split Image dialog between manual/auto

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -37,7 +37,8 @@ from guiguts.file import File, the_file, NUM_RECENT_FILES
 from guiguts.footnotes import footnote_check, FootnoteIndexStyle, footnote_mask
 from guiguts.html_convert import HTMLGeneratorDialog, HTMLMarkupTypes
 from guiguts.html_tools import (
-    HTMLImageDialog,
+    HTMLImageAutoDialog,
+    HTMLImageManualDialog,
     HTMLValidator,
     HTMLLinkChecker,
     CSSValidator,
@@ -1264,16 +1265,14 @@ class Guiguts:
         html_menu.add_button("HTML ~Generator...", HTMLGeneratorDialog.show_dialog)
         html_menu.add_button(
             "Auto-~Illustrations...",
-            lambda: HTMLImageDialog.show_dialog(auto_illus=True),
+            HTMLImageAutoDialog.show_dialog,
         )
         html_menu.add_button("Auto-~Table...", HTMLAutoTableDialog.show_dialog)
         html_menu.add_button("Auto-~List...", HTMLAutoListDialog.show_dialog)
         html_menu.add_separator()
         html_menu.add_button("HTML ~Markup...", HTMLMarkupDialog.show_dialog)
         html_menu.add_button("HTML Links/A~nchors...", HTMLLinksDialog.show_dialog)
-        html_menu.add_button(
-            "HTML Image~s...", lambda: HTMLImageDialog.show_dialog(auto_illus=False)
-        )
+        html_menu.add_button("HTML Image~s...", HTMLImageManualDialog.show_dialog)
         html_menu.add_separator()
         html_menu.add_button("~Unmatched HTML Tags", unmatched_html_markup)
         html_menu.add_button("HTML Lin~k Checker", lambda: HTMLLinkChecker().run())

--- a/src/guiguts/html_tools.py
+++ b/src/guiguts/html_tools.py
@@ -55,10 +55,10 @@ LAND_X = 4  # Common landscape screen ratio
 LAND_Y = 3
 
 
-class HTMLImageDialog(ToplevelDialog):
+class HTMLImageBaseDialog(ToplevelDialog):
     """Dialog for inserting image markup into HTML."""
 
-    manual_page = "HTML_Menu#Auto-Illustrations"
+    manual_page = ""
 
     def __init__(self, auto_illus: bool) -> None:
         """Initialize HTML Image dialog.
@@ -66,7 +66,7 @@ class HTMLImageDialog(ToplevelDialog):
         Args:
             auto_illus: True to work in Auto-Illustration mode
         """
-        super().__init__("HTML Images")
+        super().__init__("Auto-Illustrations" if auto_illus else "HTML Images")
 
         self.image: Optional[Image.Image] = None
         self.imagetk: Optional[ImageTk.PhotoImage] = None
@@ -629,6 +629,26 @@ class HTMLImageDialog(ToplevelDialog):
             case "px":
                 return f"{width_fl * self.image_height / self.image_width:.0f}"
         return "--"
+
+
+class HTMLImageManualDialog(HTMLImageBaseDialog):
+    """Dialog for manually inserting image markup into HTML."""
+
+    manual_page = "HTML_Menu#HTML_Images"
+
+    def __init__(self) -> None:
+        """Initialize HTML Manual Image dialog."""
+        super().__init__(auto_illus=False)
+
+
+class HTMLImageAutoDialog(HTMLImageBaseDialog):
+    """Dialog for "Auto-Illus" inserting image markup into HTML."""
+
+    manual_page = "HTML_Menu#Auto-Illustrations"
+
+    def __init__(self) -> None:
+        """Initialize HTML Auto Image dialog."""
+        super().__init__(auto_illus=True)
 
 
 class HTMLValidatorDialog(CheckerDialog):


### PR DESCRIPTION
Auto-Illustrations and HTML Images now bring up dialogs that are independent of one another, rather than being the same dialog with a couple buttons altered.

Fixes #1656