### PR TITLE
Tidy all markup around page seps

### DIFF
--- a/src/guiguts/misc_tools.py
+++ b/src/guiguts/misc_tools.py
@@ -637,9 +637,11 @@ class PageSeparatorDialog(ToplevelDialog):
                 f"{ps_end} +4c",
             )
             # Remove blockquote or nowrap/poetry markup
-            if match := re.search(r"(\*|#|P|p)/$", markup_prev):
+            if match := re.search(
+                r"([*#$CFILPRX])/$", markup_prev, flags=re.IGNORECASE
+            ):
                 markup_type = re.escape(match[1])
-                if re.search(rf"^/{markup_type}", markup_next):
+                if re.search(rf"^/{markup_type}", markup_next, flags=re.IGNORECASE):
                     maintext().delete(
                         ps_end,
                         f"{ps_end} +1l",


### PR DESCRIPTION
It was only checking for `/*`, `/#`, `/p`.

Now checks for any of `*#$CFILPRX`.

Also, fixed potential bug where if the case was different, e.g. `X/` before page sep, but `/x` after, it wouldn't have tidied it.

Fixes #1840