### PR TITLE
Make menu bar visible whatever dialog has focus

### DIFF
--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -74,6 +74,10 @@ class ToplevelDialog(tk.Toplevel):
 
         self.base_title = title
         self.resizable(resize_x, resize_y)
+        # Under Tk9, root menus need explicitly assigning to Toplevel dialogs
+        # Only needed on Macs, since menus are not contained within the main window
+        if is_mac():
+            self["menu"] = root()["menu"]
 
         if not is_x11():
             # Bind right-click context menu for pin/unpin anywhere in the dialog


### PR DESCRIPTION
Tk9 on Macs only displays the root menu bar when the root window has focus, not if a dialog has focus.
Assign the root menu bar to all dialogs.

Testing: Check if it breaks Tk8 version on Macs. If it does, we'll need `if is_mac() and is_tk9()` but I'd rather avoid explicit Tk9 testing where possible.