### PR TITLE
Minor ebm & ppcomp fixes

### DIFF
--- a/src/guiguts/html_tools.py
+++ b/src/guiguts/html_tools.py
@@ -1322,9 +1322,6 @@ class EbookmakerCheckerDialog(CheckerDialog):
 
         self.sort_frame.grid_forget()
 
-        self.update_count_label(False)
-        Busy.unbusy()
-
 
 class EbookmakerChecker:
     """Ebookmaker checker."""
@@ -1340,6 +1337,8 @@ class EbookmakerChecker:
             sort_key_alpha=ebookmaker_sort_key_type,
             show_suspects_only=True,
         )
+        self.dialog.update_count_label(False)
+        Busy.unbusy()
 
     def run(self) -> None:
         """Run ebookmaker"""
@@ -1471,6 +1470,8 @@ class EbookmakerCheckerAPI:
             sort_key_alpha=ebookmaker_sort_key_type,
             show_suspects_only=True,
         )
+        self.dialog.update_count_label(False)
+        Busy.unbusy()
 
     def run(self) -> None:
         """Run ebookmaker using API."""


### PR DESCRIPTION
1. Stop busy cursor being left on if ebm or ppcomp menu buttons are used when dialog is already visible
2. If one of the two ppcomp files is the currently loaded main file, and it has been modified, ask the user if they want to save before running ppcomp. If they cancel, do nothing. If they say "No", run ppcomp without saving. If they say "Yes", save then run ppcomp.

Fixes #1731 
Fixes #1732  