### PR TITLE
Ensure page label config dialog stays visible

### DIFF
--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -1532,7 +1532,7 @@ class AskStringDialog(tk.Toplevel):
         super().__init__(parent)
         self.withdraw()
         self.title(title)
-        self.transient(parent)
+        self.transient(parent)  # type: ignore[arg-type]
         self.resizable(False, False)
 
         self.result: Optional[str] = None


### PR DESCRIPTION
When choosing a page number, the AskString dialog caused the page label config dialog to go behind the root window (at least on Windows). Make it transient with respect to the parent dialog instead.

Fixes #1736

Testing notes: 
Setting page number from the page label config dialog should pop the "ask string" dialog, and when a number is entered, the label config dialog should still be in front of the root window. This may work already in `master` on some platforms - I have tested the fix works on Windows. Please check it hasn't broken behavior on macOS. Thanks