### PR TITLE
Don't split mid-word in ppcomp output

### DIFF
--- a/src/guiguts/tools/ppcomp.py
+++ b/src/guiguts/tools/ppcomp.py
@@ -761,6 +761,10 @@ def refine_punctuation_diffs(line: str) -> str:
         if not prefix and not suffix:
             return match.group(0)
 
+        # If split between two parts is mid-word, e.g. "C⦕opyright⦖⦓OPYRIGHT⦔", leave unchanged
+        if re.search(r"\p{Letter}$", a_mid) and re.search(r"^\p{Letter}", b_mid):
+            return match.group(0)
+
         parts = []
         # Prefix stays unmarked
         parts.append(prefix)


### PR DESCRIPTION
Testing notes:

One way to show the problem is when a word was in small caps, which were converted to ALLCAPS in the text file, e.g. in HTML "Copyright, 1930", and in text file "COPYRIGHT, 1930".
Output looked something like:
"C _OPYRIGHT_**opyright**, 1930" 
with italic in green and bold in purple.

This branch should give easier-to-read (but possibly more verbose) output something like:
"_COPYRIGHT_ **Copyright**, 1930" 

