### PR TITLE
Join footnote anchors more intelligently in HTML

### DIFF
--- a/src/guiguts/html_convert.py
+++ b/src/guiguts/html_convert.py
@@ -38,6 +38,7 @@ DEFAULT_HTML_DIR = importlib.resources.files(html)
 HTML_HEADER_NAME = "html_header.txt"
 PAGE_ID_PREFIX = "Page_"
 H1_SKIP_REGEX = r"(\[Illustr|/[*$fxcr]|[*$fxcr]/)"
+WORD_JOINER = "&#x2060;"
 
 inline_conversion_dict = {
     PrefKey.HTML_ITALIC_MARKUP: ("i", "italic"),
@@ -1473,8 +1474,15 @@ def html_convert_footnotes() -> None:
         id_markup = f'id="{an_id}" '
         while an_start := maintext().search(f"[{fn_label}]", an_search_start, fn_start):
             an_end = f"{an_start}+{len(fn_label) + 2}c"
-            maintext().insert(an_end, "</a>")
-            open_markup = f'&#x2060;<a {id_markup}href="#{fn_id}" class="fnanchor">'
+            open_markup = f'<a {id_markup}href="#{fn_id}" class="fnanchor">'
+            end_markup = "</a>"
+            check_text = maintext().get(f"{an_start}-1c", f"{an_end}+1c")
+            # Use Word Joiners to join to prev/next char if not space
+            if not check_text[0].isspace():
+                open_markup = f"{WORD_JOINER}{open_markup}"
+            if not check_text[-1].isspace():
+                end_markup = f"{end_markup}{WORD_JOINER}"
+            maintext().insert(an_end, end_markup)
             maintext().insert(an_start, open_markup)
             id_markup = ""
             an_search_start = maintext().index(f"{an_start}+{len(open_markup) + 4}c")


### PR DESCRIPTION
Use Word Joiner at start, end, both or neither, depending on whether there is non-space before/after anchor.

Fixes #1745

Test file with variety of footnote locations: [chap_footnotes5.txt](https://github.com/user-attachments/files/25665434/chap_footnotes5.txt)

1. Load file
2. Convert to HTML
3. Inspect positions of word joiner characters
