### PR TITLE
Fix WF word search failure with `'_`

### DIFF
--- a/src/guiguts/word_frequency.py
+++ b/src/guiguts/word_frequency.py
@@ -783,13 +783,13 @@ class WordFrequencyDialog(ToplevelDialog):
             # boundary is a word/space character
             emdash_bound = "—" if newline_word[0] == "—" else r"[^\w\s]"
             left_boundary = (
-                r"(?<!([^\W_]|\w[-'’]))"
+                r"(?<!([^\W_]|[\p{L}\p{N}][-'’]))"
                 if newline_word[0].isalnum()
                 else rf"(?<!{emdash_bound})"
             )
             emdash_bound = "—" if newline_word[-1] == "—" else r"[^\w\s]"
             right_boundary = (
-                r"(?!([^\W_]|[-'’]\w))"
+                r"(?!([^\W_]|[-'’][\p{L}\p{N}]))"
                 if newline_word[-1].isalnum()
                 else rf"(?!{emdash_bound})"
             )


### PR DESCRIPTION
When a trailing apostrophe is followed by an underscore, WF word search was not finding the word, because it is was attempting to avoid finding embedded apostrophes. For example, we don't want to find `don` in `don't`.

Avoiding treating underscore as a word character (which it is by default) fixes the situation.

Fixes #1828