### PR TITLE
Make CP Head/Foot alpha secondary sort by text

### DIFF
--- a/src/guiguts/content_providing.py
+++ b/src/guiguts/content_providing.py
@@ -610,14 +610,13 @@ class HeadFootChecker:
 
         def sort_key_error(
             entry: CheckerEntry,
-        ) -> tuple[int, str, int, int]:
+        ) -> tuple[int, str, str]:
             """Sort key function to sort entries by error prefix, then line number."""
             assert entry.text_range is not None
             return (
                 entry.section,
                 entry.error_prefix,
-                entry.text_range.start.row,
-                entry.text_range.start.col,
+                entry.text,
             )
 
         self.dialog = HeadFootCheckerDialog.show_dialog(


### PR DESCRIPTION
Instead of sorting by type of error, then line number, sort by type of error, then text of line. Thus all header lines that just contain the chapter title, or book title will appear together.

Requested [here](https://www.pgdp.net/phpBB3/viewtopic.php?p=1402264#p1402242)