### PR TITLE
Handle Ngrams properly when word contains -*

### DIFF
--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -2796,8 +2796,10 @@ def convert_sequential() -> None:
 
 def open_ngram() -> None:
     """Open Google Books Ngram viewer, using selected text if any.
-    If a single hyphenated word, compare with unhyphenated."""
+    If a single hyphenated word, compare with unhyphenated. Ignores
+    an asterisk following a hyphen and treats as just the hyphen."""
     content = re.sub(r"\s+", " ", maintext().selected_text().strip())
+    content = content.replace("-*", "-")
     # If single hyphenated word, add non-hyphenated version
     if "-" in content and "," not in content and " " not in content:
         content = f"{content},{content.replace('-', '')}"


### PR DESCRIPTION
Allows user to select a `hyphenated-*suspect` and have Ngram handle it properly without having to remove the `*` first.