### PR TITLE
Potential fix for save issue

### DIFF
--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -319,9 +319,14 @@ class File:
         Returns:
             Current filename or "" if save is cancelled
         """
+        # We want to call "busy", partly to ensure everything has finished running
+        # and dialogs have been updated. However, we don't want it to be busy if
+        # we are going to do a Save As, because control returns to the user.
+        Busy.busy()
         # If there's no filename, need to do Save As, but if called
         # via autosave, do nothing
         if not self.filename:
+            Busy.unbusy()
             return "" if autosave else self.save_as_file()
         # If we have a filename, then need to do appropriate backups
 
@@ -329,7 +334,6 @@ class File:
             """Get backup names for filename and bin file."""
             return f"{self.filename}{ext}", f"{bin_name(self.filename)}{ext}"
 
-        Busy.busy()
         binfile_name = bin_name(self.filename)
         try:
             if autosave:


### PR DESCRIPTION
Move call to `busy` to make it a little safer if PPer does something unusual, like quitting while a tool is running.

Testing notes:
1. Essentially ensure it is no worse than `master` - it may not be possible to reproduce the problem in either release, so behavior will probably be the same in both releases. There is nothing that should be noticeable under normal circumstances.
2. Test usual `Save As`, `Save`, `Quit` (when there are unsaved edits)
3. Also, try `Save` when there is no filename, i.e. it's a new creation but do `Save` instead of `Save As` - it should pop the `Save As` box (same as `master`
4. Run a tool that takes a while to complete, and try closing GG2 while the tool is running.
5. Save as 4, but try Cmd-S while tool is running, rather than closing GG2.
