### PR TITLE
Fix `px` bug in auto illus dialog

### DIFF
--- a/src/guiguts/html_tools.py
+++ b/src/guiguts/html_tools.py
@@ -512,10 +512,11 @@ class HTMLImageBaseDialog(ToplevelDialog):
         # Set up classes & styles
         unit_type = preferences.get(PrefKey.HTML_IMAGE_UNIT)
         width = self.width_textvariable.get()
+        height = self.height_textvariable.get()
         img_size = img_class = fig_class = style = ""
         if unit_type == "px":
-            img_size = f' width="{self.image_width}" height="{self.image_height}"'
-            style = f' style="width: {self.image_width}px;"'
+            img_size = f' width="{width}" height="{height}"'
+            style = f' style="width: {width}px;"'
         else:
             img_class = ' class="w100"'
             fig_class = " illow"


### PR DESCRIPTION
It was ignoring the width/height from the dialog when in `px` mode, and just used the file's pixel width/height.

It's not obvious why a user would want to use that, but it ought to work.

Testing notes:
1. Load a file that has at least one `[Illustration]` markup
2. HTML-->Auto-Illus
3. Browse to find any jpeg file
4. Set the type to `px` and note the width & height
5. Change the width (height will automatically change to keep aspect ratio correct)
6. Convert the illo to HTML

In `master` it ignores the edited width/height in the dialog. 