### PR TITLE
Remove "0 Entries" label from Good Words dialog

### DIFF
--- a/src/guiguts/content_providing.py
+++ b/src/guiguts/content_providing.py
@@ -1964,6 +1964,7 @@ def cp_list_good_words() -> None:
                 **kwargs,
             )
             self.rowcol_radio["text"] = "Order added"
+            self.count_label.grid_remove()
 
     checker_dialog = CPGoodWordsCheckerDialog.show_dialog(
         rerun_command=cp_list_good_words,


### PR DESCRIPTION
File->Content Providing->List Good Words in Project Dictionary showed the label "0 Entries" in the top left. This is shown in all checker dialogs and is the number of entries in the dialog that link to a place in the file, i.e. begin with line/column number, e.g. `27.4: ...`
Since there are none in this dialog, and it's too minor to warrant writing specific code to count and update it at the right time, just remove it, as suggested by @susanskinner

Fixes #1817