### PR TITLE
Avoid reporting `i.e.` and `e.g.` in new Scanno

### DIFF
--- a/src/guiguts/data/scannos/regex.json
+++ b/src/guiguts/data/scannos/regex.json
@@ -101,7 +101,7 @@
 "hint": "Find an exclamation/question mark followed by a space and a lower-case letter and change letter to upper-case"
 },
 {
-"match": "(\\p{IsLower})\\.(\\p{IsLower})",
+"match": "(?!(?<![\\p{Letter}\\p{Number}])(i\\.e\\.|e\\.g\\.))(\\p{IsLower})\\.(\\p{IsLower})",
 "replacement": "\\1 \\2",
 "hint": "Find an period between two lower-case letters and change it to a space"
 },


### PR DESCRIPTION
Scanno 21 in `regex.json` which detects `word.word` was reporting `i.e.` and `e.g.`

Fixes #1834

Test file: [period words.txt](https://github.com/user-attachments/files/27104848/period.words.txt)
