### PR TITLE
Cope with lowercase `[a]` multiple FN anchors

### DIFF
--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -507,7 +507,7 @@ class FootnoteChecker:
         # Check for anchors that are not paired
         anchor_matches = maintext().find_all(
             maintext().start_to_end(),
-            r"(?<!(/[#$*FfIiLlPpXxCcRr]|\\))\[([\d]+|[IiVvXxLlCc]+\.?|[A-Z])]",
+            r"(?<!(/[#$*FfIiLlPpXxCcRr]|\\))\[([\d]+|[IiVvXxLlCc]+\.?|[A-Za-z])]",
             regexp=True,
             wholeword=False,
             nocase=False,


### PR DESCRIPTION
Although a single lowercase anchor was detected, additional anchors were not.

Test file [supplied by Rick](https://www.pgdp.net/phpBB3/viewtopic.php?p=1398170#p1398170): [root.txt](https://github.com/user-attachments/files/28650532/root.txt)

See link for description of reported problem.