### PR TITLE
Improve resize of Treeview in page labels dialog

### DIFF
--- a/src/guiguts/page_details.py
+++ b/src/guiguts/page_details.py
@@ -145,7 +145,7 @@ class PageDetailsDialog(OkApplyCancelDialog):
                 f"#{col + 1}",
                 minwidth=10,
                 width=widths[col],
-                stretch=False,
+                stretch=True,
                 anchor=tk.CENTER,
             )
             self.list.heading(f"#{col + 1}", text=column)

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -764,6 +764,17 @@ class TreeviewList(ttk.Treeview):
             bordercolor=[("focus", bg_color)],
             relief=[("focus", "solid")],
         )
+        # Ensure rowheight is sufficient for font size
+        fnt = get_global_font()
+        rowheight = fnt.metrics("linespace") + 4
+        themed_style().configure(
+            "Custom.Treeview",
+            rowheight=rowheight,
+        )
+        themed_style().configure(
+            "Custom.Treeview.Heading",
+            rowheight=rowheight,
+        )
 
         super().__init__(parent, style="Custom.Treeview", **kwargs)
         self.bind("<Home>", lambda _e: self.select_and_focus_by_index(0))


### PR DESCRIPTION
1. If user grows dialog horizontally, stretch the columns (change to page labels only - different dialogs have different width resize behavior)
2. Set the row height based on the font size (affects all Treeviews: HTML internal links; Compose Help dialog; Command Palette; Unicode Search dialog results)