### PR TITLE
Clear "busy" cursor when file error from ppcomp

### DIFF
--- a/src/guiguts/tools/ppcomp.py
+++ b/src/guiguts/tools/ppcomp.py
@@ -335,16 +335,26 @@ class PPcompChecker:
         PPcompChecker.files.append(PgdpFileText(empty_args))
         fname = preferences.get(PrefKey.PPCOMP_HTML_FILE)
         if not (fname and os.path.isfile(fname)):
+            Busy.unbusy()
+            logger.error(f"File {fname} does not exist")
             return
         try:
             PPcompChecker.files[0].load(fname)
         except (FileNotFoundError, SyntaxError) as exc:
+            Busy.unbusy()
             logger.error(exc)
             return
         fname = preferences.get(PrefKey.PPCOMP_TEXT_FILE)
         if not (fname and os.path.isfile(fname)):
+            Busy.unbusy()
+            logger.error(f"File {fname} does not exist")
             return
-        PPcompChecker.files[1].load(fname)
+        try:
+            PPcompChecker.files[1].load(fname)
+        except (FileNotFoundError, SyntaxError) as exc:
+            Busy.unbusy()
+            logger.error(exc)
+            return
         for f in PPcompChecker.files:
             f.cleanup()
             # perform common cleanup for both files


### PR DESCRIPTION
If file has been moved, or user manually types a filename incorrectly in the ppcomp dialog, it now displays an error and clears the busy cursor.

Fixes #1721