### PR TITLE
Change meaning of All in Hide/Fix All in scannos

### DIFF
--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -1635,6 +1635,7 @@ class ScannoRegexCheckerDialog(CheckerDialog):
                 [
                     f"Left click: Select & find occurrence of {dlg_type}",
                     f"Right click: Hide occurrence of {dlg_type} in list",
+                    f"Shift Right click: Hide all occurrences of {dlg_type} in list",
                     f"{cmd_ctrl_string()} left click: Fix this occurrence of {dlg_type}",
                     f"{cmd_ctrl_string()} right click: Fix this occurrence and remove from list",
                     f"Shift {cmd_ctrl_string()} left click: Fix all occurrences of {dlg_type}",


### PR DESCRIPTION
Instead of ALL messages, All will now mean all messages that have the same highlighted string.