### PR TITLE
Revert "All" meaning for Regex Library

### DIFF
--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -2152,7 +2152,7 @@ def library_regexes() -> None:
     _the_regex_library_dialog = RegexCheckerDialog.show_dialog(
         rerun_command=library_regexes,
         process_command=do_replace_regex,
-        match_on_highlight=CheckerMatchType.HIGHLIGHT,
+        match_on_highlight=CheckerMatchType.ALL_MESSAGES,
     )
     _the_regex_library_dialog.load_scannos()
 


### PR DESCRIPTION
PR #1685 changed "All" to mean "All Matching" for Regex Library and Stealth Scannos. This reverts for Regex Library only.