### PR TITLE
Run Ebookmaker API command in thread

### DIFF
--- a/src/guiguts/html_tools.py
+++ b/src/guiguts/html_tools.py
@@ -1494,9 +1494,6 @@ class EbookmakerCheckerAPI:
         )
         self.dialog.display_entries(complete_msg=False)
 
-        # Optional: show busy state
-        # self.dialog.show_busy("Building via Ebookmaker…")
-
         thread = threading.Thread(target=self._run_worker, daemon=True)
         thread.start()
 
@@ -1511,11 +1508,13 @@ class EbookmakerCheckerAPI:
                 message: Initial part of message to user.
                 exc: Exception that was thrown, or a string describing the problem
             """
-            logger.error(
-                f"{message}\nConvert manually online at ebookmaker.pglaf.org\nError details:\n{exc}"
+            self._ui(
+                lambda: logger.error(
+                    f"{message}\nConvert manually online at ebookmaker.pglaf.org\nError details:\n{exc}"
+                )
             )
-            self.dialog.display_entries()
-            self.dialog.lift()
+            self._ui(self.dialog.display_entries)
+            self._ui(self.dialog.lift)
 
         timeout = 900
 


### PR DESCRIPTION
1. When user presses "Run Ebookmaker" button, send the files off to ebookmaker
2. Disable the button, and change its label to "Running..."
3. Display message in dialog to tell user what is happening
4. Pass control back to the user, who can make edits, run other tools, etc.
5. When Ebookmaker is finished and any files downloaded, display the ebookmaker log messages as usual in the dialog and bring it to the front of the screen.
6. Restore the "Run Ebookmaker" button.