### PR TITLE
Save project json when png dir is changed

### DIFF
--- a/src/guiguts/file.py
+++ b/src/guiguts/file.py
@@ -750,6 +750,7 @@ class File:
             mustexist=True,
             title=f"Select {folder_dir_str(True)} containing scans",
         )
+        self.save_bin(self.filename)
 
     def auto_image_check(self) -> None:
         """Function called repeatedly to check whether an image needs loading."""


### PR DESCRIPTION
When user changes png dir, the text/HTML file itself isn't changed, so doesn't need saving, but the project json file does. It seems harmless to do that.

Fixes #1832

To test, engineer a situation where it asks for the png dir, e.g. by moving the png dir after GG2 thinks it knows where it is, then turning on auto-image. Find the new location, then exit the program (or just reload the file). In `master` it won't remember the new location, but in this branch it should.