### PR TITLE
Add location history menu to Back/Forward buttons

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -1797,8 +1797,12 @@ class Guiguts:
         self.mainwindow.toolbar_button_virtual_event("paste", "<<Paste>>")
         self.mainwindow.toolbar_button_command("search", show_search_dialog)
         self.mainwindow.toolbar_button_command("back", lambda: maintext().go_back())
+        self.mainwindow.toolbar_button_right_menu("back", maintext().populate_back_menu)
         self.mainwindow.toolbar_button_command(
             "forward", lambda: maintext().go_forward()
+        )
+        self.mainwindow.toolbar_button_right_menu(
+            "forward", maintext().populate_forward_menu
         )
         self.mainwindow.toolbar_button_command("help", ToplevelDialog.show_manual_page)
 

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -655,6 +655,16 @@ class LocationHistory:
         if cur_mark_idx := self._get_current_mark_index():
             maintext().set_insert_index(IndexRowCol(cur_mark_idx), store_location=False)
 
+    def goto_history_index(self, idx: int) -> None:
+        """Got to history location with given index."""
+        self.history_index = idx
+
+        if cur_mark_idx := self._get_current_mark_index():
+            maintext().set_insert_index(
+                IndexRowCol(cur_mark_idx),
+                store_location=False,
+            )
+
     def current_mark(self) -> str:
         """Get current location mark."""
         try:
@@ -1781,6 +1791,44 @@ class MainText(tk.Text):
         """Go back to previous history location."""
         self.clear_selection()
         self.focus_widget().location_history.back()
+
+    def populate_back_menu(self, menu: tk.Menu) -> None:
+        """Populate back history location menu."""
+        wgt = self.focus_widget()
+        menu.add_command(label="Back location history")
+        menu.add_separator()
+        start = max(0, wgt.location_history.history_index - 10)
+        for idx in range(wgt.location_history.history_index - 1, start - 1, -1):
+            self._populate_menu(menu, idx)
+
+    def populate_forward_menu(self, menu: tk.Menu) -> None:
+        """Populate forward history location menu."""
+        wgt = self.focus_widget()
+        menu.add_command(label="Forward location history")
+        menu.add_separator()
+        end = min(
+            len(wgt.location_history.history_marks),
+            self.location_history.history_index + 11,
+        )
+        for idx in range(wgt.location_history.history_index + 1, end):
+            self._populate_menu(menu, idx)
+
+    def _populate_menu(self, menu: tk.Menu, idx: int) -> None:
+        """Populate entry in history location menu."""
+        wgt = self.focus_widget()
+        mark = wgt.location_history.history_marks[idx]
+        mark_rowcol = maintext().rowcol(mark)
+        line, col = mark_rowcol.row, mark_rowcol.col
+
+        text = wgt.get(f"{line}.0", f"{line}.end")
+        if not text:
+            text = "⏎"
+        label = f"{line}.{col}:  {text[:50]}"
+
+        menu.add_command(
+            label=label,
+            command=lambda i=idx: wgt.location_history.goto_history_index(i),  # type: ignore[misc]
+        )
 
     def go_forward(self) -> None:
         """Go forward to next history location."""

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -1694,6 +1694,19 @@ class MainWindow:
         """Set command to be executed by toolbar button."""
         self.tool_btns[name].config(command=command)
 
+    def toolbar_button_right_menu(
+        self, name: str, menu_builder: Callable[[tk.Menu], None]
+    ) -> None:
+        """Set command to be executed by right-click on toolbar button."""
+
+        def event_handler(event: tk.Event) -> None:
+            """Handle right-click event"""
+            menu = tk.Menu(self.tool_btns[name], tearoff=False)
+            menu_builder(menu)
+            menu.tk_popup(event.x_root, event.y_root)
+
+        mouse_bind(self.tool_btns[name], "3", event_handler)
+
     def toolbar_button_virtual_event(self, name: str, event: str) -> None:
         """Set virtual event to be executed by toolbar button."""
         self.toolbar_button_command(


### PR DESCRIPTION
Right-clicking on the Back/Forward buttons in the toolbar will pop a context menu listing the last (up to) 10 stored location history points. So, you can jump straight to one of them, instead of repeatedly clicking Back/Forward.