### PR TITLE
Flag added `hr` elements as decorative

### DIFF
--- a/src/guiguts/html_convert.py
+++ b/src/guiguts/html_convert.py
@@ -409,7 +409,9 @@ def html_convert_body() -> None:
         """
         if maintext().get(f"{start_idx}-4l", start_idx) != "\n\n\n\n":
             return False
-        maintext().insert(f"{line_start}-3l", '<hr class="chap x-ebookmaker-drop">')
+        maintext().insert(
+            f"{line_start}-3l", '<hr class="chap x-ebookmaker-drop" aria-hidden="true">'
+        )
         maintext().insert(f"{line_start}-1l", '<div class="chapter">')
         return True
 
@@ -1543,7 +1545,7 @@ def html_add_chapter_divs() -> None:
         maintext().insert(h2_end, "\n</div>")
         maintext().insert(
             h2_start,
-            f'\n\n<hr class="chap x-ebookmaker-drop">\n<div class="chapter">\n{extra_nl}',
+            f'\n\n<hr class="chap x-ebookmaker-drop" aria-hidden="true">\n<div class="chapter">\n{extra_nl}',
         )
         h2_end = maintext().index(f"{h2_end}+5l")
 

--- a/tests/expected/htmlconvert1.txt
+++ b/tests/expected/htmlconvert1.txt
@@ -276,7 +276,7 @@ img.w100 {width: 100%;}
 </h1>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="NOTES_FROM_CALAIS_BASE">
     NOTES FROM CALAIS BASE
@@ -305,7 +305,7 @@ img.w100 {width: 100%;}
 </p>
 <p>——-File: 004.png————————————————————————————-</p>
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 
 <div class="chapter">
 <p>
@@ -318,7 +318,7 @@ img.w100 {width: 100%;}
 <p>——-File: 005.png————————————————————————————-</p>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="TRAINING_IN_FRANCE">
     TRAINING IN FRANCE
@@ -499,7 +499,7 @@ the troops <i>en route</i> for the Front.
 ——-File: 011.png————————————————————————————-</p>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="THE_CARE_OF_THE">
     THE CARE OF THE
@@ -722,7 +722,7 @@ hospital and another.
 ——-File: 019.png————————————————————————————-</p>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="THE_ARMYS_PETROL">
     THE ARMY'S PETROL
@@ -879,7 +879,7 @@ close of business by the officers on both sides.
 ——-File: 025.png————————————————————————————-</p>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="A_GIANT_COBBLERS_SHOP">
     A GIANT COBBLER'S SHOP
@@ -1097,7 +1097,7 @@ cobbler's shops the same methods prevail.
 ——-File: 033.png————————————————————————————-</p>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="TRAINING_IN_FRANCE_1">
     TRAINING IN FRANCE
@@ -1106,7 +1106,7 @@ cobbler's shops the same methods prevail.
 </div>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="TRAINING_IN_FRANCE_2">
     <i>TRAINING IN FRANCE</i>
@@ -1243,7 +1243,7 @@ DISEMBARKING</p>
 ——-File: 045.png————————————————————————————-</p>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="THE_CARE_OF_THE_WOUNDED">
     THE CARE OF THE WOUNDED
@@ -1252,7 +1252,7 @@ DISEMBARKING</p>
 </div>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="THE_CARE_OF_THE_WOUNDED_1">
     <i>THE CARE OF THE WOUNDED</i>
@@ -1422,7 +1422,7 @@ UNDER SEAT</p>
 ——-File: 059.png————————————————————————————-</p>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="THE_ARMYS_PETROL_SUPPLY">
     THE ARMY'S PETROL SUPPLY
@@ -1431,7 +1431,7 @@ UNDER SEAT</p>
 </div>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="THE_ARMYS_PETROL_SUPPLY_1">
     <i>THE ARMY'S PETROL SUPPLY</i>
@@ -1587,7 +1587,7 @@ DEPARTMENT</p>
 ——-File: 073.png————————————————————————————-</p>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="A_GIANT_COBBLERS_SHOP_1">
     A GIANT COBBLER'S SHOP
@@ -1596,7 +1596,7 @@ DEPARTMENT</p>
 </div>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="A_GIANT_COBBLERS_SHOP_2">
     <i>A GIANT COBBLER'S SHOP</i>

--- a/tests/expected/htmlconvert2.txt
+++ b/tests/expected/htmlconvert2.txt
@@ -279,7 +279,7 @@ CHERRY-BLOSSOMS
 </p>
 <p>]</p>
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 
 <div class="chapter">
 <p>
@@ -294,7 +294,7 @@ CHERRY-BLOSSOMS
 </p>
 </div>
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 
 <div class="chapter">
 <p>
@@ -307,7 +307,7 @@ CHERRY-BLOSSOMS
 <p>[Illustration: Clad in native costume]</p>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="Many_have_been_before_me_and_the_theme">
     Many have been before me, and the theme
@@ -326,7 +326,7 @@ CHERRY-BLOSSOMS
 </div>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="CONTENTS">
     CONTENTS.
@@ -374,7 +374,7 @@ CHERRY-BLOSSOMS
 <p>[Illustration]</p>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="FOREIGN_RESIDENTS">
     FOREIGN RESIDENTS.
@@ -1041,7 +1041,7 @@ of others.</p>
 <p>[Illustration]</p>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="SHOPPING">
     SHOPPING.
@@ -1651,7 +1651,7 @@ home.</p>
 <p>[Illustration]</p>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="OUR_DINNER_AT_KIOTO">
     OUR DINNER AT KIOTO.
@@ -2221,7 +2221,7 @@ lives.</p>
 <p>[Illustration]</p>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="MIYAKO_ODORI">
     MIYAKO ODORI.
@@ -2817,7 +2817,7 @@ to the street.</p>
 <p>[Illustration]</p>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="THE_RISE_AND_FALL_OF_THE">
     THE RISE AND FALL OF THE
@@ -3397,7 +3397,7 @@ to the teachings of their hearts.</p>
 <p>[Illustration]</p>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="A_GLIMPSE_OF_ROYALTY">
     A GLIMPSE OF ROYALTY.
@@ -4101,7 +4101,7 @@ grain.”</p>
 <p>[Illustration]</p>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="FIN_DE_SIECLE_JAPAN">
     FIN DE SIÈCLE JAPAN.
@@ -4734,7 +4734,7 @@ after a manner of his own.</p>
 <p>[Illustration]</p>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="CHO_AND_EBA">
     CHO AND EBA.
@@ -5374,7 +5374,7 @@ away.</p>
 <p>[Illustration: SAYONARA]</p>
 
 
-<hr class="chap x-ebookmaker-drop">
+<hr class="chap x-ebookmaker-drop" aria-hidden="true">
 <div class="chapter">
   <h2 class="nobreak" id="Transcribers_Notes">
     Transcriber’s Notes


### PR DESCRIPTION
For accessibility reasons, when an `hr` element is decorative, rather than a genuine thought break in the text, it should have an `aria-hidden="true"` attribute, so it is not announced by screen-readers, etc. Therefore add this attribute to the `hr` elements added at the end of every chapter during HTML generation.

Addresses part of #1824