### PR TITLE
Improve Ngrams from WF Hyphen

### DIFF
--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -860,22 +860,18 @@ class WordFrequencyDialog(ToplevelDialog):
         word = self.entries[entry_index].word.replace("-*", "-")
         content_list = [word]
 
-        # If in Hyphen display, add suspects to content
-        if preferences.get(PrefKey.WFDIALOG_DISPLAY_TYPE) == WFDisplayType.HYPHENS:
-            nohyp = re.sub("[-* ]+", "", word)
-            # If chosen word is a suspect, use the related words
-            if self.entries[entry_index].suspect:
-                for entry in self.entries:
-                    entry_word = entry.word.replace("-*", "-")
-                    if (
-                        entry_word not in content_list
-                        and re.sub("[- ]+", "", entry_word) == nohyp
-                    ):
-                        content_list.append(entry_word)
-            # Ensure non-hyphen version is added, even if not in text,
-            # e.g. just "flash-*light" found
-            if nohyp not in content_list:
-                content_list.append(nohyp)
+        nohyp = re.sub("[-* ]+", "", word)
+        for entry in self.entries:
+            entry_word = entry.word.replace("-*", "-")
+            if (
+                entry_word not in content_list
+                and re.sub("[- ]+", "", entry_word) == nohyp
+            ):
+                content_list.append(entry_word)
+        # Ensure non-hyphen version is added, even if not in text,
+        # e.g. just "flash-*light" found
+        if nohyp not in content_list:
+            content_list.append(nohyp)
         # Don't want asterisks passing to Ngram viewer
         content = ",".join(content_list).replace("-*", "-")
 


### PR DESCRIPTION
Include the clicked word, any other words that are "related", (i.e. that would be the same if you removed spaces and hyphens), and always include the no-hyphen version.

Fixes #1759


This test file may be helpful - I think it contains all the possible cases: [ngram.txt](https://github.com/user-attachments/files/25804404/ngram.txt)