### PR TITLE
Add limited anchor search to FN Fixup

### DIFF
--- a/src/guiguts/application.py
+++ b/src/guiguts/application.py
@@ -491,6 +491,8 @@ class Guiguts:
         preferences.set_default(PrefKey.FOOTNOTE_INDEX_STYLE, FootnoteIndexStyle.NUMBER)
         preferences.set_default(PrefKey.FOOTNOTE_PER_LZ, False)
         preferences.set_default(PrefKey.FOOTNOTE_SPLIT_WINDOW, True)
+        preferences.set_default(PrefKey.FOOTNOTE_LIMIT_SEARCH, False)
+        preferences.set_default(PrefKey.FOOTNOTE_LIMIT_LINES, 80)
         preferences.set_default(PrefKey.SHOW_TOOLTIPS, True)
         preferences.set_default(PrefKey.WRAP_LEFT_MARGIN, 0)
         preferences.set_default(PrefKey.WRAP_RIGHT_MARGIN, 72)

--- a/src/guiguts/footnotes.py
+++ b/src/guiguts/footnotes.py
@@ -14,6 +14,7 @@ from guiguts.maintext import maintext
 from guiguts.misc_tools import tool_save
 from guiguts.preferences import (
     PersistentString,
+    PersistentInt,
     PersistentBoolean,
     PrefKey,
     preferences,
@@ -462,10 +463,18 @@ class FootnoteChecker:
             # but not where used in context of block markup, e.g. "/#[4]"
             # nor if PPer has used backslash to escape, e.g. "\[1928]"
             start_point = start
+            # Limit search for anchor if necessary
+            unlimited = not preferences.get(PrefKey.FOOTNOTE_LIMIT_SEARCH)
+            limit_lines = preferences.get(PrefKey.FOOTNOTE_LIMIT_LINES)
+            limit_point = (
+                maintext().start()
+                if unlimited
+                else maintext().rowcol(f"{start.index()}-{limit_lines}l")
+            )
             while True:
                 anchor_match = maintext().find_match(
                     f"[{fn_label}]",
-                    IndexRange(start_point, maintext().start()),
+                    IndexRange(start_point, limit_point),
                     backwards=True,
                 )
                 if anchor_match is None:
@@ -532,10 +541,24 @@ class FootnoteChecker:
                 found = False
                 for an_record_list in self.an_records:
                     for an_record in an_record_list:
-                        if an_record.text[
-                            an_record.hilite_start : an_record.hilite_end
-                        ] == an_label and maintext().compare(
-                            an_record.start.index(), ">", anchor_match.rowcol.index()
+                        if (
+                            an_record.text[
+                                an_record.hilite_start : an_record.hilite_end
+                            ]
+                            == an_label
+                            and maintext().compare(
+                                an_record.start.index(),
+                                ">",
+                                anchor_match.rowcol.index(),
+                            )
+                            and (
+                                unlimited
+                                or maintext().compare(
+                                    f"{an_record.start.index()}+{limit_lines}l",
+                                    ">",
+                                    self.fn_records[an_record.fn_index].start.index(),
+                                )
+                            )
                         ):
                             anr = AnchorRecord(
                                 an_line,
@@ -1274,6 +1297,36 @@ class FootnoteCheckerDialog(CheckerDialog):
             match_on_highlight=CheckerMatchType.ERROR_PREFIX,
             **kwargs,
         )
+
+        limited_frame = ttk.Frame(self.custom_frame)
+        limited_frame.grid(column=0, row=0, columnspan=3, sticky="NS")
+        limit_checkbox = ttk.Checkbutton(
+            limited_frame,
+            text="Limit Anchor Search to ",
+            variable=PersistentBoolean(PrefKey.FOOTNOTE_LIMIT_SEARCH),
+        )
+        limit_checkbox.grid(row=0, column=0, sticky="NS")
+        ToolTip(
+            limit_checkbox,
+            "Limit search for matching anchors to given number of lines",
+        )
+        limit_lines = ttk.Entry(
+            limited_frame,
+            width=4,
+            justify=tk.CENTER,
+            textvariable=PersistentInt(PrefKey.FOOTNOTE_LIMIT_LINES),
+            validate=tk.ALL,
+            validatecommand=(
+                self.register(lambda val: val.isdigit() and int(val) > 0 or not val),
+                "%P",
+            ),
+        )
+        limit_lines.grid(row=0, column=1, sticky="NS")
+        ToolTip(limit_lines, "Maximum number of lines to search for matching anchors")
+        ttk.Label(
+            limited_frame,
+            text=" lines",
+        ).grid(row=0, column=2, sticky="NS")
 
         fixit_frame = ttk.Frame(self.custom_frame)
         fixit_frame.grid(column=0, row=1, sticky="NSEW")

--- a/src/guiguts/preferences.py
+++ b/src/guiguts/preferences.py
@@ -56,6 +56,8 @@ class PrefKey(StrEnum):
     FOOTNOTE_INDEX_STYLE = auto()
     FOOTNOTE_PER_LZ = auto()
     FOOTNOTE_SPLIT_WINDOW = auto()
+    FOOTNOTE_LIMIT_SEARCH = auto()
+    FOOTNOTE_LIMIT_LINES = auto()
     SHOW_TOOLTIPS = auto()
     WRAP_LEFT_MARGIN = auto()
     WRAP_RIGHT_MARGIN = auto()


### PR DESCRIPTION
Limit search for matching anchors to the number of lines given if the checkbox is checked in FN Fixup.

Fixes #1940

Test file: [chap_footnotes6.txt](https://github.com/user-attachments/files/31352685/chap_footnotes6.txt)
Set limit to 12 lines, for example.
