### PR TITLE
Cope with `[][]` regex better

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -3205,16 +3205,18 @@ class MainText(tk.Text):
             logger.error(
                 "Regex timed out. Try changing the regex or flags;\n"
                 "or increase the timeout in the Preferences dialog, Advanced tab.\n\n"
-                "Search highlighting turned off temporarily."
+                "Search & regex highlighting turned off temporarily."
             )
             self.highlight_search_deactivate()
+            self.highlight_regex_deactivate()
             return None, 0
         except re.error as e:
             logger.error(
                 f"Regex error: {str(e)}\n\n"
-                "Search highlighting turned off temporarily."
+                "Search & regex highlighting turned off temporarily."
             )
             self.highlight_search_deactivate()
+            self.highlight_regex_deactivate()
             return None, 0
         if match is None:
             return None, 0

--- a/src/guiguts/search.py
+++ b/src/guiguts/search.py
@@ -462,7 +462,7 @@ class SearchDialog(ToplevelDialog):
             new_value = self.search_box.get()
         if preferences.get(PrefKey.SEARCHDIALOG_REGEX):
             try:
-                re.compile(new_value)
+                re.compile(new_value, flags=re.V1)
                 self.search_box["style"] = ""
             except re.error:
                 self.search_box["style"] = "BadRegex.TCombobox"


### PR DESCRIPTION
1. Report is by changing the regex to red in the SR dialog - the validation routine wasn't using V1 regex rules
2. Turn off regex highlighting if the regex fails

Fixes #1890 

Testing notes:
1. Make sure your file has some square brackets in it
2. Enter `[][]` in the S/R search field, check "regex" - note that in `master`, it does not get displayed in red text as a warning that it's not legal.
3. Press Highlight All - note that in `master` you get an infinite loop of error dialog.