### PR TITLE
Consolidate common PPcomp diff

### DIFF
--- a/src/guiguts/tools/ppcomp.py
+++ b/src/guiguts/tools/ppcomp.py
@@ -560,7 +560,7 @@ def render_marked_diff(
     for lnum, (text, line_pair) in enumerate(lines):
         if line_pair is None:
             continue
-        # If there is another line after this one, look for the following circumstance:
+        # If there is another line after this one, look for the following circumstances:
         # 1. Next line is also the next line in the text file
         # 2. This line is just an underscore (plus flags)
         # 3. Next line has an underscore at the end
@@ -580,7 +580,19 @@ def render_marked_diff(
                 line_pair = next_line_pair
                 lines[lnum] = (text, line_pair)
                 # Nullify next line so it is ignore next time round loop
-                lines[lnum + 1] = ("", None)
+                lines[lnum + 1] = (next_text, None)
+        # If there is a line before this one, look for the following circumstances:
+        # 1. This line is just an underscore (plus flags)
+        # 2. Next line has an underscore at the end
+        if lnum > 0:
+            prev_text = lines[lnum - 1][0]
+            if re.fullmatch(underscore_reg, text) and re.search(
+                f"{underscore_reg}$", prev_text
+            ):
+                # Increment text line number
+                line_pair = (line_pair[0], line_pair[1] + 1)
+                lines[lnum] = (text, line_pair)
+
         a_line, b_line = line_pair
         if html_ln:
             if a_line is not None:


### PR DESCRIPTION
Where a line is italic, frequently get solitary underscore in diffs, then the closing underscore on the end of the next line. Particularly happens in poetry. Consolidate those two diffs into one.

Fixes #1711

Note that the start of a poetry verse (which likely has an underscore in the text version) will still have the underscore on a line on its own, but lines in the middle of a verse will generally be consolidated by this commit.

[Test file](https://github.com/user-attachments/files/25076043/thedruidpathppvsmall.zip)
