### PR TITLE
Make "Next para begins with quote" work for poetry

### DIFF
--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -2570,8 +2570,12 @@ class CurlyQuotesDialog(CheckerDialog):
             elif match_text == "":  # Blank line
                 # Expect dqtype == 0 unless next line starts with open double quote
                 # AND user has enabled that exception
+                next_line = (
+                    maintext().get(f"{linebeg} +1l", f"{linebeg} +1l lineend").lstrip()
+                )
+                next_line_ch = next_line[0] if next_line else ""
                 if dqtype == 1 and (
-                    maintext().get(f"{linebeg} +1l") != DQUOTES[0]
+                    next_line_ch != DQUOTES[0]
                     or not preferences.get(PrefKey.CURLY_DOUBLE_QUOTE_EXCEPTION)
                 ):
                     hilite_start = IndexRowCol(last_open_double_idx).col
@@ -2595,7 +2599,7 @@ class CurlyQuotesDialog(CheckerDialog):
                         )
                 dqtype = 0
                 # Expect sqtype == 0 unless next line starts with open single quote
-                if sqtype == 1 and maintext().get(f"{linebeg} +1l") != SQUOTES[0]:
+                if sqtype == 1 and next_line_ch != SQUOTES[0]:
                     hilite_start = IndexRowCol(last_open_single_idx).col
                     text_range = IndexRange(
                         last_open_single_idx,


### PR DESCRIPTION
In Curly Quote check, if the checkbox is enabled, it does not report that a paragraph has an unclosed quote if the next paragraph begins with a quote. This did not work when the next paragraph was indented, e.g. poetry.

Fixes #1774

Testing notes: 
1. Load [cq.txt](https://github.com/user-attachments/files/25973256/cq.txt)
2. Run Tools, Curly Quotes, Check
3. In `master` lines 7 & 27 are reported since it does not detect the quotes on the start of the next paragraph.
4. In this branch, they are not reported
