### PR TITLE
Small PPhtml improvements

### DIFF
--- a/src/guiguts/tools/pphtml.py
+++ b/src/guiguts/tools/pphtml.py
@@ -751,6 +751,15 @@ class PPhtmlChecker:
                     None,
                 )
             )
+        elif re.search(r"<[A-Za-z][^>]*>", title_str):
+            test_passed = False
+            fail_string = PPhtmlChecker.fail_flag
+            errors.append(
+                (
+                    "    Title must not contain HTML tags",
+                    None,
+                )
+            )
         elif (
             h1_str.rstrip(".,;:").lower()
             != title_str.removesuffix(" | Project Gutenberg").rstrip(".,;:").lower()
@@ -1231,6 +1240,7 @@ class PPhtmlChecker:
             count > 0,
             f"Number of h2 tags (usually chapters; should be > 0): {count}",
             [],
+            fail_string=PPhtmlChecker.warn_flag,
         )
         # h3 headings
         count = self.file_text.count("<h3")

--- a/tests/expected/pphtml1.txt
+++ b/tests/expected/pphtml1.txt
@@ -36,7 +36,7 @@
 
 ===== Miscellaneous checks =====
 --- [pass] Lines with "--" instead of "—" (should be 0): 0 ---
---- *FAIL* Number of h2 tags (usually chapters; should be > 0): 0 ---
+--- *WARN* Number of h2 tags (usually chapters; should be > 0): 0 ---
 --- [info] Number of h3 tags (usually sections): 0 ---
 --- [info] Number of tables: 0 ---
 --- *FAIL* Special checks ---


### PR DESCRIPTION
1. Trap use of HTML tags in `<title>` text
2. Change "Number of h2 tags" FAIL to WARN

Fixes #1883
Fixes #1884