### PR TITLE
Catch "computer offline" exceptions

### DIFF
--- a/src/guiguts/html_tools.py
+++ b/src/guiguts/html_tools.py
@@ -1022,8 +1022,11 @@ class HTMLValidator:
         except (requests.exceptions.Timeout, TimeoutError) as exc:
             report_exception(f"Request to {validator_url} timed out.", exc)
             return
-        except ConnectionError as exc:
+        except (requests.exceptions.ConnectionError, ConnectionError) as exc:
             report_exception(f"Connection error to {validator_url}.", exc)
+            return
+        except requests.exceptions.RequestException as exc:
+            report_exception("Validator request failed.", exc)
             return
         # Check if HTTP request was unsuccessful
         try:
@@ -1167,8 +1170,11 @@ class CSSValidator:
         except (requests.exceptions.Timeout, TimeoutError) as exc:
             report_exception(f"Request to {validator_url} timed out.", exc)
             return
-        except ConnectionError as exc:
+        except (requests.exceptions.ConnectionError, ConnectionError) as exc:
             report_exception(f"Connection error to {validator_url}.", exc)
+            return
+        except requests.exceptions.RequestException as exc:
+            report_exception("Validator request failed.", exc)
             return
         # Check if HTTP request was unsuccessful
         try:
@@ -1912,8 +1918,11 @@ class EbookmakerCheckerAPI:
         except (requests.exceptions.Timeout, TimeoutError) as exc:
             report_exception(f"Initial request to {url} timed out.", exc)
             return
-        except ConnectionError as exc:
+        except (requests.exceptions.ConnectionError, ConnectionError) as exc:
             report_exception(f"Initial connection error to {url}.", exc)
+            return
+        except requests.exceptions.RequestException as exc:
+            report_exception("Ebookmaker request failed.", exc)
             return
         # Check if HTTP request was unsuccessful
         try:


### PR DESCRIPTION
1. HTML & CSS Validators & ebookmaker gave exceptions if computer was offline
2. Ebookmaker exception was silent because it's run in background thread, so just appeared to run for ever
3. Catch exceptions correctly with specific `requests` exception, as well as a generic one.
4. Note that dialog may be left visible, but user will have seen error message box, so will know that something has gone wrong relating to not being connected, and will then remember they are working offline.

Fixes #1896