### PR TITLE
Improve Scanno regex & fix bug in S/R replacement

### DIFF
--- a/src/guiguts/data/scannos/regex.json
+++ b/src/guiguts/data/scannos/regex.json
@@ -86,13 +86,13 @@
 "hint": "Find a word containing at least 5 consonants in a row"
 },
 {
-"match": "(\\p{Letter}*\\.)(?=\"?\\n *\"?\\p{Lower}+)",
-"replacement": ",\\1",
+"match": "(\\p{Letter}*)\\.(?=\"?\\n *\"?(?![cfprx]/)\\p{Lower}+)",
+"replacement": "\\1,",
 "hint": "Find a period with the following line starting with a lower case character and change the period to a comma"
 },
 {
-"match": "(?<!\\.\\.)(\\p{Letter}*\\.)(?= \\p{IsLower}+)",
-"replacement": ",\\1",
+"match": "(?<!\\.\\.)(\\p{Letter}*)\\.(?= \\p{IsLower}+)",
+"replacement": "\\1,",
 "hint": "Find a period followed by a space and a lower-case letter and replace it with a comma"
 },
 {

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -1113,7 +1113,7 @@ def strip_outer_lookarounds(pattern: str) -> str:
                     end = find_matching_paren(pattern, i)
                     if end == len(pattern) - 1:
                         pattern = pattern[:i] + "$"
-                    break
+                        break
         else:
             pattern = re.sub(r"\(\?<?[=!][^()]*\)$", "$", pattern)
 


### PR DESCRIPTION
If regex had nested lookahead/lookbehind at the end of the string, the code failed to remove it properly, so the replacement didn't work.

Also, stealth scanno regexes 18 & 19 were wrong - they matched the correct string, but didn't fix them correctly.

And the original purpose of the work - regex 18 now doesn't match if the line below is actually lowercase markup for poetry, center, etc., e.g. `p/`