### PR TITLE
Treat `&nbsp;` as space in PPhtml h1/title check

### DIFF
--- a/src/guiguts/tools/pphtml.py
+++ b/src/guiguts/tools/pphtml.py
@@ -736,6 +736,7 @@ class PPhtmlChecker:
 
         errors: list[tuple[str, Optional[IndexRange]]] = []
         title_str = re.sub(r"\s+", " ", title_str).strip()
+        h1_str = re.sub(r"&nbsp;", " ", h1_str)
         h1_str = re.sub(r"<br.*?>", " ", h1_str)
         h1_str = re.sub(r"<.*?>", "", h1_str)
         h1_str = re.sub(r"\s+", " ", h1_str).strip()


### PR DESCRIPTION
When `&nbsp;` is used in `h1` text, if should be treated as a space.

Testing: Change a space to `&nbsp;` in `h1` text in an HTML file where the `h1` and `<title>` text are identical, and note that `master` then considers the `h1` and `<title>` text to be different, whereas this branch does not.

Fixes #1851