### PR TITLE
Use `<aside>` for footnotes instead of `<div>`

### DIFF
--- a/src/guiguts/html_convert.py
+++ b/src/guiguts/html_convert.py
@@ -1458,11 +1458,11 @@ def html_convert_footnotes() -> None:
         else:
             fn_cutoff = fn_end
         # Add markup for footnote
-        maintext().replace(fn_cutoff, f"{fn_end} lineend", "</p></div>")
+        maintext().replace(fn_cutoff, f"{fn_end} lineend", "</p></aside>")
         maintext().replace(
             fn_start,
             f"{fn_label_end}+1c",
-            f'<div class="footnote"><p><a id="{fn_id}" href="#{an_id}" class="label">[{fn_label}]</a>',
+            f'<aside class="footnote" role="doc-footnote" data-epub-type="footnote"><p><a id="{fn_id}" href="#{an_id}" class="label" role="doc-backlink">[{fn_label}]</a>',
         )
 
         # Search backwards for another footnote with the same label (or start of file)
@@ -1479,7 +1479,7 @@ def html_convert_footnotes() -> None:
         id_markup = f'id="{an_id}" '
         while an_start := maintext().search(f"[{fn_label}]", an_search_start, fn_start):
             an_end = f"{an_start}+{len(fn_label) + 2}c"
-            open_markup = f'<a {id_markup}href="#{fn_id}" class="fnanchor">'
+            open_markup = f'<a {id_markup}href="#{fn_id}" class="fnanchor" role="doc-noteref" data-epub-type="noteref">'
             end_markup = "</a>"
             check_text = maintext().get(f"{an_start}-1c", f"{an_end}+1c")
             # Use Word Joiners to join to prev/next char if not space
@@ -1506,23 +1506,23 @@ def html_convert_footnote_landing_zones() -> None:
             lz_next = tk.END
         # Find last footnote in this LZ by searching backwards from next LZ
         lz_end = maintext().search(
-            '<div class="footnote">', lz_next, lz_start, backwards=True
+            '<aside class="footnote">', lz_next, lz_start, backwards=True
         )
         if lz_end:
             lz_end = maintext().search(
-                "</div>", lz_end, lz_next
+                "</aside>", lz_end, lz_next
             )  # End of last footnote
         else:
             # No FN in LZ
             lz_end = f"{lz_start}"
         lz_end += " lineend"
-        maintext().insert(lz_end, "\n</div>")
+        maintext().insert(lz_end, "\n</section>")
         # FOOTNOTES heading may be marked with p or h3 markup
-        # <p>FOOTNOTES:</p> ==> <div class="footnotes"><h3>FOOTNOTES:</h3>
+        # <p>FOOTNOTES:</p> ==> <section class="footnotes"><h3>FOOTNOTES:</h3>
         if maintext().get(lz_start, f"{lz_start}+2c") == "<p":
             maintext().replace(f"{lz_start}+15c", f"{lz_start}+16c", "h3")
             maintext().replace(f"{lz_start}+1c", f"{lz_start}+2c", "h3")
-        maintext().insert(lz_start, '<div class="footnotes">\n')
+        maintext().insert(lz_start, '<section class="footnotes" role="doc-endnotes">\n')
 
 
 def html_add_chapter_divs() -> None:

--- a/src/guiguts/html_convert.py
+++ b/src/guiguts/html_convert.py
@@ -1462,7 +1462,7 @@ def html_convert_footnotes() -> None:
         maintext().replace(
             fn_start,
             f"{fn_label_end}+1c",
-            f'<aside class="footnote" role="doc-footnote" data-epub-type="footnote"><p><a id="{fn_id}" href="#{an_id}" class="label" role="doc-backlink">[{fn_label}]</a>',
+            f'<aside class="footnote" id="{fn_id}" role="doc-footnote" data-epub-type="footnote"><p><a href="#{an_id}" class="label" role="doc-backlink">[{fn_label}]</a>',
         )
 
         # Search backwards for another footnote with the same label (or start of file)

--- a/src/guiguts/html_convert.py
+++ b/src/guiguts/html_convert.py
@@ -1494,7 +1494,11 @@ def html_convert_footnotes() -> None:
 
 
 def html_convert_footnote_landing_zones() -> None:
-    """Add HTML markup around Landing Zones beginning with "FOOTNOTES"."""
+    """Add HTML markup around Landing Zones beginning with "FOOTNOTES".
+
+    Also adjust footnote markup for footnotes within landing zones.
+    Apple Books, for example, removes footnote text from file under some circumstances.
+    """
     lz_end = "1.0"
     fnhead_regex = "(<p>|<h3.*>\n  )FOOTNOTES:(</p>|\n</h3)"
     while lz_start := maintext().search(fnhead_regex, lz_end, tk.END, regexp=True):
@@ -1515,14 +1519,28 @@ def html_convert_footnote_landing_zones() -> None:
         else:
             # No FN in LZ
             lz_end = f"{lz_start}"
-        lz_end += " lineend"
+        lz_end += "+1l lineend"  # Allow for lines added below
         maintext().insert(lz_end, "\n</section>")
         # FOOTNOTES heading may be marked with p or h3 markup
         # <p>FOOTNOTES:</p> ==> <section class="footnotes"><h3>FOOTNOTES:</h3>
         if maintext().get(lz_start, f"{lz_start}+2c") == "<p":
             maintext().replace(f"{lz_start}+15c", f"{lz_start}+16c", "h3")
             maintext().replace(f"{lz_start}+1c", f"{lz_start}+2c", "h3")
+
         maintext().insert(lz_start, '<section class="footnotes" role="doc-endnotes">\n')
+        # Footnotes within landing zone - use `<div>` element instead of `<aside>`
+        # Also don't want doc-footnote or epub:type="footnote"
+        fn_start = lz_start
+        while fn_start := maintext().search(
+            '<aside class="footnote', f"{fn_start}+1l", lz_end, regexp=True
+        ):
+            line = maintext().get(fn_start, f"{fn_start} lineend")
+            line = (
+                line.replace("<aside", "<div")
+                .replace("</aside", "</div")
+                .replace(' role="doc-footnote" data-epub-type="footnote"', "")
+            )
+            maintext().replace(fn_start, f"{fn_start} lineend", line)
 
 
 def html_add_chapter_divs() -> None:

--- a/src/guiguts/html_convert.py
+++ b/src/guiguts/html_convert.py
@@ -1506,7 +1506,7 @@ def html_convert_footnote_landing_zones() -> None:
             lz_next = tk.END
         # Find last footnote in this LZ by searching backwards from next LZ
         lz_end = maintext().search(
-            '<aside class="footnote">', lz_next, lz_start, backwards=True
+            '<aside class="footnote', lz_next, lz_start, backwards=True
         )
         if lz_end:
             lz_end = maintext().search(


### PR DESCRIPTION
Makes it clear that it's supplementary to the main text.

Also wrap grouped chapter/endnotes in `section` with a suitable role, rather than `div`.

Add `role` to footnote markup, to enable epub readers to handle footnotes with popups, etc.

Fixes #1881

Testing notes:

1. Sample text file: [chap_footnotes6.txt](https://github.com/user-attachments/files/29439557/chap_footnotes6.txt)
2. Expected HTML file after autogen: [chap_footnotes6new.html](https://github.com/user-attachments/files/29439571/chap_footnotes6new.html)
3. Since ebookmaker can't cope with `<aside>`, here's a version of the HTML with `aside` changed to `div`: [chap_footnotes6newdiv.html](https://github.com/user-attachments/files/29439582/chap_footnotes6newdiv.html)
4. Here's a zip of the epub3 file ebookmaker creates, demonstrating pop-up footnotes when viewed in Calibre: [99999-images-epub3.zip](https://github.com/user-attachments/files/29439590/99999-images-epub3.zip)
5. Screenshot below is what is shown when clicking on `[2]` anchor, ringed in red - the popup window appears containing the footnote text. Arrow ringed in yellow navigates from the popup to the actual footnote in the text. Clicking the green-ringed footnote number, in the popup or in the text, returns to the anchor location.
 
<img width="868" height="894" alt="image" src="https://github.com/user-attachments/assets/b93c1853-b796-4db3-8071-203a93cea5d3" />


