### PR TITLE
Split at emdash in bookloupe, even with digits

### DIFF
--- a/src/guiguts/tools/bookloupe.py
+++ b/src/guiguts/tools/bookloupe.py
@@ -634,7 +634,8 @@ class BookloupeChecker:
         """
         # Consider hyphenated (or emdashed) words as two separate words
         # but exclude DP-style fractions, e.g. 1-3/4)
-        s_line = re.sub(r"(?<!\d)[-—](?!\d)", " ", line)
+        s_line = line.replace("—", " ")
+        s_line = re.sub(r"(?<!\d)-(?!\d)", " ", s_line)
         # Treat nbsp as space
         s_line = re.sub(r"\xa0", " ", s_line)
         # Split at spaces, ignoring leading/trailing non-word characters on words


### PR DESCRIPTION
Bookloupe report: `Digit in watch—1,505` was caused by an attempt to not split `2-3/4` that emdashes got caught in with.

Fixes #1776

Testing: Variations on linked issue's example: `my watch—1,505 miles out from Chicago, 6,322 feet elevation.`

Note it will (and should IMO) still report `my watch-1,505 miles out from Chicago, 6,322 feet elevation.` where the emdash is changed to a hyphen.