### PR TITLE
Add "expanded" mode to PPcomp

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -142,7 +142,7 @@ from guiguts.tools.jeebies import jeebies_check, JeebiesParanoiaLevel
 from guiguts.tools.levenshtein import levenshtein_check, LevenshteinEditDistance
 from guiguts.tools.pptxt import pptxt
 from guiguts.tools.pphtml import PPhtmlChecker
-from guiguts.tools.ppcomp import PPcompChecker
+from guiguts.tools.ppcomp import PPcompChecker, PPcompDisplayType
 from guiguts.utilities import (
     is_mac,
     is_windows,
@@ -816,6 +816,7 @@ class Guiguts:
         preferences.set_default(PrefKey.PPCOMP_ROUNDS_PROOFERS, False)
         preferences.set_default(PrefKey.PPCOMP_ROUNDS_REGROUP, False)
         preferences.set_default(PrefKey.PPCOMP_ROUNDS_PAGE_BLOCK, False)
+        preferences.set_default(PrefKey.PPCOMP_DISPLAY_TYPE, PPcompDisplayType.EXPANDED)
         # Check all preferences have a default
         for pref_key in PrefKey:
             assert preferences.get_default(pref_key) is not None

--- a/src/guiguts/checkers.py
+++ b/src/guiguts/checkers.py
@@ -370,10 +370,11 @@ class CheckerDialog(ToplevelDialog):
         self.sort_frame.rowconfigure(0, weight=1)
         for cc in range(0, 2):
             self.sort_frame.columnconfigure(cc, weight=1)
-        ttk.Label(
+        self.sort_label = ttk.Label(
             self.sort_frame,
             text="Sort:",
-        ).grid(row=0, column=0, sticky="NS", padx=5)
+        )
+        self.sort_label.grid(row=0, column=0, sticky="NS", padx=5)
 
         # Can't use a PersistentString directly, since we save this value for each checker dialog
         sort_type = tk.StringVar(
@@ -394,13 +395,14 @@ class CheckerDialog(ToplevelDialog):
             value=CheckerSortType.ROWCOL,
         )
         self.rowcol_radio.grid(row=0, column=1, sticky="NS", padx=2)
-        ttk.Radiobutton(
+        self.alpha_radio = ttk.Radiobutton(
             self.sort_frame,
             text="Alpha/Type",
             command=sort_type_changed,
             variable=sort_type,
             value=CheckerSortType.ALPHABETIC,
-        ).grid(row=0, column=2, sticky="NS", padx=2)
+        )
+        self.alpha_radio.grid(row=0, column=2, sticky="NS", padx=2)
         if sort_custom_label:
             ttk.Radiobutton(
                 self.sort_frame,
@@ -1033,34 +1035,42 @@ class CheckerDialog(ToplevelDialog):
         """
         self.section_count += 1
 
-    def _add_headfoot(self, hf_type: CheckerEntryType, *headfoot_lines: str) -> None:
+    def _add_headfoot(
+        self,
+        hf_type: CheckerEntryType,
+        *headfoot_lines: str,
+        section: Optional[int] = None,
+    ) -> None:
         """Internal method to add header or footer to dialog.
 
         Args:
             hf_type: Either header or footer type
             headfoot_lines: Section header or footer lines
+            section: Optional overwrite of section count.
         """
         assert hf_type in (CheckerEntryType.HEADER, CheckerEntryType.FOOTER)
-        self.new_section()
+        if section is None:
+            self.new_section()
         for line in headfoot_lines:
-            self.add_entry(line, None, None, None, hf_type)
-        self.new_section()
+            self.add_entry(line, None, None, None, hf_type, section=section)
+        if section is None:
+            self.new_section()
 
-    def add_header(self, *header_lines: str) -> None:
+    def add_header(self, *header_lines: str, section: Optional[int] = None) -> None:
         """Add header to dialog.
 
         Args:
             header_lines: Strings to add as header lines
         """
-        self._add_headfoot(CheckerEntryType.HEADER, *header_lines)
+        self._add_headfoot(CheckerEntryType.HEADER, *header_lines, section=section)
 
-    def add_footer(self, *footer_lines: str) -> None:
+    def add_footer(self, *footer_lines: str, section: Optional[int] = None) -> None:
         """Add footer to dialog.
 
         Args:
             footer_lines: Strings to add as footer lines
         """
-        self._add_headfoot(CheckerEntryType.FOOTER, *footer_lines)
+        self._add_headfoot(CheckerEntryType.FOOTER, *footer_lines, section=section)
 
     def add_entry(
         self,
@@ -1072,6 +1082,7 @@ class CheckerDialog(ToplevelDialog):
         error_prefix: str = "",
         ep_index: int = 0,
         severity: Optional[CheckerEntrySeverity] = None,
+        section: Optional[int] = None,
     ) -> None:
         """Add an entry ready to be displayed in the dialog.
 
@@ -1087,6 +1098,7 @@ class CheckerDialog(ToplevelDialog):
             error_prefix: Prefix string indicating an error.
             ep_index: Error prefix index (to control color) - must be 0 or 1
             severity: Optional severity of error to override default determination.
+            section: Optional overwrite of section count.
         """
         assert ep_index in (0, 1)
         # Default determination of severity
@@ -1104,7 +1116,7 @@ class CheckerDialog(ToplevelDialog):
             text_range,
             hilite_start,
             hilite_end,
-            self.section_count,
+            self.section_count if section is None else section,
             len(self.entries),
             entry_type,
             error_prefix,
@@ -1175,7 +1187,7 @@ class CheckerDialog(ToplevelDialog):
         for entry in self.entries:
             if self.skip_entry(entry):
                 continue
-            if entry.text_range is not None:
+            if entry.text_range is not None and entry.text_range.start.row >= 0:
                 maxrow = max(maxrow, entry.text_range.start.row)
                 maxcol = max(maxcol, entry.text_range.start.col)
         maxrowlen = len(str(maxrow))
@@ -1188,6 +1200,7 @@ class CheckerDialog(ToplevelDialog):
             and self.view_options_frame.winfo_ismapped()
         )
 
+        space = " "
         for entry in self.entries:
             if self.skip_entry(entry):
                 continue
@@ -1198,9 +1211,10 @@ class CheckerDialog(ToplevelDialog):
                 self.count_suspects += 1
             if entry.text_range is not None:
                 colstr = f"{entry.text_range.start.col}:"
-                rowcol_str = (
-                    f"{entry.text_range.start.row:>{maxrowlen}}.{colstr:<{maxcollen}}"
-                )
+                if entry.text_range.start.row < 0:
+                    rowcol_str = f"{space:>{maxrowlen}} {space:<{maxcollen}}"
+                else:
+                    rowcol_str = f"{entry.text_range.start.row:>{maxrowlen}}.{colstr:<{maxcollen}}"
             ep = "" if hide_ep else entry.error_prefix
             self.text.insert(tk.END, rowcol_str + ep + entry.text + "\n")
             if entry.hilite_start is not None and entry.hilite_end is not None:

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -259,6 +259,7 @@ class PrefKey(StrEnum):
     PPCOMP_ROUNDS_PROOFERS = auto()
     PPCOMP_ROUNDS_REGROUP = auto()
     PPCOMP_ROUNDS_PAGE_BLOCK = auto()
+    PPCOMP_DISPLAY_TYPE = auto()
 
 
 class Preferences:

--- a/src/guiguts/tools/ppcomp.py
+++ b/src/guiguts/tools/ppcomp.py
@@ -862,6 +862,11 @@ def refine_punctuation_diffs(line: str) -> str:
         if re.search(r"\p{Letter}$", a_mid) and re.search(r"^\p{Letter}", b_mid):
             return match.group(0)
 
+        # If middle portion is whitespace (e.g. "a dead"/"adead") leave unchanged
+        # because just a space is hard to spot in the output
+        if not a_mid.strip() and not b_mid.strip():
+            return match.group(0)
+
         parts = []
         # Prefix stays unmarked
         parts.append(prefix)

--- a/src/guiguts/tools/ppcomp.py
+++ b/src/guiguts/tools/ppcomp.py
@@ -783,7 +783,7 @@ def render_marked_diff(
         if expanded:
             dialog.add_header("")
             for i in range(a_line - 2, -1, -1):
-                before_line = line = re.sub(
+                before_line = re.sub(
                     r" {2,}",
                     " ",
                     re.sub(r"<[^>]+>", " ", PPcompChecker.files[0].lines[i]),

--- a/src/guiguts/tools/ppcomp.py
+++ b/src/guiguts/tools/ppcomp.py
@@ -795,7 +795,7 @@ def render_marked_diff(
         dialog.add_entry(f"{sub_line}{text}", index)
         if expanded:
             for i in range(a_line, len(PPcompChecker.files[0].lines)):
-                after_line = line = re.sub(
+                after_line = re.sub(
                     r" {2,}",
                     " ",
                     re.sub(r"<[^>]+>", " ", PPcompChecker.files[0].lines[i]),

--- a/src/guiguts/tools/ppcomp.py
+++ b/src/guiguts/tools/ppcomp.py
@@ -36,6 +36,7 @@ import argparse
 import copy
 from dataclasses import dataclass
 import difflib
+from enum import StrEnum, auto
 import logging
 import os
 import subprocess
@@ -56,6 +57,7 @@ from guiguts.maintext import HighlightTag, maintext
 from guiguts.preferences import (
     PrefKey,
     PersistentBoolean,
+    PersistentString,
     preferences,
 )
 from guiguts.utilities import is_windows, IndexRowCol, IndexRange
@@ -74,6 +76,13 @@ NO_SPACE_AFTER = "[({"
 PAIR_RE = re.compile(
     rf"{FLAG_CH_1_L}(.*?){FLAG_CH_1_R}\s+{FLAG_CH_2_L}(.*?){FLAG_CH_2_R}"
 )
+
+
+class PPcompDisplayType(StrEnum):
+    """Enum class to store PPcomp display types."""
+
+    COMPACT = auto()
+    EXPANDED = auto()
 
 
 class HTMLSyntaxError(SyntaxError):
@@ -103,6 +112,33 @@ class PPcompCheckerDialog(CheckerDialog):
         )
 
         self.rerun_button["text"] = "Compare"
+        self.sort_label["text"] = "Display:"
+        self.rowcol_radio.grid_forget()
+        self.alpha_radio.grid_forget()
+
+        self.compact_radio = ttk.Radiobutton(
+            self.sort_frame,
+            text="Compact",
+            variable=PersistentString(PrefKey.PPCOMP_DISPLAY_TYPE),
+            value=PPcompDisplayType.COMPACT,
+        )
+        self.compact_radio.grid(row=0, column=1, sticky="NS", padx=2)
+        ToolTip(
+            self.compact_radio,
+            "Display results in compact format next time Compare is run",
+        )
+        self.expanded_radio = ttk.Radiobutton(
+            self.sort_frame,
+            text="Expanded",
+            variable=PersistentString(PrefKey.PPCOMP_DISPLAY_TYPE),
+            value=PPcompDisplayType.EXPANDED,
+        )
+        self.expanded_radio.grid(row=0, column=2, sticky="NS", padx=2)
+        ToolTip(
+            self.expanded_radio,
+            "Display results in expanded format (similar to Workbench) next time Compare is run",
+        )
+
         self.custom_frame.columnconfigure(0, weight=1)
         fn_frame = ttk.Frame(self.custom_frame)
         fn_frame.grid(row=0, column=0, sticky="NSEW")
@@ -390,10 +426,11 @@ class PPcompCheckerDialog(CheckerDialog):
                     entry.error_prefix,
                     entry.ep_index,
                     entry.severity,
+                    entry.section,
                 )
             else:
                 # Not a diff - must be a header ("FOOTNOTES")
-                checker.dialog.add_header(entry.text)
+                checker.dialog.add_header(entry.text, section=entry.section)
         checker.dialog.display_entries()
         if save_sel_idx is not None:
             checker.dialog.select_entry_by_index(save_sel_idx)
@@ -663,6 +700,9 @@ def render_marked_diff(
 
     last_a = last_b = None
     cur_linenum: tuple[int, int] | None = None
+    expanded = (
+        preferences.get(PrefKey.PPCOMP_DISPLAY_TYPE) == PPcompDisplayType.EXPANDED
+    )
 
     def flush_changes():
         if old_buf:
@@ -685,7 +725,11 @@ def render_marked_diff(
             b_line = r["b_line"] + b_file_start
 
         # New source line → flush current output line
-        if (a_line, b_line) != (last_a, last_b):
+        # Compact flushes if either source file changes line
+        # Expanded only flushes if first source file changes line
+        if (expanded and a_line != last_a) or (
+            not expanded and (a_line, b_line) != (last_a, last_b)
+        ):
             flush_changes()
             if cur_line and line_has_change:
                 lines.append((join_tokens(cur_line), cur_linenum))
@@ -715,6 +759,7 @@ def render_marked_diff(
         lines.append((join_tokens(cur_line), cur_linenum))
 
     # ---- Send to the dialog ----
+    no_lineno = IndexRange(IndexRowCol(-1, -1), IndexRowCol(-1, -1))
     for text, line_pair in lines:
         if line_pair is None:
             continue
@@ -733,8 +778,33 @@ def render_marked_diff(
                 index = None
             sub_line = f"{a_line}.0: " if a_line else ""
 
+        spaces = " " * len(sub_line)
         text = refine_punctuation_diffs(text)
+        if expanded:
+            dialog.add_header("")
+            for i in range(a_line - 2, -1, -1):
+                before_line = line = re.sub(
+                    r" {2,}",
+                    " ",
+                    re.sub(r"<[^>]+>", " ", PPcompChecker.files[0].lines[i]),
+                ).strip()
+                if before_line:
+                    dialog.add_entry(f"{spaces}{before_line}", no_lineno)
+                    dialog.new_section()
+                    break
         dialog.add_entry(f"{sub_line}{text}", index)
+        if expanded:
+            for i in range(a_line, len(PPcompChecker.files[0].lines)):
+                after_line = line = re.sub(
+                    r" {2,}",
+                    " ",
+                    re.sub(r"<[^>]+>", " ", PPcompChecker.files[0].lines[i]),
+                ).strip()
+                if after_line:
+                    dialog.new_section()
+                    dialog.add_entry(f"{spaces}{after_line}", no_lineno)
+                    dialog.new_section()
+                    break
 
 
 def longest_common_prefix(a: str, b: str) -> int:
@@ -1001,6 +1071,7 @@ class PgdpFile:
         self.args = args
         self.basename = ""
         self.text = ""  # file text
+        self.lines = []  # split into lines
         # line text started, before stripping boilerplate and/or head
         self.start_line = 0
         self.footnotes = ""  # footnotes text, if extracted
@@ -1031,6 +1102,7 @@ class PgdpFile:
             raise FileNotFoundError("Cannot load file: " + filename) from ex
         if len(self.text) < 10:
             raise SyntaxError("File is too short: " + filename)
+        self.lines = self.text.splitlines()
 
     def strip_pg_boilerplate(self):
         """Remove the PG header and footer from the text if present."""


### PR DESCRIPTION
Make the output more spaced out, with more context, so that it is more similar to PPWB version.

Radio buttons at top of dialog set Compact/Expanded mode for next run.
Switching file should still work, though context lines may end up with an extra/missing leading space or two after switching - shouldn't be a significant problem.