### PR TITLE
Add `Rewrap Selection Except Indented Text`

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -1211,7 +1211,7 @@ class Guiguts:
             "Word ~Distance Check", lambda: levenshtein_check(self.file.project_dict)
         )
         tools_menu.add_separator()
-        tools_menu.add_button("~Page Separator Fixup...", page_separator_fixup)
+        tools_menu.add_button("Pa~ge Separator Fixup...", page_separator_fixup)
         tools_menu.add_button("~Footnote Fixup...", footnote_check)
         fn_mask_menu = tools_menu.add_submenu("M~ask/Unmask Footnote Styles")
         fn_mask_menu.add_button(
@@ -1242,6 +1242,10 @@ class Guiguts:
         tools_menu.add_separator()
         tools_menu.add_button("~Rewrap All", self.file.rewrap_all)
         tools_menu.add_button("R~ewrap Selection", self.file.rewrap_selection)
+        tools_menu.add_button(
+            "Rewrap Selection Exce~pt Indented Text",
+            lambda: self.file.rewrap_selection(skip_indented=True),
+        )
         tools_menu.add_button(
             "Block Rewrap Selec~tion", lambda: self.file.rewrap_selection(bq_depth=1)
         )

--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -1007,12 +1007,13 @@ class File:
         with path.open("a", encoding="utf-8") as fp:
             fp.write(f"{word}\n")
 
-    def rewrap_selection(self, bq_depth: int = 0) -> None:
+    def rewrap_selection(self, bq_depth: int = 0, skip_indented: bool = False) -> None:
         """Wrap selected text.
 
         Args:
             section_range: Range of text to be wrapped.
             bq_depth: Starting blockquote depth (only 0 or 1 supported)
+            skip_indented: If True, skip paragraphs that begin with a space
         """
         ranges = maintext().selected_ranges()
         if not ranges:
@@ -1025,7 +1026,7 @@ class File:
             ranges[0].end.row += 1
         Busy.busy()
         maintext().undo_block_begin()
-        self.rewrap_section(ranges[0], bq_depth)
+        self.rewrap_section(ranges[0], bq_depth, skip_indented)
         Busy.unbusy()
 
     def rewrap_all(self) -> None:
@@ -1035,12 +1036,15 @@ class File:
         self.rewrap_section(IndexRange("1.0", maintext().index(tk.END)))
         Busy.unbusy()
 
-    def rewrap_section(self, section_range: IndexRange, bq_depth: int = 0) -> None:
+    def rewrap_section(
+        self, section_range: IndexRange, bq_depth: int = 0, skip_indented: bool = False
+    ) -> None:
         """Wrap a section of the text, preserving page mark locations.
 
         Args:
             section_range: Range of text to be wrapped.
             bq_depth: Starting blockquote depth (only 0 or 1 supported)
+            skip_indented: If True, skip paragraphs that begin with a space
         """
         maintext().selection_ranges_store_with_marks()
 
@@ -1053,7 +1057,10 @@ class File:
         maintext().strip_end_of_line_spaces()
         mark_list = self.pin_page_marks()
         maintext().rewrap_section(
-            section_range, lambda: self.unpin_page_marks(mark_list), bq_depth
+            section_range,
+            lambda: self.unpin_page_marks(mark_list),
+            bq_depth,
+            skip_indented,
         )
 
         # Dummy insert & delete, so that if user re-does the wrap, the insert

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -3298,6 +3298,7 @@ class MainText(tk.Text):
         section_range: IndexRange,
         tidy_function: Callable[[], None],
         bq_depth: int,
+        skip_indented: bool = False,
     ) -> None:
         """Wrap a section of the text.
 
@@ -3305,6 +3306,7 @@ class MainText(tk.Text):
             section_range: Range of text to be wrapped.
             tidy_function: Function to call to tidy up before returning.
             bq_depth: Block quote depth to start at - only 0 and 1 supported.
+            skip_indented: If True, skip paragraphs that begin with a space
         """
         default_left = preferences.get(PrefKey.WRAP_LEFT_MARGIN)
         default_right = preferences.get(PrefKey.WRAP_RIGHT_MARGIN)
@@ -3399,6 +3401,7 @@ class MainText(tk.Text):
                             paragraph,
                             block_params_list[bq_depth],
                             wrapper,
+                            skip_indented,
                         )
                         paragraph = ""
                     # Reposition line_start in case above wrapping changed line numbering
@@ -3495,6 +3498,7 @@ class MainText(tk.Text):
                             index_main,
                             index_right,
                             wrapper,
+                            skip_indented,
                         )
 
                 # End blocks should have been dealt with by the begin block code
@@ -3521,6 +3525,7 @@ class MainText(tk.Text):
                     paragraph,
                     block_params_list[bq_depth],
                     wrapper,
+                    skip_indented,
                 )
                 paragraph = ""
 
@@ -3553,6 +3558,7 @@ class MainText(tk.Text):
                 paragraph,
                 block_params_list[bq_depth],
                 wrapper,
+                skip_indented,
             )
         tidy_function()
 
@@ -3563,6 +3569,7 @@ class MainText(tk.Text):
         paragraph: str,
         wrap_params: WrapParams,
         wrapper: TextWrapper,
+        skip_indented: bool = False,
     ) -> None:
         """Wrap a complete paragraph and replace it in the text.
 
@@ -3572,8 +3579,11 @@ class MainText(tk.Text):
             paragraph: Text of the paragraph to be wrapped.
             wrap_params: Wrapping parameters.
             wrapper: TextWrapper object to perform the wrapping - re-used for efficiency.
+            skip_indented: If True, skip paragraphs that begin with a space
         """
 
+        if skip_indented and paragraph.startswith(" "):
+            return
         if paragraph.startswith("       *" * 5):
             return
         # Remove leading/trailing space
@@ -3632,6 +3642,7 @@ class MainText(tk.Text):
         main_margin: int,
         right_margin: int,
         wrapper: TextWrapper,
+        skip_indented: bool = False,
     ) -> None:
         """Wrap the index section between start_index and end_index.
 
@@ -3645,6 +3656,7 @@ class MainText(tk.Text):
             main_margin: Left margin for main index entries
             right_margin: Right margin to wrap between.
             wrapper: TextWrapper object to perform the wrapping - re-used for efficiency.
+            skip_indented: If True, skip paragraphs that begin with a space
         """
         # Mark end_index in case wrapping below changes line numbering
         self.set_mark_position(
@@ -3692,6 +3704,7 @@ class MainText(tk.Text):
                 line,
                 WrapParams(wrap_margin, main_margin + indent, right_margin),
                 wrapper,
+                skip_indented,
             )
             line_start = self.index(INDEX_NEXT_LINE_MARK)
 


### PR DESCRIPTION
Fixes #1825

Algorithm: if first letter of paragraph is a space character, don't rewrap that paragraph

Note that it is intended for use after main rewrapping, and after wrap markup has been removed, i.e. when a late edit is made and a section needs to be rewrapped again. It will preserve poetry, tables, etc., instead of blindly rewrapping them, as `master` does.