### PR TITLE
Handle backslashes in Scannos file dropdown

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -567,30 +567,40 @@ class Guiguts:
         preferences.set_default(PrefKey.IMAGE_VIEWER_INTERNAL, False)
         preferences.set_default(
             PrefKey.SCANNOS_FILENAME,
-            str(DEFAULT_SCANNOS_DIR.joinpath(DEFAULT_REGEX_SCANNOS)),
+            str(DEFAULT_SCANNOS_DIR.joinpath(DEFAULT_REGEX_SCANNOS)).replace("\\", "/"),
         )
         preferences.set_default(
             PrefKey.SCANNOS_HISTORY,
             [
-                str(DEFAULT_SCANNOS_DIR.joinpath(DEFAULT_REGEX_SCANNOS)),
-                str(DEFAULT_SCANNOS_DIR.joinpath(DEFAULT_STEALTH_SCANNOS)),
-                str(DEFAULT_SCANNOS_DIR.joinpath(DEFAULT_MISSPELLED_SCANNOS)),
+                str(DEFAULT_SCANNOS_DIR.joinpath(DEFAULT_REGEX_SCANNOS)).replace(
+                    "\\", "/"
+                ),
+                str(DEFAULT_SCANNOS_DIR.joinpath(DEFAULT_STEALTH_SCANNOS)).replace(
+                    "\\", "/"
+                ),
+                str(DEFAULT_SCANNOS_DIR.joinpath(DEFAULT_MISSPELLED_SCANNOS)).replace(
+                    "\\", "/"
+                ),
             ],
         )
         preferences.set_default(PrefKey.SCANNOS_AUTO_ADVANCE, True)
         preferences.set_default(
             PrefKey.REGEX_LIBRARY_FILENAME,
-            str(DEFAULT_REGEX_LIBRARY_DIR.joinpath(DEFAULT_DASHES_REGEX_LIBRARY)),
+            str(
+                DEFAULT_REGEX_LIBRARY_DIR.joinpath(DEFAULT_DASHES_REGEX_LIBRARY)
+            ).replace("\\", "/"),
         )
         preferences.set_default(
             PrefKey.REGEX_LIBRARY_HISTORY,
             [
-                str(DEFAULT_REGEX_LIBRARY_DIR.joinpath(DEFAULT_DASHES_REGEX_LIBRARY)),
+                str(
+                    DEFAULT_REGEX_LIBRARY_DIR.joinpath(DEFAULT_DASHES_REGEX_LIBRARY)
+                ).replace("\\", "/"),
                 str(
                     DEFAULT_REGEX_LIBRARY_DIR.joinpath(
                         DEFAULT_ITALIC_SEMANTIC_REGEX_LIBRARY
                     )
-                ),
+                ).replace("\\", "/"),
             ],
         )
         preferences.set_default(PrefKey.REGEX_LIBRARY_AUTO_ADVANCE, True)

--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -38,6 +38,7 @@ from guiguts.utilities import (
     IndexRange,
     cmd_ctrl_string,
     is_mac,
+    is_windows,
     sound_bell,
     load_dict_from_json,
     is_debug,
@@ -1650,6 +1651,23 @@ class ScannoRegexCheckerDialog(CheckerDialog):
         for row in range(4):
             frame.rowconfigure(row, uniform="equal height")
 
+        if is_windows():
+            fn_hist: list[str] = preferences.get(self.hist_pref)
+            changed = any("\\" in fn for fn in fn_hist)
+            fn_hist = [fn.replace("\\", "/") for fn in fn_hist]
+            len_hist = len(fn_hist)
+            fn_hist = list(dict.fromkeys(fn_hist))  # Uniquify preserving order
+            if len(fn_hist) != len_hist:
+                changed = True
+            if changed:
+                preferences.set(self.hist_pref, fn_hist)
+
+            fname: str = preferences.get(self.fn_pref)
+            changed = "\\" in fname
+            if changed:
+                fname = fname.replace("\\", "/")
+                preferences.set(self.fn_pref, fname)
+
         self.file_combo = PathnameCombobox(
             frame,
             self.hist_pref,
@@ -1743,6 +1761,8 @@ class ScannoRegexCheckerDialog(CheckerDialog):
             )
         )
         if filename:
+            if is_windows():
+                filename = filename.replace("\\", "/")
             self.focus()
             preferences.set(self.fn_pref, filename)
             self.load_scannos()
@@ -1750,9 +1770,6 @@ class ScannoRegexCheckerDialog(CheckerDialog):
     def select_file(self) -> None:
         """Handle selection of a scannos file."""
         self.load_scannos()
-
-    def prune_scannos(self) -> None:
-        """Remove files from history that no longer exist."""
 
     def load_scannos(self) -> None:
         """Load a scannos file."""


### PR DESCRIPTION
On Windows, files could end up in the Scannos & Regex Library dropdown menus with variations in the whether the path contained forward- or backslashes.
Force all such paths to forward slashes to avoid duplicates.

Fixes #1670

Exact problem can't really be tested on non-Windows platforms, but worth checking that Loading a file in the dialog causes it to be added to the dropdown, and if that file is deleted, it will be removed from the dropdown the next time that dialog is closed & reopened.