### PR TITLE
Avoid false positives in Unmatched Block Markup

### DIFF
--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -1002,7 +1002,7 @@ def unmatched_block_markup() -> None:
     unmatched_markup_check(
         UnmatchedBlockMarkupDialog,
         rerun_command=unmatched_block_markup,
-        match_reg=f"^(/{ALL_BLOCKS_REG}|{ALL_BLOCKS_REG}/)",
+        match_reg=f"^(/{ALL_BLOCKS_REG}|{ALL_BLOCKS_REG}/ *$)",
         match_pair_func=match_pair_block_markup,
         nest_reg="/#|#/",
         sort_key_alpha=sort_key_block_markup,


### PR DESCRIPTION
Fixes #1746

Now only recognizes closing markup such as `c/` if it doesn't have other text after it on the line.

Test file: [co.txt](https://github.com/user-attachments/files/25690869/co.txt)
- Reports 2 errors in `master`
- Reports 1 error with this commit
