### PR TITLE
Add `<nav>` around autogen index

### DIFF
--- a/src/guiguts/html_convert.py
+++ b/src/guiguts/html_convert.py
@@ -695,8 +695,9 @@ def html_convert_body() -> None:
             maintext().replace(
                 line_start,
                 line_end,
-                '<ul class="index">',
+                '<nav>\n<ul class="index">',
             )
+            next_step += 1
             reset_ibs_dict()
             index_blank_lines = 2  # Force first entry to be start of section
             continue
@@ -707,8 +708,9 @@ def html_convert_body() -> None:
                 maintext().replace(
                     line_start,
                     line_end,
-                    "</ul>",
+                    "</ul>\n</nav>",
                 )
+                next_step += 1
                 continue
             if selection == "":
                 index_blank_lines += 1


### PR DESCRIPTION
`/i...i/` markup causes an index to created during HTML autogen. This commit adds `<nav>` around the index.

Fixes #1862