### PR TITLE
Fix Repeated Word PPtext check

### DIFF
--- a/src/guiguts/tools/pptxt.py
+++ b/src/guiguts/tools/pptxt.py
@@ -425,8 +425,10 @@ def repeated_words_check() -> None:
             # restrictive regex comparison below using word boundaries.
             if word == wordn1[: len(word)]:
                 possibles = True
+        if len(words_on_line) == 1:
+            wordn1 = words_on_line[-1]
         # Add last word on line to no_numbers_words_on_line if not a number.
-        if len(words_on_line) > 1 and not re.match(r"^[\p{Nd}]+$", wordn1):
+        if len(words_on_line) > 0 and wordn1 and not re.match(r"^[\p{Nd}]+$", wordn1):
             no_numbers_words_on_line.append(wordn1)
         # There may be possible repeats of words (non-numbers) on line.
         if possibles:


### PR DESCRIPTION
1. If all words on line were numeric, a false positive occurred
2. If a single word on a line had a repeat word at the start of the next line, it wasn't reported.

Fixes #1694

Testing notes:

1. 
```
  1900                        $123,021
  1901                         146,834
```

2.
```
abd
abd

def def
```
