### PR TITLE
Preserve multiple mid-line space in autogen `/$`

### DIFF
--- a/src/guiguts/html_convert.py
+++ b/src/guiguts/html_convert.py
@@ -667,6 +667,10 @@ def html_convert_body() -> None:
         # lines within "/$" or "/*" markup
         if dollar_nowrap_flag or asterisk_nowrap_flag:
             do_per_line_markup(selection, line_start, line_end, ibs_dict)
+            # Preserve mid-line multiple spaces for "/$"
+            if dollar_nowrap_flag:
+                nbsp_sel = re.sub("  ", "&nbsp; ", selection.lstrip())
+                maintext().replace(line_start, line_end, nbsp_sel)
             # Add 0.5em margin per space character
             if n_spaces > 0:
                 maintext().insert(


### PR DESCRIPTION
In GG1, `/$` markup not only indents using an HTML span with margin, but also replaces pairs of mid-line spaces with `&nbsp; `. Without that, HTML compresses the multiple spaces to one, which is not what is wanted.

This makes GG2 do the same. Fixes #1717

Testing notes: 

- [dollar.txt](https://github.com/user-attachments/files/25188806/dollar.txt) - test file from issue
- Run autogen.
- Compare with output of GG1.
- HTML code layout is different, but essentials that affect reader's view of the text should be the same