### PR TITLE
Catch exception when backing up GGprefs

### DIFF
--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -461,8 +461,10 @@ class Preferences:
         try:
             with open(self.prefsfile, "w", encoding="utf-8") as fp:
                 json.dump(self.dict, fp, indent=2, ensure_ascii=False)
-        except OSError:
-            logger.error(f"Unable to save preferences to {self.prefsfile}")
+        except (PermissionError, OSError) as exc:
+            logger.error(
+                f"Unable to save preferences to GGPrefs file. Details:\n{str(exc)}"
+            )
 
     def load(self, prefs_basefile: Optional[str]) -> None:
         """Load dictionary from JSON file, and use PrefKeys

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -442,6 +442,10 @@ class Preferences:
                     os.replace(day_backup, week_backup)
                 except FileNotFoundError:
                     pass  # Nothing we can do
+                except PermissionError as exc:
+                    logger.error(
+                        f"Unable to back up GGPrefs file. Details:\n{str(exc)}"
+                    )
 
         if is_older_than(day_backup, 86400):  # 1 day
             if os.path.exists(self.prefsfile):
@@ -449,6 +453,10 @@ class Preferences:
                     os.replace(self.prefsfile, day_backup)
                 except FileNotFoundError:
                     pass  # Nothing we can do
+                except PermissionError as exc:
+                    logger.error(
+                        f"Unable to back up GGPrefs day file. Details:\n{str(exc)}"
+                    )
 
         try:
             with open(self.prefsfile, "w", encoding="utf-8") as fp:


### PR DESCRIPTION
It didn't catch Permission Errors

Fixes #1838 

Testing notes:

> I've reproduced the exception by making the GGprefs day and week files readonly, and setting the date on the day file to more than a day old, then doing something like moving a dialog that would write to the prefs file, triggering an attempt to back it up to the day file.