### PR TITLE
Fix two-finger tap on macOS with Tk9

### DIFF
--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -1121,7 +1121,7 @@ def mouse_bind(
 ) -> None:
     """Bind mouse button callback to event on widget.
 
-    If binding is to mouse button 3, then if on a Mac bind
+    If binding is to mouse button 3, then if on a Mac also bind
     to mouse-2 and Control-mouse-1 instead
 
     Args:
@@ -1138,8 +1138,7 @@ def mouse_bind(
         widget.bind(button2, callback)
         control1 = f"<Control-{match[1]}1>"
         widget.bind(control1, callback)
-    else:
-        widget.bind(event, callback)
+    widget.bind(event, callback)
 
 
 def handle_mouse_wheel(widget: tk.Widget, event: tk.Event, vertical: bool) -> None:


### PR DESCRIPTION
With Tk9, 2-finger tap is generating mouse 3, whereas it
generated mouse 2 with Tk9. Bind both of these, so it
should work with either Tk version.

Testing of debug version:
In Tk9 environment, and Tk8 environment, do two-finger tap on main text window, then look at output in the terminal window. Compare with Ctrl-click.