### PR TITLE
Restore focus to text after status/toolbar use

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -1685,7 +1685,10 @@ class Guiguts:
         )
         the_statusbar.add_binding("page label", StatusBar.BTN_1, self.file.goto_page)
         the_statusbar.add_binding(
-            "page label", StatusBar.SHIFT_BTN_1, self.show_page_details_dialog
+            "page label",
+            StatusBar.SHIFT_BTN_1,
+            self.show_page_details_dialog,
+            refocus=False,
         )
 
         the_statusbar.add(
@@ -1780,10 +1783,16 @@ class Guiguts:
         )
         the_statusbar.add_binding("ordinal", StatusBar.BTN_1, ordinal_name_display)
         the_statusbar.add_binding(
-            "ordinal", StatusBar.SHIFT_BTN_1, UnicodeBlockDialog.show_common_dialog
+            "ordinal",
+            StatusBar.SHIFT_BTN_1,
+            UnicodeBlockDialog.show_common_dialog,
+            refocus=False,
         )
         the_statusbar.add_binding(
-            "ordinal", StatusBar.SHIFT_BTN_3, UnicodeBlockDialog.show_unicode_dialog
+            "ordinal",
+            StatusBar.SHIFT_BTN_3,
+            UnicodeBlockDialog.show_unicode_dialog,
+            refocus=False,
         )
 
     def init_toolbar(self) -> None:
@@ -1795,7 +1804,9 @@ class Guiguts:
         self.mainwindow.toolbar_button_virtual_event("cut", "<<Cut>>")
         self.mainwindow.toolbar_button_virtual_event("copy", "<<Copy>>")
         self.mainwindow.toolbar_button_virtual_event("paste", "<<Paste>>")
-        self.mainwindow.toolbar_button_command("search", show_search_dialog)
+        self.mainwindow.toolbar_button_command(
+            "search", show_search_dialog, refocus=False
+        )
         self.mainwindow.toolbar_button_command("back", lambda: maintext().go_back())
         self.mainwindow.toolbar_button_right_menu("back", maintext().populate_back_menu)
         self.mainwindow.toolbar_button_command(
@@ -1804,7 +1815,9 @@ class Guiguts:
         self.mainwindow.toolbar_button_right_menu(
             "forward", maintext().populate_forward_menu
         )
-        self.mainwindow.toolbar_button_command("help", ToplevelDialog.show_manual_page)
+        self.mainwindow.toolbar_button_command(
+            "help", ToplevelDialog.show_manual_page, refocus=False
+        )
 
     def logging_init(self) -> None:
         """Set up basic logger until GUI is ready."""

--- a/src/guiguts/mainwindow.py
+++ b/src/guiguts/mainwindow.py
@@ -1286,31 +1286,41 @@ class StatusBar(ttk.Frame):
                 self.set(key, func())
         self.after(200, self._update)
 
-    def add_binding(self, key: str, event: str, callback: Callable[[], Any]) -> None:
+    def add_binding(
+        self, key: str, event: str, callback: Callable[[], Any], refocus: bool = True
+    ) -> None:
         """Add an action to be executed when the given event occurs
 
         Args:
             key: Key to refer to field.
-            callback: Function to be called when event occurs.
             event: Event to trigger action. Use button release to avoid
               clash with button activate appearance behavior.
               Also bind Space to do same as button 1;
               Cmd/Ctrl+button 1 and Cmd/Ctrl+space as button 3,
               all with optional Shift key modifier
+            callback: Function to be called when event occurs.
+            refocus: Set False if it should not refocus on main text after: defaults to True.
         """
-        mouse_bind(self.fields[key], event, lambda _: callback())
+
+        def callback_and_focus(_: tk.Event) -> Any:
+            result = callback()
+            if refocus:
+                maintext().focus_widget().focus_set()
+            return result
+
+        mouse_bind(self.fields[key], event, callback_and_focus)
         if event == StatusBar.BTN_1:
-            mouse_bind(self.fields[key], "space", lambda _: callback())
+            mouse_bind(self.fields[key], "space", callback_and_focus)
         elif event == StatusBar.SHIFT_BTN_1:
-            mouse_bind(self.fields[key], "Shift+space", lambda _: callback())
+            mouse_bind(self.fields[key], "Shift+space", callback_and_focus)
         if event == StatusBar.BTN_3:
-            mouse_bind(self.fields[key], "Ctrl+ButtonRelease-1", lambda _: callback())
-            mouse_bind(self.fields[key], "Ctrl+space", lambda _: callback())
+            mouse_bind(self.fields[key], "Ctrl+ButtonRelease-1", callback_and_focus)
+            mouse_bind(self.fields[key], "Ctrl+space", callback_and_focus)
         elif event == StatusBar.SHIFT_BTN_3:
             mouse_bind(
-                self.fields[key], "Shift+Ctrl+ButtonRelease-1", lambda _: callback()
+                self.fields[key], "Shift+Ctrl+ButtonRelease-1", callback_and_focus
             )
-            mouse_bind(self.fields[key], "Shift+Ctrl+space", lambda _: callback())
+            mouse_bind(self.fields[key], "Shift+Ctrl+space", callback_and_focus)
 
     def set_first_tab_behavior(self, key: str) -> None:
         """Set up tab bindings for first status bar button.
@@ -1690,9 +1700,23 @@ class MainWindow:
 
         bind_shift_tab(self.mainimage.prev_img_button, prev_img_focus_prev)
 
-    def toolbar_button_command(self, name: str, command: Callable) -> None:
-        """Set command to be executed by toolbar button."""
-        self.tool_btns[name].config(command=command)
+    def toolbar_button_command(
+        self, name: str, command: Callable, refocus: bool = True
+    ) -> None:
+        """Set command to be executed by toolbar button.
+
+        Args:
+            name: Name of button to set command for.
+            command: Function to be executed.
+            refocus: Set False if it should not refocus on main text after: defaults to True.
+        """
+
+        def callback_and_focus() -> None:
+            command()
+            if refocus:
+                maintext().focus_widget().focus_set()
+
+        self.tool_btns[name].config(command=callback_and_focus)
 
     def toolbar_button_right_menu(
         self, name: str, menu_builder: Callable[[tk.Menu], None]
@@ -1704,6 +1728,7 @@ class MainWindow:
             menu = tk.Menu(self.tool_btns[name], tearoff=False)
             menu_builder(menu)
             menu.tk_popup(event.x_root, event.y_root)
+            maintext().focus_widget().focus_set()
 
         mouse_bind(self.tool_btns[name], "3", event_handler)
 

--- a/src/guiguts/misc_dialogs.py
+++ b/src/guiguts/misc_dialogs.py
@@ -42,6 +42,7 @@ from guiguts.widgets import (
     ToplevelDialog,
     ToolTip,
     insert_in_focus_widget,
+    focus_in_focus_widget,
     OkApplyCancelDialog,
     OkCancelDialog,
     mouse_bind,
@@ -2537,6 +2538,14 @@ class UnicodeBlockDialog(ToplevelDialog):
         dlg = UnicodeBlockDialog.show_dialog()
         dlg.combobox.set(UnicodeBlockDialog.commonly_used_characters_name)
         dlg.block_selected(update_pref=False)
+
+    def on_destroy(self) -> None:
+        """Tidy up when the dialog is destroyed.
+
+        Override to return focus into the focus widget.
+        """
+        super().on_destroy()
+        focus_in_focus_widget()
 
     def combo_key(self, event: tk.Event) -> str:
         """Handle key press in combo box."""

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -1325,7 +1325,7 @@ def register_focus_widget(widget: ttk.Entry | tk.Text) -> None:
 
 def focus_in_focus_widget() -> None:
     """Return focus to the text/entry widget of interest where characters get inserted
-    by `insert_in_focus_widget.
+    by `insert_in_focus_widget`.
 
     This is useful if a dialog was popped from the status/tool bar, rather than leaving
     focus there.

--- a/src/guiguts/widgets.py
+++ b/src/guiguts/widgets.py
@@ -1323,6 +1323,18 @@ def register_focus_widget(widget: ttk.Entry | tk.Text) -> None:
         _text_focus_widget = widget
 
 
+def focus_in_focus_widget() -> None:
+    """Return focus to the text/entry widget of interest where characters get inserted
+    by `insert_in_focus_widget.
+
+    This is useful if a dialog was popped from the status/tool bar, rather than leaving
+    focus there.
+    """
+    if _text_focus_widget is None or not _text_focus_widget.winfo_exists():
+        return
+    _text_focus_widget.focus_set()
+
+
 def insert_in_focus_widget(string: str) -> None:
     """Insert given string in the text/entry widget of interest that most recently had focus.
 


### PR DESCRIPTION
Most buttons in the status/toolbar don't want focus to remain in the status/toolbar. After they have executed their action, restore focus to the main text.

Buttons that pop a dialog should not force focus back to text window, since the dialog needs to have focus.

Complication with a dialog like Commonly Used Chars (Shift-click char name button in status bar) is that you do want focus to return to the text after using it, but only once the dialog is closed. So, the "close" is overridden to do that.

Testing: All options in status and tool bar (including with Shift, etc, as described in the tooltips). Open/Save dialogs should include both loading/saving, and also cancelling the operation. The Unicode dialogs should also be tested.