### PR TITLE
Add `"T`/`"I` and `T'm`/`I'm`, etc to CP Filter

### DIFF
--- a/src/guiguts/content_providing.py
+++ b/src/guiguts/content_providing.py
@@ -1103,8 +1103,8 @@ class CPFilteringDialog(CheckerDialog):
         re_exc2 = re.compile(r"'!!")
         re_h = re.compile(r"!!(?=\w)")
         re_exc = re.compile(r"(?<=\w)!(?=\w)")
-        re_ti = re.compile(r"\bT('ll|'m|'d|f|s|t)\b")
-        re_tiw = re.compile(r'"T\b')
+        re_ti = re.compile(r"\bT(['’]ll|['’]m|['’]d|f|s|t)\b")
+        re_tiw = re.compile(r'(["“])T\b')
         re_1i = re.compile(r"(?<![^'\" ])1\b(?!\.)")
         re_0o = re.compile(r"(?<![^'\" ])0\b")
         re_li = re.compile(r"(?<![^'\" ])l\b(?!')")
@@ -1315,7 +1315,7 @@ class CPFilteringDialog(CheckerDialog):
                 add_to_changes(key, "Scanno mid-word ! → l", cnt, linenum)
                 line, cnt = re_ti.subn(r"I\1", line)  # T to I for T'm, T'll, etc.
                 add_to_changes(key, "Scanno T' → I'", cnt, linenum)
-                line, cnt = re_tiw.subn('"I', line)  # "T\b to "I
+                line, cnt = re_tiw.subn(r"\1I", line)  # "T\b to "I
                 add_to_changes(key, 'Scanno "T → "I', cnt, linenum)
 
             # Standalone 1 preceded by space or quote, not followed by period --> I

--- a/src/guiguts/content_providing.py
+++ b/src/guiguts/content_providing.py
@@ -1313,7 +1313,7 @@ class CPFilteringDialog(CheckerDialog):
                 add_to_changes(key, "Scanno non-word-end !! → H", cnt, linenum)
                 line, cnt = re_exc.subn("l", line)  # ! to l if midword
                 add_to_changes(key, "Scanno mid-word ! → l", cnt, linenum)
-                line, cnt = re_ti.subn("I", line)  # T to I for T'm, T'll, etc.
+                line, cnt = re_ti.subn(r"I\1", line)  # T to I for T'm, T'll, etc.
                 add_to_changes(key, "Scanno T' → I'", cnt, linenum)
                 line, cnt = re_tiw.subn('"I', line)  # "T\b to "I
                 add_to_changes(key, 'Scanno "T → "I', cnt, linenum)

--- a/src/guiguts/content_providing.py
+++ b/src/guiguts/content_providing.py
@@ -1103,6 +1103,8 @@ class CPFilteringDialog(CheckerDialog):
         re_exc2 = re.compile(r"'!!")
         re_h = re.compile(r"!!(?=\w)")
         re_exc = re.compile(r"(?<=\w)!(?=\w)")
+        re_ti = re.compile(r"\bT('ll|'m|'d|f|s|t)\b")
+        re_tiw = re.compile(r'"T\b')
         re_1i = re.compile(r"(?<![^'\" ])1\b(?!\.)")
         re_0o = re.compile(r"(?<![^'\" ])0\b")
         re_li = re.compile(r"(?<![^'\" ])l\b(?!')")
@@ -1311,6 +1313,10 @@ class CPFilteringDialog(CheckerDialog):
                 add_to_changes(key, "Scanno non-word-end !! → H", cnt, linenum)
                 line, cnt = re_exc.subn("l", line)  # ! to l if midword
                 add_to_changes(key, "Scanno mid-word ! → l", cnt, linenum)
+                line, cnt = re_ti.subn("I", line)  # T to I for T'm, T'll, etc.
+                add_to_changes(key, "Scanno T' → I'", cnt, linenum)
+                line, cnt = re_tiw.subn('"I', line)  # "T\b to "I
+                add_to_changes(key, 'Scanno "T → "I', cnt, linenum)
 
             # Standalone 1 preceded by space or quote, not followed by period --> I
             key = PrefKey.CP_1_TO_I

--- a/src/guiguts/data/cp_files/scannos.json
+++ b/src/guiguts/data/cp_files/scannos.json
@@ -805,7 +805,6 @@
   "carth" : "earth",
   "eartb" : "earth",
   "eartli" : "earth",
-  "casc" : "ease",
   "casily" : "easily",
   "easilv" : "easily",
   "eastem" : "eastern",
@@ -3088,7 +3087,6 @@
   "mbber" : "rubber",
   "mde" : "rude",
   "mle" : "rule",
-  "mn" : "run",
   "mral" : "rural",
   "msh" : "rush",
   "mst" : "rust"


### PR DESCRIPTION
Under the "2/3 letter scannos" sub-toggle, change capital "T" to "I" for some common words, and for standalone "T" following double quotes.

Fixes #1921

Testing: should fix cases described here: https://www.pgdp.net/phpBB3/viewtopic.php?p=1403237#p1403237
