### PR TITLE
Fix Jeebies bug when word after "he" starts with "he"

### DIFF
--- a/src/guiguts/tools/jeebies.py
+++ b/src/guiguts/tools/jeebies.py
@@ -491,11 +491,11 @@ class JeebiesChecker:
             hebe_form = paragraph_text[match_obj.start(0) : match_obj.end(0)]
             hebe_count = self.find_in_dictionary(hebe_form)
             # Avoid the "tribe be not" or "catastrophe he had" trap.
-            s_hebe = f" {hebe}"
+            s_hebe = f" {hebe} "
             hebe_start = match_obj.start(0) + hebe_form.index(s_hebe) + 1
             # Swap 'he' for 'be' (or vice versa) in 3-word form and lookup that.
             # Avoid the "tribe be not" or "catastrophe he had" trap.
-            s_behe = f" {behe}"
+            s_behe = f" {behe} "
             behe_form = re.sub(s_hebe, s_behe, hebe_form)
             behe_count = self.find_in_dictionary(behe_form)
 


### PR DESCRIPTION
Example is `will he here`. The code had a bug where it replaced all occurrences of space+`he` with space+`be` to determine if the `be` form is more common than the `he` form. However, for `will he here`, it results in `will be bere`, which doesn't occur in the he/be corpus. Hence Jeebies doesn't report `will he here`, because it's more common than `will be bere`. Once the bug is fixed, Jeebies does report it because `will he here` is less common than `will be here`.
Discovered by diligent WWer who doesn't use the GG2 version of Jeebies.

Test file: [jack_brag_vol2.txt](https://github.com/user-attachments/files/28069754/jack_brag_vol2.txt)
Line 3545 is the one that is not reported in `master`
