### PR TITLE
Validate number of multirows

### DIFF
--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -412,6 +412,7 @@ class SearchDialog(ToplevelDialog):
             preferences.set(PrefKey.SEARCHDIALOG_MULTI_ROWS, 10)
         num_multi_rows = nrows if multi_flag else 1
         last_shown = 0
+        self.update()
         for w_list in (
             self.replace_box,
             self.replace_btn,


### PR DESCRIPTION
Allow numbers from 1 to 10, whether input via spinbox arrows, or by typing number in box.

Also bind "Return/Enter" key to number field, so if user has 3 rows, and wants 4, they can type "4" then Return/Enter.

Fixes #1763