### PR TITLE
[mac] Touchpad scroll improvements/support for scrollbar and line number gutter

### DIFF
--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -253,6 +253,45 @@ class TextLineNumbers(tk.Canvas):
         self.bind("<Enter>", lambda _: bind_mouse_wheel(self, self.textwidget))
         self.bind("<Leave>", lambda _: unbind_mouse_wheel(self))
 
+        # On Tk9 macOS, trackpad gestures fire <TouchpadScroll> rather than
+        # <MouseWheel>, and (unlike MouseWheel) it's delivered directly to the
+        # widget under the pointer, so bind it here rather than via the
+        # Enter/Leave + bind_all approach used for <MouseWheel> above. Rate-limit
+        # to ~60fps by accumulating deltas between frames, matching the text
+        # widget and scrollbars, so scrolling feels the same over the gutter.
+        if is_mac():
+            pending_x: float = 0.0
+            pending_y: float = 0.0
+            after_id: Optional[str] = None
+
+            def to_signed_16(n: int) -> int:
+                return n if n < 0x8000 else n - 0x10000
+
+            def flush_scroll() -> None:
+                nonlocal pending_x, pending_y, after_id
+                after_id = None
+                y_scroll = int(-pending_y)
+                x_scroll = int(-pending_x)
+                pending_y += y_scroll
+                pending_x += x_scroll
+                if y_scroll:
+                    self.textwidget.yview_scroll(y_scroll, "pixels")
+                if x_scroll:
+                    self.textwidget.xview_scroll(x_scroll, "pixels")
+
+            def touchpad_scroll(event: tk.Event) -> str:
+                nonlocal pending_x, pending_y, after_id
+                pending_y += to_signed_16(event.delta & 0xFFFF)
+                pending_x += to_signed_16((event.delta >> 16) & 0xFFFF)
+                if after_id is None:
+                    after_id = self.after(16, flush_scroll)
+                return "break"
+
+            try:
+                self.bind("<TouchpadScroll>", touchpad_scroll)
+            except tk.TclError:
+                pass  # Tk < 9, TouchpadScroll not available
+
     def redraw(self) -> None:
         """Redraw line numbers."""
         # Allow for 5 digit line numbers

--- a/src/guiguts/maintext.py
+++ b/src/guiguts/maintext.py
@@ -1359,6 +1359,15 @@ class MainText(tk.Text):
             try:
                 self.bind("<TouchpadScroll>", _make_touchpad_handler(self))
                 self.peer.bind("<TouchpadScroll>", _make_touchpad_handler(self.peer))
+                # Scrollbars have their own default TouchpadScroll binding, which
+                # scrolls much faster than the rate-limited handler above, so
+                # override it to match the feel of scrolling over the text itself.
+                main_handler = _make_touchpad_handler(self)
+                peer_handler = _make_touchpad_handler(self.peer)
+                self.vscroll.bind("<TouchpadScroll>", main_handler)
+                self.hscroll.bind("<TouchpadScroll>", main_handler)
+                self.peer_vscroll.bind("<TouchpadScroll>", peer_handler)
+                self.peer_hscroll.bind("<TouchpadScroll>", peer_handler)
             except tk.TclError:
                 pass  # Tk < 9, TouchpadScroll not available
 


### PR DESCRIPTION
When using Tk9, the new touchpad events are introduced (for supported platforms; which right now I believe are only Macs). A while back, this event was implemented for the main text document.

This PR contains 2 updates:
1. When hovering over the text document scroll bar, scrolling with touchpad was previously much faster than over the main document. This change makes them about equivalent instead.
2. When hovering over the line number gutter, the touchpad previously did nothing at all. This change implements touchpad scrolling there, and makes it roughly as fast as the text document scrolling.

This should only happen on Macs, but may as well do a quick test in Windows.

It appears to work properly in my testing, but @srjfoo should verify in both Tk8 and Tk9.
